### PR TITLE
[Component] RadioButton UIKit / Remove Halo Padding from component.

### DIFF
--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonToggleUIView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonToggleUIView.swift
@@ -69,28 +69,28 @@ final class RadioButtonToggleUIView: UIView {
         else { return }
 
         backgroundColor = .clear
-        let borderWidth = rect.width / 7
+        let haloWidth = rect.width / 7
+        let center = rect.width / 2
+        let centerPoint = CGPoint(x: center, y: center)
 
         if self.isPressed {
-            let haloPath = UIBezierPath.circle(position: borderWidth/2,
-                                               size: rect.width - borderWidth)
-            haloPath.lineWidth = borderWidth
+            let haloPath = UIBezierPath.circle(arcCenter: centerPoint, radius: (rect.width/2 - haloWidth/2))
+            haloPath.lineWidth = haloWidth
             ctx.setStrokeColor(haloColor.cgColor)
             haloPath.stroke()
         }
         
-        let innerBorderWidth = (rect.width - borderWidth*2) / 10
-        let togglePath = UIBezierPath.circle(position: borderWidth,
-                                             size: rect.width - borderWidth*2)
+        let innerBorderWidth = (rect.width - haloWidth*2) / 10
+        let toggleWidth = rect.width - (haloWidth*2)
+        let togglePath = UIBezierPath.circle(arcCenter: centerPoint, radius: (toggleWidth/2 - innerBorderWidth/2))
         togglePath.lineWidth = innerBorderWidth
         ctx.setStrokeColor(buttonColor.cgColor)
         togglePath.stroke()
         
         if fillColor != .clear {
-            let fillSize = (rect.width - borderWidth*2) / 2
-            let fillPath = UIBezierPath.circle(position: rect.width/2 - fillSize/2,
-                                               size: fillSize)
-            
+            let fillSize = (rect.width - haloWidth*2) / 2
+            let fillPath = UIBezierPath.circle(arcCenter: centerPoint, radius: fillSize/2)
+
             ctx.setFillColor(fillColor.cgColor)
             fillPath.fill()
         }
@@ -100,13 +100,8 @@ final class RadioButtonToggleUIView: UIView {
 // MARK: Private helpers
 
 private extension UIBezierPath {
-    static func circle(position: CGFloat,
-                         size: CGFloat) ->  UIBezierPath {
-        let outerOval = CGRect(x: position,
-                               y: position,
-                               width: size,
-                               height: size)
-
-       return UIBezierPath(ovalIn: outerOval)
+    static func circle(arcCenter: CGPoint,
+                       radius: CGFloat) ->  UIBezierPath {
+        return UIBezierPath(arcCenter: arcCenter, radius: radius, startAngle: 0, endAngle: 360, clockwise: true)
     }
 }

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonToggleUIViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonToggleUIViewTests.swift
@@ -1,0 +1,35 @@
+//
+//  RadioButtonToggleUIViewTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 06.06.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import Spark
+@testable import SparkCore
+
+final class RadioButtonToggleUIViewTests: UIKitComponentTestCase {
+
+    func test_not_pressed() {
+        let sut = RadioButtonToggleUIView(haloColor: .gray, buttonColor: .blue, fillColor: .green)
+        sut.frame = CGRect(x: 0, y: 0, width: 28, height: 28)
+        sut.translatesAutoresizingMaskIntoConstraints = false
+
+        assertSnapshotInDarkAndLight(matching: sut)
+    }
+
+    func test_pressed() {
+        let sut = RadioButtonToggleUIView(haloColor: .gray, buttonColor: .red, fillColor: .orange)
+        sut.isPressed = true
+        sut.frame = CGRect(x: 0, y: 0, width: 28, height: 28)
+        sut.translatesAutoresizingMaskIntoConstraints = false
+
+        assertSnapshotInDarkAndLight(matching: sut)
+    }
+
+}

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupViewTests.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
-import XCTest
-
 import SnapshotTesting
-@testable import Spark
-@testable import SparkCore
 import SwiftUI
 import XCTest
+
+@testable import Spark
+@testable import SparkCore
 
 final class RadioButtonUIGroupViewTests: UIKitComponentTestCase {
 

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
@@ -15,6 +15,7 @@ private enum Constants {
     static let toggleViewHeight: CGFloat = 28
     static let toggleViewSpacing: CGFloat = 4
     static let textLabelTopSpacing: CGFloat = 3
+    static let haloWidth: CGFloat = 3
 }
 
 /// A radio button view composed of a toggle item, a label and a possible sublabel.
@@ -69,6 +70,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
     @ScaledUIMetric private var toggleSize = Constants.toggleViewHeight
     @ScaledUIMetric private var spacing: CGFloat
     @ScaledUIMetric private var textLabelTopSpacing = Constants.textLabelTopSpacing
+    @ScaledUIMetric private var haloWidth = Constants.haloWidth
 
     private var subscriptions = Set<AnyCancellable>()
 
@@ -91,7 +93,9 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
     private var toggleViewHeightConstraint: NSLayoutConstraint?
     private var toggleViewSpacingConstraint: NSLayoutConstraint?
     private var labelViewTopConstraint: NSLayoutConstraint?
-    private var labelViewBottomConstraint: NSLayoutConstraint?
+    private var toggleViewTopConstraint: NSLayoutConstraint?
+    private var toggleViewLeadingConstraint: NSLayoutConstraint?
+    private var toggleViewTrailingConstraint: NSLayoutConstraint?
     private var labelPositionConstraints: [NSLayoutConstraint] = []
 
     //  MARK: - Initialization
@@ -150,13 +154,17 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         self._toggleSize.update(traitCollection: self.traitCollection)
         self._spacing.update(traitCollection: self.traitCollection)
         self._textLabelTopSpacing.update(traitCollection: self.traitCollection)
+        self._haloWidth.update(traitCollection: self.traitCollection)
 
         toggleViewSpacingConstraint?.constant = -self.spacing
         toggleViewWidthConstraint?.constant = self.toggleSize
         toggleViewHeightConstraint?.constant = self.toggleSize
 
         labelViewTopConstraint?.constant = self.textLabelTopSpacing
-        labelViewBottomConstraint?.constant = -self.textLabelTopSpacing
+
+        toggleViewTopConstraint?.constant = -self.haloWidth
+        toggleViewLeadingConstraint?.constant = -self.haloWidth
+        toggleViewTrailingConstraint?.constant = self.haloWidth
     }
 
 
@@ -274,9 +282,9 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         let labelViewTopConstraint = self.labelView.topAnchor.constraint(
             equalTo: self.toggleView.topAnchor, constant: self.textLabelTopSpacing)
         let toggleViewTopConstraint = self.toggleView.topAnchor.constraint(
-            equalTo: self.safeAreaLayoutGuide.topAnchor)
+            equalTo: self.safeAreaLayoutGuide.topAnchor, constant: -(self.haloWidth))
         let bottomViewConstraint = self.supplementaryLabelView.bottomAnchor.constraint(
-            equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -(self.textLabelTopSpacing))
+            equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: 0)
 
         let labelPositionConstraints = calculatePositionConstraints()
 
@@ -299,19 +307,26 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         self.toggleViewHeightConstraint = toggleViewHeightConstraint
         self.toggleViewSpacingConstraint = toggleViewSpacingConstraint
         self.labelViewTopConstraint = labelViewTopConstraint
-        self.labelViewBottomConstraint = bottomViewConstraint
         self.labelPositionConstraints = labelPositionConstraints
+        self.toggleViewTopConstraint = toggleViewTopConstraint
     }
 
     private func calculatePositionConstraints() -> [NSLayoutConstraint] {
         if self.viewModel.labelPosition == .right {
+
+            let toggleViewLeadingConstraint = self.toggleView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: -self.haloWidth)
+            self.toggleViewLeadingConstraint = toggleViewLeadingConstraint
+
             return [
-                self.toggleView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
+                toggleViewLeadingConstraint,
                 self.labelView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor)
             ]
         } else {
+            let toggleViewTrailingConstraint = self.toggleView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: self.haloWidth)
+            self.toggleViewTrailingConstraint = toggleViewTrailingConstraint
+
             return [
-                self.toggleView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
+                toggleViewTrailingConstraint,
                 self.labelView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
             ]
         }

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
@@ -15,7 +15,7 @@ private enum Constants {
     static let toggleViewHeight: CGFloat = 28
     static let toggleViewSpacing: CGFloat = 4
     static let textLabelTopSpacing: CGFloat = 3
-    static let haloWidth: CGFloat = 3
+    static let haloWidth: CGFloat = 4
 }
 
 /// A radio button view composed of a toggle item, a label and a possible sublabel.


### PR DESCRIPTION
Removed "Halo"-Padding from RadioButton-UIView.

Please also check the [Snapshot tests PR](https://github.com/adevinta/spark-ios-snapshots/pull/21).

![image](https://github.com/adevinta/spark-ios/assets/128726463/a18ba7d2-31ad-4b15-a357-74a1af40c8fc)
