### PR TITLE
[Core] Checkout similar branch in snapshots repository.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,13 +45,10 @@ jobs:
           path: spark-ios-snapshots
       - name: Check snapshot branch checkout failure
         if: steps.checkout_snapshot_branch_similar_to_main_repo.outcome != 'success'
-        runs-on: macos-latest
-        steps:
-          - name: Run snapshots main branch
-            uses: actions/checkout@v3
-            with:
-              repository: adevinta/spark-ios-snapshots
-              path: spark-ios-snapshots
+        uses: actions/checkout@v3
+        with:
+          repository: adevinta/spark-ios-snapshots
+          path: spark-ios-snapshots
       - name: Run fastlane unit_tests TARGET_NAME:SparkCore
         run: fastlane unit_tests TARGET_NAME:SparkCore
       - name: Tar files

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,10 +37,20 @@ jobs:
         id: extract_branch
       - name: Run snapshots
         uses: actions/checkout@v3
+        continue-on-error: true
+        id: checkout_snapshot_branch_similar_to_main_repo
         with:
           repository: adevinta/spark-ios-snapshots
           ref: ${{ steps.extract_branch.outputs.branch }}
           path: spark-ios-snapshots
+      - name: Check snapshot branch checkout failure
+        if: steps.checkout_snapshot_branch_similar_to_main_repo.outcome != 'success'
+        steps:
+          - name: Run snapshots main branch
+            uses: actions/checkout@v3
+            with:
+              repository: adevinta/spark-ios-snapshots
+              path: spark-ios-snapshots
       - name: Run fastlane unit_tests TARGET_NAME:SparkCore
         run: fastlane unit_tests TARGET_NAME:SparkCore
       - name: Tar files

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,7 @@ jobs:
           path: spark-ios-snapshots
       - name: Check snapshot branch checkout failure
         if: steps.checkout_snapshot_branch_similar_to_main_repo.outcome != 'success'
+        runs-on: macos-latest
         steps:
           - name: Run snapshots main branch
             uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,10 +31,12 @@ jobs:
         with:
           spec: project.yml
           version: '2.33.0'
+      # Get the current source branch name of the spark-ios-repository-PR and store it in "outputs.branch".
       - name: Extract branch name
         shell: bash
         run: echo "branch=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >>$GITHUB_OUTPUT
         id: extract_branch
+      # Now try to checkout the same branch (outputs.branch) in spark-ios-snapshots-repository.
       - name: Run snapshots
         uses: actions/checkout@v3
         continue-on-error: true
@@ -43,7 +45,8 @@ jobs:
           repository: adevinta/spark-ios-snapshots
           ref: ${{ steps.extract_branch.outputs.branch }}
           path: spark-ios-snapshots
-      - name: Check snapshot branch checkout failure
+      # If checking out (outputs.branch)-branch in spark-ios-snapshots fails, fallback to main branch.
+      - name: Run snapshot on main
         if: steps.checkout_snapshot_branch_similar_to_main_repo.outcome != 'success'
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,10 +31,15 @@ jobs:
         with:
           spec: project.yml
           version: '2.33.0'
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >>$GITHUB_OUTPUT
+        id: extract_branch
       - name: Run snapshots
         uses: actions/checkout@v3
         with:
           repository: adevinta/spark-ios-snapshots
+          ref: ${{ steps.extract_branch.outputs.branch }}
           path: spark-ios-snapshots
       - name: Run fastlane unit_tests TARGET_NAME:SparkCore
         run: fastlane unit_tests TARGET_NAME:SparkCore

--- a/core/Sources/Components/RadioButton/View/RadioButtionGroupViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/RadioButtionGroupViewTests.swift
@@ -47,8 +47,9 @@ final class RadioButtionGroupViewTests: SwiftUIComponentTestCase {
                 RadioButtonItem(id: 6,
                                 label: "6 Radio button / Warning",
                                 state: .warning(message: "Warning")),
-            ]).frame(width: 400, height: 600)
-
+            ])
+            .frame(width: 400)
+            .fixedSize(horizontal: false, vertical: true)
         assertSnapshotInDarkAndLight(matching: sut)
     }
 }


### PR DESCRIPTION
This PR changes GitHub actions workflow a bit. When performing snapshot tests, the same branch is checked out in spark-ios-snapshots like the spark-iOS PR source branch. This makes it easier to modify snapshots and resolves conflicting changes.

If there is no branch with the same name found in spark-ios-snapshots, the behavior is not changed at all. Then, the main branch for spark-ios-snapshots is used. This is useful when there are no snapshot-test-changes in the current PR.