### PR TITLE
[Tag] Add colors use cases

### DIFF
--- a/core/Sources/Components/Tag/UseCase/GetColors/TagGetColorsUseCase.swift
+++ b/core/Sources/Components/Tag/UseCase/GetColors/TagGetColorsUseCase.swift
@@ -1,0 +1,53 @@
+//
+//  TagGetColorsUseCase.swift
+//  SparkCore
+//
+//  Created by robin.lemaire on 29/03/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+// sourcery: AutoMockable
+protocol TagGetColorsUseCaseable {
+    func execute(from theme: Theme,
+                 intentColor: TagIntentColor,
+                 variant: TagVariant) -> TagColorables
+}
+
+struct TagGetColorsUseCase: TagGetColorsUseCaseable {
+
+    // MARK: - Properties
+
+    private let getIntentColorsUseCase: TagGetIntentColorsUseCaseable
+
+    // MARK: - Initialization
+
+    init(getIntentColorsUseCase: TagGetIntentColorsUseCaseable = TagGetIntentColorsUseCase()) {
+        self.getIntentColorsUseCase = getIntentColorsUseCase
+    }
+
+    // MARK: - Methods
+
+    func execute(from theme: Theme,
+                 intentColor: TagIntentColor,
+                 variant: TagVariant) -> TagColorables {
+        let intentColors = self.getIntentColorsUseCase.execute(for: intentColor,
+                                                               on: theme.colors)
+
+        switch variant {
+        case .filled:
+            return TagColors(backgroundColor: intentColors.color,
+                             borderColor: intentColors.color,
+                             foregroundColor: intentColors.onColor)
+
+        case .outlined:
+            return TagColors(backgroundColor: intentColors.surfaceColor,
+                             borderColor: intentColors.color,
+                             foregroundColor: intentColors.color)
+
+        case .tinted:
+            return TagColors(backgroundColor: intentColors.containerColor,
+                             borderColor: intentColors.containerColor,
+                             foregroundColor: intentColors.onContainerColor)
+        }
+    }
+}

--- a/core/Sources/Components/Tag/UseCase/GetColors/TagGetColorsUseCaseTests.swift
+++ b/core/Sources/Components/Tag/UseCase/GetColors/TagGetColorsUseCaseTests.swift
@@ -1,0 +1,160 @@
+//
+//  TagGetColorsUseCaseTests.swift
+//  SparkCoreTests
+//
+//  Created by robin.lemaire on 06/04/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+@testable import SparkCore
+
+final class TagGetColorsUseCaseTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_execute_for_all_variant_cases() throws {
+        // GIVEN
+        let intentColorsMock = TagIntentColorablesGeneratedMock()
+        intentColorsMock.underlyingColor = ColorTokenGeneratedMock()
+        intentColorsMock.underlyingOnColor = ColorTokenGeneratedMock()
+        intentColorsMock.underlyingSurfaceColor = ColorTokenGeneratedMock()
+        intentColorsMock.underlyingContainerColor = ColorTokenGeneratedMock()
+        intentColorsMock.underlyingOnContainerColor = ColorTokenGeneratedMock()
+
+        let items: [TagGetColors] = [
+            .init(
+                givenVariant: .filled,
+                expectedBackgroundToken: intentColorsMock.color,
+                expectedBorderToken: intentColorsMock.color,
+                expectedForegroundToken: intentColorsMock.onColor
+            ),
+            .init(
+                givenVariant: .outlined,
+                expectedBackgroundToken: intentColorsMock.surfaceColor,
+                expectedBorderToken: intentColorsMock.color,
+                expectedForegroundToken: intentColorsMock.color
+            ),
+            .init(
+                givenVariant: .tinted,
+                expectedBackgroundToken: intentColorsMock.containerColor,
+                expectedBorderToken: intentColorsMock.containerColor,
+                expectedForegroundToken: intentColorsMock.onContainerColor
+            )
+        ]
+
+        for item in items {
+            let intentColorMock: TagIntentColor = .success
+
+            let themeColorsMock = ColorsGeneratedMock()
+
+            let themeMock = ThemeGeneratedMock()
+            themeMock.underlyingColors = themeColorsMock
+
+            let getIntentColorsUseCaseMock = TagGetIntentColorsUseCaseableGeneratedMock()
+            getIntentColorsUseCaseMock.executeWithIntentColorAndColorsReturnValue = intentColorsMock
+
+            let useCase = TagGetColorsUseCase(getIntentColorsUseCase: getIntentColorsUseCaseMock)
+
+            // WHEN
+            let colors = useCase.execute(from: themeMock,
+                                         intentColor: intentColorMock,
+                                         variant: item.givenVariant)
+
+            // Other UseCase
+            Tester.testGetIntentColorsUseCaseExecuteCalling(
+                givenGetIntentColorsUseCase: getIntentColorsUseCaseMock,
+                givenIntentColor: intentColorMock,
+                givenThemeColors: themeColorsMock
+            )
+
+            // Colors Properties
+            try Tester.testColorsProperties(givenColors: colors,
+                                            getColors: item)
+        }
+    }
+}
+
+// MARK: - Tester
+
+private struct Tester {
+
+    static func testGetIntentColorsUseCaseExecuteCalling(
+        givenGetIntentColorsUseCase: TagGetIntentColorsUseCaseableGeneratedMock,
+        givenIntentColor: TagIntentColor,
+        givenThemeColors: ColorsGeneratedMock
+    ) {
+        let getIntentColorsUseCaseArgs = givenGetIntentColorsUseCase.executeWithIntentColorAndColorsReceivedArguments
+        XCTAssertEqual(givenGetIntentColorsUseCase.executeWithIntentColorAndColorsCallsCount,
+                       1,
+                       "Wrong call number on execute on getIntentColorsUseCase")
+        XCTAssertEqual(getIntentColorsUseCaseArgs?.intentColor,
+                       givenIntentColor,
+                       "Wrong intentColor parameter on execute on getIntentColorsUseCase")
+        XCTAssertIdentical(getIntentColorsUseCaseArgs?.colors as? ColorsGeneratedMock,
+                           givenThemeColors,
+                           "Wrong colors parameter on execute on getIntentColorsUseCase")
+    }
+
+    static func testColorsProperties(
+        givenColors: TagColorables,
+        getColors: TagGetColors
+    ) throws {
+        // Background Color
+        try self.testColor(
+            givenColorProperty: givenColors.backgroundColor,
+            givenPropertyName: "backgroundColor",
+            givenVariant: getColors.givenVariant,
+            expectedColorToken: getColors.expectedBackgroundToken
+        )
+        
+        // Border Color
+        try self.testColor(
+            givenColorProperty: givenColors.borderColor,
+            givenPropertyName: "borderColor",
+            givenVariant: getColors.givenVariant,
+            expectedColorToken: getColors.expectedBorderToken
+        )
+
+        // Foreground Color
+        try self.testColor(
+            givenColorProperty: givenColors.foregroundColor,
+            givenPropertyName: "foregroundColor",
+            givenVariant: getColors.givenVariant,
+            expectedColorToken: getColors.expectedForegroundToken
+        )
+    }
+
+    private static func testColor(
+        givenColorProperty: ColorToken?,
+        givenPropertyName: String,
+        givenVariant: TagVariant,
+        expectedColorToken: ColorToken?
+    ) throws {
+        let errorPrefixMessage = " \(givenPropertyName) for .\(givenVariant) case"
+
+        if let givenColorProperty {
+            let color = try XCTUnwrap(givenColorProperty as? ColorTokenGeneratedMock,
+                                      "Wrong" + errorPrefixMessage)
+            XCTAssertIdentical(color,
+                               expectedColorToken as? ColorTokenGeneratedMock,
+                               "Wrong value" + errorPrefixMessage)
+
+        } else {
+            XCTAssertNil(givenColorProperty,
+                         "Should be nil" + errorPrefixMessage)
+        }
+    }
+}
+
+// MARK: - Others Strucs
+
+private struct TagGetColors {
+
+    let givenVariant: TagVariant
+
+    let expectedBackgroundToken: ColorToken
+    let expectedBorderToken: ColorToken?
+    let expectedForegroundToken: ColorToken
+}

--- a/core/Sources/Components/Tag/UseCase/GetIntentColors/TagGetIntentColorsUseCase.swift
+++ b/core/Sources/Components/Tag/UseCase/GetIntentColors/TagGetIntentColorsUseCase.swift
@@ -1,0 +1,74 @@
+//
+//  TagGetIntentColorsUseCase.swift
+//  SparkCore
+//
+//  Created by robin.lemaire on 29/03/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+// sourcery: AutoMockable
+protocol TagGetIntentColorsUseCaseable {
+    func execute(for intentColor: TagIntentColor,
+                 on colors: Colors) -> TagIntentColorables
+}
+
+struct TagGetIntentColorsUseCase: TagGetIntentColorsUseCaseable {
+
+    // MARK: - Methods
+
+    func execute(for intentColor: TagIntentColor,
+                 on colors: Colors) -> TagIntentColorables {
+        let surfaceColor = colors.base.surface
+
+        switch intentColor {
+        case .alert:
+            return TagIntentColors(color: colors.feedback.alert,
+                                   onColor: colors.feedback.onAlert,
+                                   containerColor: colors.feedback.alertContainer,
+                                   onContainerColor: colors.feedback.onAlertContainer,
+                                   surfaceColor: surfaceColor)
+
+        case .danger:
+            return TagIntentColors(color: colors.feedback.error,
+                                   onColor: colors.feedback.onError,
+                                   containerColor: colors.feedback.errorContainer,
+                                   onContainerColor: colors.feedback.onErrorContainer,
+                                   surfaceColor: surfaceColor)
+
+        case .info:
+            return TagIntentColors(color: colors.feedback.info,
+                                   onColor: colors.feedback.onInfo,
+                                   containerColor: colors.feedback.infoContainer,
+                                   onContainerColor: colors.feedback.onInfoContainer,
+                                   surfaceColor: surfaceColor)
+
+        case .neutral:
+            return TagIntentColors(color: colors.feedback.neutral,
+                                   onColor: colors.feedback.onNeutral,
+                                   containerColor: colors.feedback.neutralContainer,
+                                   onContainerColor: colors.feedback.onNeutralContainer,
+                                   surfaceColor: surfaceColor)
+
+        case .primary:
+            return TagIntentColors(color: colors.primary.primary,
+                                   onColor: colors.primary.onPrimary,
+                                   containerColor: colors.primary.primaryContainer,
+                                   onContainerColor: colors.primary.onPrimaryContainer,
+                                   surfaceColor: surfaceColor)
+
+        case .secondary:
+            return TagIntentColors(color: colors.secondary.secondary,
+                                   onColor: colors.secondary.onSecondary,
+                                   containerColor: colors.secondary.secondaryContainer,
+                                   onContainerColor: colors.secondary.onSecondaryContainer,
+                                   surfaceColor: surfaceColor)
+
+        case .success:
+            return TagIntentColors(color: colors.feedback.success,
+                                   onColor: colors.feedback.onSuccess,
+                                   containerColor: colors.feedback.successContainer,
+                                   onContainerColor: colors.feedback.onSuccessContainer,
+                                   surfaceColor: surfaceColor)
+        }
+    }
+}

--- a/core/Sources/Components/Tag/UseCase/GetIntentColors/TagGetIntentColorsUseCaseTests.swift
+++ b/core/Sources/Components/Tag/UseCase/GetIntentColors/TagGetIntentColorsUseCaseTests.swift
@@ -1,0 +1,169 @@
+//
+//  TagGetIntentColorsUseCaseTests.swift
+//  SparkCoreTests
+//
+//  Created by robin.lemaire on 06/04/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+@testable import SparkCore
+
+final class  TagGetIntentColorsUseCaseTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_execute_for_all_intentColor_cases() throws {
+        // GIVEN
+        let colorsMock = ColorsGeneratedMock.mocked()
+
+        let items: [TagGetIntentColors] = [
+            .init(
+                givenIntentColor: .alert,
+                expectedColor: colorsMock.feedback.alert,
+                expectedOnColor: colorsMock.feedback.onAlert,
+                expectedContainerColor: colorsMock.feedback.alertContainer,
+                expectedOnContainerColor: colorsMock.feedback.onAlertContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            ),
+            .init(
+                givenIntentColor: .danger,
+                expectedColor: colorsMock.feedback.error,
+                expectedOnColor: colorsMock.feedback.onError,
+                expectedContainerColor: colorsMock.feedback.errorContainer,
+                expectedOnContainerColor: colorsMock.feedback.onErrorContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            ),
+            .init(
+                givenIntentColor: .info,
+                expectedColor: colorsMock.feedback.info,
+                expectedOnColor: colorsMock.feedback.onInfo,
+                expectedContainerColor: colorsMock.feedback.infoContainer,
+                expectedOnContainerColor: colorsMock.feedback.onInfoContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            ),
+            .init(
+                givenIntentColor: .neutral,
+                expectedColor: colorsMock.feedback.neutral,
+                expectedOnColor: colorsMock.feedback.onNeutral,
+                expectedContainerColor: colorsMock.feedback.neutralContainer,
+                expectedOnContainerColor: colorsMock.feedback.onNeutralContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            ),
+            .init(
+                givenIntentColor: .primary,
+                expectedColor: colorsMock.primary.primary,
+                expectedOnColor: colorsMock.primary.onPrimary,
+                expectedContainerColor: colorsMock.primary.primaryContainer,
+                expectedOnContainerColor: colorsMock.primary.onPrimaryContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            ),
+            .init(
+                givenIntentColor: .secondary,
+                expectedColor: colorsMock.secondary.secondary,
+                expectedOnColor: colorsMock.secondary.onSecondary,
+                expectedContainerColor: colorsMock.secondary.secondaryContainer,
+                expectedOnContainerColor: colorsMock.secondary.onSecondaryContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            ),
+            .init(
+                givenIntentColor: .success,
+                expectedColor: colorsMock.feedback.success,
+                expectedOnColor: colorsMock.feedback.onSuccess,
+                expectedContainerColor: colorsMock.feedback.successContainer,
+                expectedOnContainerColor: colorsMock.feedback.onSuccessContainer,
+                expectedSurfaceColor: colorsMock.base.surface
+            )
+        ]
+
+        for item in items {
+
+            let useCase = TagGetIntentColorsUseCase()
+
+            // WHEN
+            let intentColors = useCase.execute(for: item.givenIntentColor,
+                                               on: colorsMock)
+
+            //  Intent Colors Properties
+            try Tester.testColorsProperties(givenIntentColors: intentColors,
+                                            getIntentColors: item)
+        }
+    }
+}
+
+// MARK: - Tester
+
+private struct Tester {
+
+    static func testColorsProperties(
+        givenIntentColors: TagIntentColorables,
+        getIntentColors: TagGetIntentColors
+    ) throws {
+        // Color
+        try self.testColor(
+            givenColorProperty: givenIntentColors.color,
+            givenPropertyName: "color",
+            givenIntentColor: getIntentColors.givenIntentColor,
+            expectedColorToken: getIntentColors.expectedColor
+        )
+        // On Color
+        try self.testColor(
+            givenColorProperty: givenIntentColors.onColor,
+            givenPropertyName: "onColor",
+            givenIntentColor: getIntentColors.givenIntentColor,
+            expectedColorToken: getIntentColors.expectedOnColor
+        )
+
+        // Container Color
+        try self.testColor(
+            givenColorProperty: givenIntentColors.containerColor,
+            givenPropertyName: "containerColor",
+            givenIntentColor: getIntentColors.givenIntentColor,
+            expectedColorToken: getIntentColors.expectedContainerColor
+        )
+
+        // On Container Color
+        try self.testColor(
+            givenColorProperty: givenIntentColors.onContainerColor,
+            givenPropertyName: "onContainerColor",
+            givenIntentColor: getIntentColors.givenIntentColor,
+            expectedColorToken: getIntentColors.expectedOnContainerColor
+        )
+
+        // Surface Color
+        try self.testColor(
+            givenColorProperty: givenIntentColors.surfaceColor,
+            givenPropertyName: "surfaceColor",
+            givenIntentColor: getIntentColors.givenIntentColor,
+            expectedColorToken: getIntentColors.expectedSurfaceColor
+        )
+    }
+
+    private static func testColor(
+        givenColorProperty: ColorToken,
+        givenPropertyName: String,
+        givenIntentColor: TagIntentColor,
+        expectedColorToken: ColorToken
+    ) throws {
+        let errorPrefixMessage = " \(givenPropertyName) for .\(givenIntentColor) case"
+
+        let color = try XCTUnwrap(givenColorProperty as? ColorTokenGeneratedMock,
+                                  "Wrong" + errorPrefixMessage)
+        XCTAssertIdentical(color,
+                           expectedColorToken as? ColorTokenGeneratedMock,
+                           "Wrong value" + errorPrefixMessage)    }
+}
+
+// MARK: - Others Strucs
+
+private struct TagGetIntentColors {
+
+    let givenIntentColor: TagIntentColor
+
+    let expectedColor: ColorToken
+    let expectedOnColor: ColorToken
+    let expectedContainerColor: ColorToken
+    let expectedOnContainerColor: ColorToken
+    let expectedSurfaceColor: ColorToken
+}


### PR DESCRIPTION
- Add first use case to get a TagIntentColorables object from intent color
- Add second use case to get a TagColorables object (used by UI) from intent color and variant