### PR TITLE
[Component] RadioButton SwiftUI: Horizontal layout

### DIFF
--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtionGroupViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtionGroupViewTests.swift
@@ -23,8 +23,15 @@ final class RadioButtionGroupViewTests: SwiftUIComponentTestCase {
         )
     }()
 
+    private let items = [
+        RadioButtonItem(id: 1,
+                        label: "Label 1"),
+        RadioButtonItem(id: 2,
+                        label: "Label 2")
+    ]
+
     // MARK: - Tests
-    func test_group() throws {
+    func test_group() {
         let sut = RadioButtonGroupView(
             theme: SparkTheme.shared,
             title: "Radio Button Group (SwiftUI)",
@@ -49,6 +56,41 @@ final class RadioButtionGroupViewTests: SwiftUIComponentTestCase {
                                 state: .warning(message: "Warning"))])
             .frame(width: 400)
             .fixedSize(horizontal: false, vertical: true)
+
+        assertSnapshotInDarkAndLight(matching: sut)
+    }
+
+    func test_horizontal_group_with_title() {
+        let sut = RadioButtonGroupView(
+            theme: SparkTheme.shared,
+            title: "Radio Button Horizontal Group (SwiftUI)",
+            selectedID: self.selectedID,
+            items: self.items,
+            groupLayout: .horizontal
+        ).fixedSize()
+
+        assertSnapshotInDarkAndLight(matching: sut)
+    }
+
+    func test_horizontal_group_no_title() {
+        let sut = RadioButtonGroupView(
+            theme: SparkTheme.shared,
+            selectedID: self.selectedID,
+            items: self.items,
+            groupLayout: .horizontal
+        ).fixedSize()
+
+        assertSnapshotInDarkAndLight(matching: sut)
+    }
+
+    func test_vertical_group_no_title_left_label() {
+        let sut = RadioButtonGroupView(
+            theme: SparkTheme.shared,
+            selectedID: self.selectedID,
+            items: self.items,
+            radioButtonLabelPosition: .left,
+            groupLayout: .vertical
+        ).fixedSize()
 
         assertSnapshotInDarkAndLight(matching: sut)
     }

--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupView.swift
@@ -36,6 +36,8 @@ public struct RadioButtonGroupView<ID: Equatable & Hashable & CustomStringConver
     private let theme: Theme
     private let items: [RadioButtonItem<ID>]
     private let title: String?
+    private let groupLayout: RadioButtonGroupLayout
+    private let radioButtonLabelPosition: RadioButtonLabelPosition
 
     // MARK: - Local properties
 
@@ -52,36 +54,72 @@ public struct RadioButtonGroupView<ID: Equatable & Hashable & CustomStringConver
     public init(theme: Theme,
                 title: String? = nil,
                 selectedID: Binding<ID>,
-                items: [RadioButtonItem<ID>]) {
+                items: [RadioButtonItem<ID>],
+                radioButtonLabelPosition: RadioButtonLabelPosition = .right,
+                groupLayout: RadioButtonGroupLayout = .vertical) {
         self.theme = theme
         self.items = items
         self.selectedID = selectedID
         self.title = title
-
-        self._spacing = ScaledMetric(wrappedValue: theme.layout.spacing.xLarge - RadioButtonConstants.radioButtonPadding * 2)
+        self.groupLayout = groupLayout
+        self.radioButtonLabelPosition = radioButtonLabelPosition
+        self._spacing = ScaledMetric(wrappedValue: theme.layout.spacing.xLarge)
     }
 
     // MARK: - Content
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: self.spacing) {
-            if let title = self.title {
-                Text(title)
-                    .font(self.theme.typography.subhead.font)
-                    .foregroundColor(self.theme.colors.base.onSurface.color)
-                    .padding(.leading, self.titlePadding)
-            }
 
-            ForEach(items, id: \.id) { item in
-                RadioButtonView(
-                    theme: theme,
-                    id: item.id,
-                    label: item.label,
-                    selectedID: self.selectedID,
-                    state: item.state
-                )
-                .accessibilityIdentifier(RadioButtonAccessibilityIdentifier.radioButtonIdentifier(id: item.id))
+        if let title = self.title {
+            VStack(alignment: .leading, spacing: self.spacing) {
+                radioButtonTitle(title)
+
+                if self.groupLayout == .vertical {
+                    radioButtonItems
+                } else {
+                    horizontalRadioButtons
+                }
             }
+        } else if groupLayout == .vertical {
+            verticalRadioButtons
+        } else {
+            horizontalRadioButtons
+        }
+    }
+
+    @ViewBuilder
+    private func radioButtonTitle(_ title: String) -> some View {
+        Text(title)
+            .font(self.theme.typography.subhead.font)
+            .foregroundColor(self.theme.colors.base.onSurface.color)
+    }
+
+    @ViewBuilder
+    private var horizontalRadioButtons: some View {
+        HStack(alignment: .top, spacing: self.spacing) {
+            radioButtonItems
+        }
+    }
+
+    @ViewBuilder
+    private var verticalRadioButtons: some View {
+        VStack(alignment: .leading, spacing: self.spacing) {
+            radioButtonItems
+        }
+    }
+
+    @ViewBuilder
+    private var radioButtonItems: some View {
+        ForEach(items, id: \.id) { item in
+            RadioButtonView(
+                theme: theme,
+                id: item.id,
+                label: item.label,
+                selectedID: self.selectedID,
+                state: item.state,
+                labelPosition: self.radioButtonLabelPosition
+            )
+            .accessibilityIdentifier(RadioButtonAccessibilityIdentifier.radioButtonIdentifier(id: item.id))
         }
     }
 }

--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonViewTests.swift
@@ -74,6 +74,13 @@ final class RadioButtonViewTests: SwiftUIComponentTestCase {
         assertSnapshotInDarkAndLight(matching: view)
     }
 
+    func test_label_left() throws {
+        let view = sut(state: .enabled, isSelected: true, label: "Label")
+            .labelPosition(.left)
+            .fixedSize()
+        assertSnapshotInDarkAndLight(matching: view)
+    }
+
     // MARK: - Private Helper Functions
     func sut(state: SparkSelectButtonState, isSelected: Bool, label: String? = nil) -> RadioButtonView<Int> {
         let selectedID = Binding<Int> (

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIViewTests.swift
@@ -14,7 +14,6 @@ import XCTest
 
 final class RadioButtonUIViewTests: UIKitComponentTestCase {
 
-
     // MARK: - Properties
     var boundSelectedID = 0
 

--- a/spark/Demo/Classes/View/Components/RadioButton/RadioButtonGroup.swift
+++ b/spark/Demo/Classes/View/Components/RadioButton/RadioButtonGroup.swift
@@ -15,13 +15,15 @@ struct RadioButtonGroup: View {
 
     @State var selectedID: Int = 1
     let theme = SparkTheme.shared
+    @State var rightTextAligment: Bool = false
+    @State var dummyBinding: Int = 1
 
     // MARK: - View
     var body: some View {
-        VStack {
+        VStack(alignment: .leading) {
             RadioButtonGroupView(
                 theme: self.theme,
-                title: "Radio Button Group",
+                title: "Radio Button Group (SwiftUI)",
                 selectedID: self.$selectedID,
                 items: [
                     RadioButtonItem(id: 1,
@@ -41,10 +43,42 @@ struct RadioButtonGroup: View {
                     RadioButtonItem(id: 6,
                                     label: "6 Radio button / Warning",
                                     state: .warning(message: "Warning")),
-                ])
+                ],
+                radioButtonLabelPosition: .left
+            )
             Text("Selected Value \(selectedID)")
+                .padding(.bottom, 20)
+
+            Text("Toggle label value")
+
+            RadioButtonGroupView(theme: self.theme,
+                                 selectedID: self.$rightTextAligment,
+                                 items: [
+                                    RadioButtonItem(id: false,
+                                                    label: "Left"),
+                                    RadioButtonItem(id: true,
+                                                    label: "Right")
+                                    ],
+                                 groupLayout: .horizontal)
+
+            HStack {
+                RadioButtonGroupView(theme: self.theme,
+                                     selectedID: self.$dummyBinding,
+                                     items: [
+                                        RadioButtonItem(id: 1,
+                                                        label: "Label 1"),
+                                        RadioButtonItem(id: 2,
+                                                        label: "Label 2")
+                                     ],
+                                     radioButtonLabelPosition: self.rightTextAligment ? .right : .left,
+                                     groupLayout: .horizontal)
+                Spacer()
+            }
+
+            Spacer()
 
         }
+        .padding(8)
     }
 }
 


### PR DESCRIPTION
Added 
- left label alignment
- horizontal layout
- removed touch area padding

![image](https://github.com/adevinta/spark-ios/assets/128726463/094e85b1-7077-4a69-86f8-5073bc815170)

![image](https://github.com/adevinta/spark-ios/assets/128726463/06b90d95-d575-4026-addd-60c76c5d8325)
