### PR TITLE
Property Wrapper: ScaledUIMetric.

### DIFF
--- a/core/Sources/Extension/PropertyWrapper/ScaledUIMetric.swift
+++ b/core/Sources/Extension/PropertyWrapper/ScaledUIMetric.swift
@@ -1,0 +1,82 @@
+//
+//  ScaledUIMetric.swift
+//  Spark
+//
+//  Created by janniklas.freundt.ext on 05.05.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import UIKit
+
+/// ScaledUIMetric is a property wrapper for UIKit. It scales values according to the current trait collection content size and behaves similar to the @`ScaledMetric`-property wrapper for SwiftUI.
+@propertyWrapper struct ScaledUIMetric<Value> where Value : BinaryFloatingPoint {
+    // MARK: - Properties
+
+    /// Returns the scaled value for the `baseValue` according to the trait collection. When setting this property a new baseValue is set.
+    var wrappedValue: Value {
+        get {
+            return self.scaledValue(for: self.traitCollection)
+        }
+        set {
+            self.baseValue = newValue
+        }
+    }
+
+    /// The base value for the calculation.
+    private var baseValue: Value
+
+    /// The font metrics the scaling is based on. The default value is `.body`-text-style.
+    private let metrics: UIFontMetrics
+    
+    /// The trait collection used for the scaling operation. The default value is nil, which means the current trait collection will be used (`UITraitCollection.current`).
+    private var traitCollection: UITraitCollection?
+
+    // MARK: - Initialization
+
+    /// Initialize a new property wrapper.
+    /// - Parameters:
+    ///   - baseValue: The base value used in the calculation.
+    ///   - metrics: The font metrics the scaling is based on.
+    ///   - traitCollection: The trait collection used for the scaling operation. The default value is nil, which means the current trait collection will be used (`UITraitCollection.current`).
+    init(
+        wrappedValue baseValue: Value,
+        relativeTo metrics: UIFontMetrics,
+        traitCollection: UITraitCollection? = nil
+    ) {
+        self.baseValue = baseValue
+        self.metrics = metrics
+        self.traitCollection = traitCollection
+    }
+
+    /// Initialize a new property wrapper.
+    /// - Parameters:
+    ///   - baseValue: The base value used in the calculation.
+    ///   - metrics: The text style the scaling is based on. The default value is `.body`-text-style.
+    ///   - traitCollection: The trait collection used for the scaling operation. The default value is nil, which means the current trait collection will be used (`UITraitCollection.current`).
+    init(
+        wrappedValue baseValue: Value,
+        relativeTo textStyle: UIFont.TextStyle = .body,
+        traitCollection: UITraitCollection? = nil
+    ) {
+        self.init(
+            wrappedValue: baseValue,
+            relativeTo: UIFontMetrics(forTextStyle: textStyle),
+            traitCollection: traitCollection
+        )
+    }
+
+    // MARK: - Methods
+
+    /// Update the trait collection.
+    /// - Parameter traitCollection: a new trait collection.
+    mutating func update(traitCollection: UITraitCollection?) {
+        self.traitCollection = traitCollection
+    }
+
+    /// Returns a scaled base value for the given trait colletion.
+    /// - Parameter traitCollection: the trait collection
+    /// - Returns: a scaled value
+    func scaledValue(for traitCollection: UITraitCollection?) -> Value {
+        Value(self.metrics.scaledValue(for: CGFloat(self.baseValue), compatibleWith: traitCollection ?? UITraitCollection.current))
+    }
+}

--- a/core/Sources/Extension/PropertyWrapper/ScaledUIMetric.swift
+++ b/core/Sources/Extension/PropertyWrapper/ScaledUIMetric.swift
@@ -27,7 +27,7 @@ import UIKit
 
     /// The font metrics the scaling is based on. The default value is `.body`-text-style.
     private let metrics: UIFontMetrics
-    
+
     /// The trait collection used for the scaling operation. The default value is nil, which means the current trait collection will be used (`UITraitCollection.current`).
     private var traitCollection: UITraitCollection?
 

--- a/core/Sources/Extension/PropertyWrapper/ScaledUIMetricTests.swift
+++ b/core/Sources/Extension/PropertyWrapper/ScaledUIMetricTests.swift
@@ -1,0 +1,153 @@
+//
+//  ScaledUIMetricTests.swift
+//  SparkCore
+//
+//  Created by janniklas.freundt.ext on 05.05.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+@testable import SparkCore
+import SwiftUI
+import XCTest
+
+final class ScaledUIMetricTests: XCTestCase {
+
+    // MARK: - Properties
+
+    @ScaledUIMetric(traitCollection: UITraitCollection(preferredContentSizeCategory: .medium)) var basicMetric: CGFloat = 11
+    @ScaledUIMetric(relativeTo: .body) var bodyMetric: CGFloat = 22
+    @ScaledUIMetric(relativeTo: .largeTitle) var titleMetric: CGFloat = 0
+    @ScaledUIMetric var zeroMetric: CGFloat = 0
+    @ScaledUIMetric var comparisonMetric: CGFloat = 10
+    @ScaledUIMetric var comparisonMetricExtraLarge: CGFloat = 10
+
+    // MARK: - Tests
+    func test_property_wrapper_basic() throws {
+        // Then
+        XCTAssertEqual(self.basicMetric, 10.666, accuracy: 0.1, "wrong scaled value")
+
+        // Given
+        self.basicMetric = 110
+
+        // Then
+        XCTAssertEqual(self.basicMetric, 105, accuracy: 0.1, "wrong scaled value")
+    }
+
+    func test_property_wrapper_body() throws {
+        // Given
+        self._bodyMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge))
+
+        // Then
+        XCTAssertEqual(self.bodyMetric, 62.0, accuracy: 0.1, "wrong scaled value")
+
+        // Given
+        self._bodyMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: .extraSmall))
+
+        // Then
+        XCTAssertEqual(self.bodyMetric, 19.0, accuracy: 0.1, "wrong scaled value")
+    }
+
+    func test_property_wrapper_large_title() throws {
+        // Given
+        titleMetric = 22
+        self._titleMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge))
+
+        // Then
+        XCTAssertEqual(self.titleMetric, 37.66, accuracy: 0.1, "wrong scaled value")
+
+        // Given
+        self._titleMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: .extraSmall))
+
+        // Then
+        XCTAssertEqual(self.titleMetric, 20.333, accuracy: 0.1, "wrong scaled value")
+    }
+
+    func test_property_wrapper_zero() throws {
+        // Given
+        self._zeroMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge))
+
+        // Then
+        XCTAssertEqual(self.zeroMetric, 0, "wrong scaled value")
+
+        // Given
+        self._zeroMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: .extraSmall))
+
+        // Then
+        XCTAssertEqual(self.zeroMetric, 0, "wrong scaled value")
+    }
+
+    /// Compares the result of SwiftUI `ScaledMetric` with the result of `ScaledUIMetric`.
+    func test_property_wrapper_behaves_like_swiftui_scaled_metric() throws {
+        // Given
+        let size = UIContentSizeCategory.extraLarge
+        self._comparisonMetric.update(traitCollection: UITraitCollection(preferredContentSizeCategory: size))
+
+        // Then
+        let expectation = expectation(description: "swiftui view did appear")
+
+        self.givenSwiftUIView(size: ContentSizeCategory(size)!, didAppearHandler: { swiftUISize in
+            XCTAssertEqual(self.comparisonMetric, swiftUISize, accuracy: 0.1, "ScaledMetric and ScaledUIMetric produce different values")
+
+            expectation.fulfill()
+        })
+        // Wait for the async request to complete
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    /// Compares the result of SwiftUI `ScaledMetric` with the result of `ScaledUIMetric`.
+    func test_property_wrapper_behaves_like_swiftui_scaled_metric_extra_large() throws {
+        // Given
+        let size = UIContentSizeCategory.accessibilityExtraExtraExtraLarge
+        self._comparisonMetricExtraLarge.update(traitCollection: UITraitCollection(preferredContentSizeCategory: size))
+
+        // Then
+        let expectation = expectation(description: "swiftui view did appear")
+
+        self.givenSwiftUIView(size: ContentSizeCategory(size)!, didAppearHandler: { swiftUISize in
+            XCTAssertEqual(self.comparisonMetricExtraLarge, swiftUISize, accuracy: 0.1, "ScaledMetric and ScaledUIMetric produce different values")
+
+            expectation.fulfill()
+        })
+        // Wait for the async request to complete
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    // MARK: - Helper
+
+    private func givenSwiftUIView(size: ContentSizeCategory, didAppearHandler: @escaping ((_ value: CGFloat) -> Void)) {
+
+        let window = UIWindow()
+
+        let view =
+            TestView(didAppearHandler: { swiftUIValue in
+                didAppearHandler(swiftUIValue)
+                window.removeFromSuperview()
+            })
+            .environment(\.sizeCategory, size)
+
+        let viewController = UIHostingController(rootView: view)
+
+        // Simulate the view appearance
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+    }
+}
+
+// MARK: - Test view to compare with SwiftUI ScaledMetric
+private struct TestView: View {
+    // MARK: - Properties
+
+    /// We have to wrap the `ScaledMetric`inside a view. Other configurations are not supported.
+    @ScaledMetric var value: CGFloat = 10
+
+    var didAppearHandler: ((_ value: CGFloat) -> Void)?
+
+    // MARK: - Body
+    var body: some View {
+        EmptyView()
+            .onAppear {
+                self.didAppearHandler?(value)
+            }
+    }
+}


### PR DESCRIPTION
ScaledUIMetric is a property wrapper for UIKit. It scales values according to the current trait collection content size and behaves similar to the @`ScaledMetric`-property wrapper for SwiftUI.