### PR TITLE
[Component] RadioButton UIKit / Fix typo 'Buttion'

### DIFF
--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /// RadioButtonGroupView is a radio button group control which renders a list of ``RadioButtonView``.
 ///
-/// The radio buttion group is created by providing:
+/// The radio button group is created by providing:
 /// - A theme
 /// - An option title. If the title is empty, no title will be rendered.
 /// - The selectedID, a binding value.

--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupViewTests.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupViewTests.swift
@@ -1,5 +1,5 @@
 //
-//  RadioButtionGroupViewTests.swift
+//  RadioButtonGroupViewTests.swift
 //  SparkCoreTests
 //
 //  Created by michael.zimmermann on 26.04.23.
@@ -12,7 +12,7 @@ import SnapshotTesting
 import SwiftUI
 import XCTest
 
-final class RadioButtionGroupViewTests: SwiftUIComponentTestCase {
+final class RadioButtonGroupViewTests: SwiftUIComponentTestCase {
 
     // MARK: - Properties
     var backingSelectedID = 1

--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonView.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonView.swift
@@ -18,7 +18,7 @@ private enum Constants {
 /// Radio buttons are used for selecting a single value from a selection of values.
 /// The values from which can be selected need to be ``Equatable`` & ``CustomStringConvertible``.
 ///
-/// The radio buttion is created by providing:
+/// The radio button is created by providing:
 /// - A theme
 /// - A unique ID
 /// - A label representing the value to be selected

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupViewDelegate.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupViewDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// Delegate that receives changes of radio buttion ui group view
+/// Delegate that receives changes of radio button ui group view
 public protocol RadioButtonUIGroupViewDelegate: AnyObject {
     func radioButtonGroup<ID : Hashable & Equatable & CustomStringConvertible>(_ radioButtonGroup: some RadioButtonUIGroupView<ID>, didChangeSelection item: ID)
 }

--- a/spark/Demo/Classes/View/Components/RadioButton/RadioButtonUIGroup.swift
+++ b/spark/Demo/Classes/View/Components/RadioButton/RadioButtonUIGroup.swift
@@ -13,14 +13,14 @@ import SwiftUI
 
 // MARK: SwiftUI Representable
 struct RadioButtonUIGroup: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> RadioButtionUIGroupViewController {
-        return RadioButtionUIGroupViewController()
+    func makeUIViewController(context: Context) -> RadioButtonUIGroupViewController {
+        return RadioButtonUIGroupViewController()
     }
 
-    func updateUIViewController(_ uiViewController: RadioButtionUIGroupViewController, context: Context) { }
+    func updateUIViewController(_ uiViewController: RadioButtonUIGroupViewController, context: Context) { }
 }
 
-final class RadioButtionUIGroupViewController: UIViewController {
+final class RadioButtonUIGroupViewController: UIViewController {
 
     // MARK: - Constant definitions
 


### PR DESCRIPTION
Fix the typos of "Buttion"
Please also check the [PR](https://github.com/adevinta/spark-ios-snapshots/pull/26) for the snapshots.