### PR TITLE
[Checkbox#180] Replaced binding with delegate and publisher in UIKit Checkboxes

### DIFF
--- a/core/Demo/Classes/CheckboxGroupUIView_Previews.swift
+++ b/core/Demo/Classes/CheckboxGroupUIView_Previews.swift
@@ -190,14 +190,7 @@ final class CheckboxGroupViewController: UIViewController {
 
         let groupView = CheckboxGroupUIView(
             checkedImage: checkedImage,
-            items: .init(
-                get: { [weak self] in
-                    self?.items ?? []
-                },
-                set: { [weak self] in
-                    self?.items = $0
-                }
-            ),
+            items: self.items,
             layout: self.checkboxGroupLayout,
             checkboxPosition: .left,
             theme: theme,

--- a/core/Demo/Classes/CheckboxUIView_Previews.swift
+++ b/core/Demo/Classes/CheckboxUIView_Previews.swift
@@ -129,10 +129,7 @@ final class CheckboxViewController: UIViewController {
             text: "Hello world!",
             checkedImage: checkedImage,
             state: .enabled,
-            selectionState: .init(
-                get: { return self.checkboxValue1 },
-                set: { self.checkboxValue1 = $0 }
-            ),
+            selectionState: self.checkboxValue1,
             checkboxPosition: .left
         )
         view.addSubview(checkbox)
@@ -143,10 +140,7 @@ final class CheckboxViewController: UIViewController {
             text: "Second checkbox! This is a very very long descriptive text.",
             checkedImage: checkedImage,
             state: .disabled,
-            selectionState: .init(
-                get: { return self.checkboxValue2},
-                set: { self.checkboxValue2 = $0 }
-            ),
+            selectionState: self.checkboxValue2,
             checkboxPosition: .left
         )
         view.addSubview(checkbox2)
@@ -158,10 +152,7 @@ final class CheckboxViewController: UIViewController {
             text: "Error checkbox",
             checkedImage: checkedImage,
             state: .error(message: "Error message"),
-            selectionState: .init(
-                get: { return self.checkboxValue3 },
-                set: { self.checkboxValue3 = $0 }
-            ),
+            selectionState: self.checkboxValue3,
             checkboxPosition: .left
         )
         view.addSubview(errorCheckbox)
@@ -172,10 +163,7 @@ final class CheckboxViewController: UIViewController {
             text: "Right checkbox",
             checkedImage: checkedImage,
             state: .success(message: "Success message"),
-            selectionState: .init(
-                get: { return self.checkboxValue4 },
-                set: { self.checkboxValue4 = $0 }
-            ),
+            selectionState: self.checkboxValue4,
             checkboxPosition: .right
         )
         view.addSubview(successCheckbox)
@@ -192,10 +180,7 @@ final class CheckboxViewController: UIViewController {
             ),
             checkedImage: checkedImage,
             state: .success(message: "Success message"),
-            selectionState: .init(
-                get: { return self.checkboxValue4 },
-                set: { self.checkboxValue4 = $0 }
-            ),
+            selectionState: self.checkboxValue4,
             checkboxPosition: .right
         )
         view.addSubview(attributedCheckbox)
@@ -230,6 +215,5 @@ final class CheckboxViewController: UIViewController {
 
 extension CheckboxViewController: CheckboxUIViewDelegate {
     func checkbox(_ checkbox: SparkCore.CheckboxUIView, didChangeSelection state: SparkCore.CheckboxSelectionState) {
-        print("checkbox", checkbox.text, "did switch to", state)
     }
 }

--- a/core/Sources/Common/Combine/Publisher/Publisher-Subscribe.swift
+++ b/core/Sources/Common/Combine/Publisher/Publisher-Subscribe.swift
@@ -12,11 +12,10 @@ import Foundation
 extension Publisher where Failure == Never {
     func subscribe<S>(
         in subscriptions: inout Set<AnyCancellable>,
-        on scheduler: S = RunLoop.main,
+        on scheduler: S = DispatchQueue.main,
         action: @escaping (Self.Output) -> Void ) where S: Scheduler {
-
             self
-                .receive(on: RunLoop.main)
+                .receive(on: scheduler)
                 .sink { value in
                     action(value)
                 }

--- a/core/Sources/Common/Combine/Publisher/Publisher-SubscribeTests.swift
+++ b/core/Sources/Common/Combine/Publisher/Publisher-SubscribeTests.swift
@@ -1,0 +1,27 @@
+//
+//  Publisher-SubscribeTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 13.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+@testable import SparkCore
+import XCTest
+
+final class Publisher_SubscribeTests: XCTestCase {
+    private var subscriptions = Set<AnyCancellable>()
+
+    func test_subscribe() {
+        let sut = CurrentValueSubject<Int, Never>(10).eraseToAnyPublisher()
+
+        let exp = expectation(description: "Value should be emitted")
+        sut.subscribe(in: &self.subscriptions) { value in
+            XCTAssertEqual(value, 10)
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 0.001)
+    }
+}

--- a/core/Sources/Common/Combine/Publisher/Publisher-SubscribeTests.swift
+++ b/core/Sources/Common/Combine/Publisher/Publisher-SubscribeTests.swift
@@ -22,6 +22,6 @@ final class Publisher_SubscribeTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 0.001)
+        wait(for: [exp], timeout: 0.1)
     }
 }

--- a/core/Sources/Common/Enum/Either.swift
+++ b/core/Sources/Common/Enum/Either.swift
@@ -35,3 +35,13 @@ extension Either {
         }
     }
 }
+
+extension Either {
+    static func of(_ left: Left?, or right: Right) -> Either {
+        if let left = left {
+            return .left(left)
+        } else {
+            return .right(right)
+        }
+    }
+}

--- a/core/Sources/Common/Enum/EitherTests.swift
+++ b/core/Sources/Common/Enum/EitherTests.swift
@@ -21,4 +21,14 @@ final class EitherTests: TestCase {
         let sut: Either<Int, String> = .right("A")
         XCTAssertEqual(sut.rightValue, "A")
     }
+
+    func test_or_value() {
+        let sut: Either<Int, String> = .of(1, or: "Hello")
+        XCTAssertEqual(sut, .left(1))
+    }
+
+    func test_or_other_value() {
+        let sut: Either<Int, String> = .of(nil, or: "Hello")
+        XCTAssertEqual(sut, .right("Hello"))
+    }
 }

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -17,6 +17,7 @@ public final class CheckboxGroupUIView: UIView {
     private var subscriptions = Set<AnyCancellable>()
     private var items: [any CheckboxGroupItemProtocol]
     private var subject = PassthroughSubject<[any CheckboxGroupItemProtocol], Never>()
+
     @Published public var theme: Theme {
         didSet {
             self.spacingXLarge = self.theme.layout.spacing.xLarge
@@ -28,7 +29,7 @@ public final class CheckboxGroupUIView: UIView {
         }
     }
     private var accessibilityIdentifierPrefix: String
-    private var checkboxes: [CheckboxUIView] = []
+    private (set) var checkboxes: [CheckboxUIView] = []
     private var titleLabel: UILabel?
 
     private var titleLabelBottomConstraint: NSLayoutConstraint?

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -40,8 +40,10 @@ public final class CheckboxGroupUIView: UIView {
 
     // MARK: - Public properties.
 
+    /// The delegate CheckboxGroupUIViewDelegate` which may be set to retrieve changes to the checkboxes.
     public weak var delegate: CheckboxGroupUIViewDelegate?
 
+    /// Changes to the checkboxgroup are published to the publisher.
     public var publisher: some Publisher<[any CheckboxGroupItemProtocol], Never> {
         return self.subject
     }

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewActionTests.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewActionTests.swift
@@ -1,0 +1,65 @@
+//
+//  CheckboxGroupUIViewActionTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 14.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class CheckboxGroupUIViewActionTests: TestCase {
+    // MARK: Private Properties
+    private var theme: Theme!
+    private var subscriptions: Set<AnyCancellable>!
+    private var delegate: CheckboxGroupUIViewDelegateGeneratedMock!
+    private var items: [any CheckboxGroupItemProtocol] = [
+        CheckboxGroupItem(title: "Apple", id: "1", selectionState: .selected, state: .error(message: "An unknown error occured.")),
+        CheckboxGroupItem(title: "Cake", id: "2", selectionState: .indeterminate),
+        CheckboxGroupItem(title: "Fish", id: "3", selectionState: .unselected),
+        CheckboxGroupItem(title: "Fruit", id: "4", selectionState: .unselected, state: .success(message: "Great!")),
+        CheckboxGroupItem(title: "Vegetables", id: "5", selectionState: .unselected, state: .disabled)
+    ]
+
+    // MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.theme = SparkTheme.shared
+        self.subscriptions = .init()
+        self.delegate = .init()
+    }
+
+    // MARK: - Tests
+    func test_action_from_checbox_item_propagated() {
+        let sut = sut()
+
+        let exp = expectation(description: "Checkbox change should be published")
+
+        sut.publisher.sink { items in
+            XCTAssertEqual(items[0].selectionState, .unselected)
+            exp.fulfill()
+        }.store(in: &self.subscriptions)
+
+        sut.checkboxes[0].actionTapped(sender: UIButton())
+
+        wait(for: [exp], timeout: 0.001)
+
+        XCTAssertEqual(self.delegate.checkboxGroupWithCheckboxGroupAndStateCallsCount, 1)
+        XCTAssertEqual(self.delegate.checkboxGroupWithCheckboxGroupAndStateReceivedArguments?.state[0].selectionState, .unselected)
+    }
+
+    // MARK: Private Functions
+    private func sut() -> CheckboxGroupUIView {
+        let sut = CheckboxGroupUIView(checkedImage: IconographyTests.shared.checkmark,
+                                   items: self.items,
+                                   checkboxPosition: .left,
+                                   theme: self.theme,
+                                   accessibilityIdentifierPrefix: "XX")
+
+        sut.delegate = self.delegate
+        return sut
+    }
+}

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewDelegate.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewDelegate.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-/// The checkbox delegate informs about a new checkbox selection state.
+/// The checkbox groupe delegate informs about a changes to any of the checkbox selection state.
+// sourcery: AutoMockable
 public protocol CheckboxGroupUIViewDelegate: AnyObject {
     /// The checkbox group selection was changed.
     /// - Parameters:

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewDelegate.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  CheckboxGroupUIViewDelegate.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 13.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+/// The checkbox delegate informs about a new checkbox selection state.
+public protocol CheckboxGroupUIViewDelegate: AnyObject {
+    /// The checkbox group selection was changed.
+    /// - Parameters:
+    ///   - checkboxGroup: The updated checkbox group.
+    ///   - state: The new checkbox state.
+    func checkboxGroup(_ checkboxGroup: CheckboxGroupUIView, didChangeSelection state: [any CheckboxGroupItemProtocol])
+}

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewTests.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIViewTests.swift
@@ -28,14 +28,7 @@ final class CheckboxGroupUIViewTests: UIKitComponentTestCase {
 
         let groupView = CheckboxGroupUIView(
             checkedImage: checkedImage,
-            items: .init(
-                get: { [weak self] in
-                    self?.items ?? []
-                },
-                set: { [weak self] in
-                    self?.items = $0
-                }
-            ),
+            items: self.items,
             layout: .vertical,
             checkboxPosition: position,
             theme: theme,

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -89,8 +89,10 @@ public final class CheckboxUIView: UIView {
     }
 
     private var subject: PassthroughSubject<CheckboxSelectionState, Never>
+
     // MARK: - Public properties.
 
+    /// Changes to the checbox state are published to the publisher.
     public var publisher: some Publisher<CheckboxSelectionState, Never> {
         return self.subject
     }

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -41,6 +41,8 @@ public final class CheckboxUIView: UIView {
         label.numberOfLines = 0
         label.setContentCompressionResistancePriority(.required,
                                                       for: .vertical)
+        label.adjustsFontForContentSizeCategory = true
+
         return label
     }()
 
@@ -50,6 +52,7 @@ public final class CheckboxUIView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.backgroundColor = .clear
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
@@ -436,16 +439,12 @@ public final class CheckboxUIView: UIView {
         self.controlView.theme = self.theme
         self.controlView.colors = self.colors
 
-        self.textLabel.adjustsFontForContentSizeCategory = true
         if self.attributedText == nil {
-            let font = self.theme.typography.body1.uiFont
-            self.textLabel.font = font
+            self.textLabel.font = self.theme.typography.body1.uiFont
             self.textLabel.textColor = self.colors.textColor.uiColor
         }
 
-        let captionFont = self.theme.typography.caption.uiFont
-        self.supplementaryTextLabel.font = captionFont
-        self.supplementaryTextLabel.adjustsFontForContentSizeCategory = true
+        self.supplementaryTextLabel.font = self.theme.typography.caption.uiFont
         self.supplementaryTextLabel.textColor = self.colors.checkboxTintColor.uiColor
     }
 
@@ -469,7 +468,7 @@ public final class CheckboxUIView: UIView {
         self.supplementaryTextLabel.alpha = opacity
     }
 
-    @IBAction private func actionTapped(sender: UIButton) {
+    @IBAction func actionTapped(sender: UIButton) {
         self.isPressed = false
 
         guard self.interactionEnabled else { return }

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewActionTests.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewActionTests.swift
@@ -1,0 +1,105 @@
+//
+//  CheckboxUIViewActionTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 13.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class CheckboxUIViewActionTests: TestCase {
+
+    private var sut: CheckboxUIView!
+    private var theme: Theme!
+    private var delegate: CheckboxUIViewDelegateGeneratedMock!
+    private var subscriptions: Set<AnyCancellable>!
+
+    // MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.theme = SparkTheme.shared
+        self.subscriptions = .init()
+        self.delegate = .init()
+    }
+
+    // MARK: - Tests
+    func test_enabled_state_delegate_called() {
+        let sut = sut(state: .enabled, selectionState: .unselected)
+        sut.delegate = self.delegate
+
+        let exp = expectation(description: "Expect changed value to be published")
+
+        sut.publisher.subscribe(in: &self.subscriptions) { state in
+            XCTAssertEqual(state, .selected)
+            exp.fulfill()
+        }
+
+        sut.actionTapped(sender: UIButton())
+
+        wait(for: [exp], timeout: 0.01)
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateCallsCount, 1, "Delegate called")
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateReceivedArguments?.state, .selected)
+    }
+
+    func test_error_state_not_selected_delegate_called() {
+        let sut = sut(state: .error(message: "Message"), selectionState: .selected)
+        sut.delegate = self.delegate
+
+        let exp = expectation(description: "Expect changed value to be published")
+
+        sut.publisher.subscribe(in: &self.subscriptions) { state in
+            XCTAssertEqual(state, .unselected)
+            exp.fulfill()
+        }
+
+        sut.actionTapped(sender: UIButton())
+
+        wait(for: [exp], timeout: 0.01)
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateCallsCount, 1, "Delegate called")
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateReceivedArguments?.state, .unselected)
+    }
+
+    func test_success_state_indeterminate_delegate_called() {
+        let sut = sut(state: .success(message: "Message"), selectionState: .indeterminate)
+        sut.delegate = self.delegate
+
+        let exp = expectation(description: "Expect changed value to be published")
+
+        sut.publisher.subscribe(in: &self.subscriptions) { state in
+            XCTAssertEqual(state, .selected)
+            exp.fulfill()
+        }
+
+        sut.actionTapped(sender: UIButton())
+
+        wait(for: [exp], timeout: 0.01)
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateCallsCount, 1, "Delegate called")
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateReceivedArguments?.state, .selected)
+    }
+
+    func test_disabled_state_nothing_happens() {
+        let sut = self.sut(state: .disabled)
+        sut.delegate = self.delegate
+        sut.actionTapped(sender: UIButton())
+
+        XCTAssertEqual(self.delegate.checkboxWithCheckboxAndStateCallsCount, 0, "Delegate not called")
+    }
+
+    // MARK: Private Helper Functions
+    private func sut(state: SelectButtonState,
+             selectionState: CheckboxSelectionState = .unselected) -> CheckboxUIView {
+        let sut = CheckboxUIView(theme: theme,
+                                 text: "Checkbox",
+                                 checkedImage: IconographyTests.shared.checkmark,
+                                 state: state,
+                                 selectionState: selectionState,
+                                 checkboxPosition: .left)
+        sut.frame = CGRect(x: 0, y: 0, width: 400, height: 800)
+        return sut
+
+    }
+}

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewDelegate.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewDelegate.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// The checkbox delegate informs about a new checkbox selection state.
+// sourcery: AutoMockable
 public protocol CheckboxUIViewDelegate: AnyObject {
     /// The checkbox selection was changed.
     /// - Parameters:

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewTests.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewTests.swift
@@ -29,10 +29,7 @@ final class CheckboxUIViewTests: UIKitComponentTestCase {
                 text: "Selected checkbox.",
                 checkedImage: self.checkedImage,
                 state: state,
-                selectionState: .init(
-                    get: { return .selected },
-                    set: { _ in }
-                ),
+                selectionState: .selected,
                 checkboxPosition: .right
             )
 
@@ -47,10 +44,7 @@ final class CheckboxUIViewTests: UIKitComponentTestCase {
                 text: "Selected checkbox.",
                 checkedImage: self.checkedImage,
                 state: state,
-                selectionState: .init(
-                    get: { return .selected },
-                    set: { _ in }
-                ),
+                selectionState: .selected,
                 checkboxPosition: .left
             )
 
@@ -65,10 +59,7 @@ final class CheckboxUIViewTests: UIKitComponentTestCase {
                 text: "Unselected checkbox.",
                 checkedImage: self.checkedImage,
                 state: state,
-                selectionState: .init(
-                    get: { return .unselected },
-                    set: { _ in }
-                ),
+                selectionState: .unselected,
                 checkboxPosition: .left
             )
 
@@ -83,10 +74,7 @@ final class CheckboxUIViewTests: UIKitComponentTestCase {
                 text: "Indeterminate checkbox.",
                 checkedImage: self.checkedImage,
                 state: state,
-                selectionState: .init(
-                    get: { return .indeterminate },
-                    set: { _ in }
-                ),
+                selectionState: .indeterminate,
                 checkboxPosition: .left
             )
 
@@ -101,10 +89,7 @@ final class CheckboxUIViewTests: UIKitComponentTestCase {
                 text: "Multiline checkbox.\nMore text.",
                 checkedImage: self.checkedImage,
                 state: state,
-                selectionState: .init(
-                    get: { return .selected },
-                    set: { _ in }
-                ),
+                selectionState: .selected,
                 checkboxPosition: .left
             )
 
@@ -120,10 +105,7 @@ final class CheckboxUIViewTests: UIKitComponentTestCase {
                 attributedText: attributedText,
                 checkedImage: self.checkedImage,
                 state: state,
-                selectionState: .init(
-                    get: { return .selected },
-                    set: { _ in }
-                ),
+                selectionState: .selected,
                 checkboxPosition: .left
             )
 

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
@@ -55,12 +55,14 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
     }()
 
     // MARK: - Public Properties
+    /// All the items `RadioButtonUIItem` of the radio button group
     public var items: [RadioButtonUIItem<ID>] {
         didSet {
             self.didUpdateItems()
         }
     }
 
+    /// An optional title of the radio button group
     public var title: String? {
         didSet {
             if self.setTextOf(label: self.titleLabel,
@@ -72,6 +74,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
         }
     }
 
+    /// An optional supplementary text of the radio button group rendered at the bottom of the group. This is NOT well defined for the states `enabled` and disabled.
     public var supplementaryText: String? {
         didSet {
             if self.setTextOf(label: self.supplementaryLabel,
@@ -83,6 +86,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
         }
     }
 
+    /// The current state `RadioButtonGroupState` of the items within the group, e.g. `enabled`.
     public var state: RadioButtonGroupState {
         get {
             return self.viewModel.state
@@ -116,7 +120,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
         }
     }
 
-    /// The label position according to the toggle, either `left` or `right`. The default value is `.left`
+    /// The label position `RadioButtonLabelPosition` according to the toggle, either `left` or `right`. The default value is `.left`
     public var radioButtonLabelPosition: RadioButtonLabelPosition {
         didSet {
             guard radioButtonLabelPosition != oldValue else { return }
@@ -128,7 +132,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
         }
     }
 
-    /// The group layout of the radio buttons, either `horizontal` or `vertical`. The default is `vertical`.
+    /// The group layout `RadioButtonGroupLayout` of the radio buttons, either `horizontal` or `vertical`. The default is `vertical`.
     public var groupLayout: RadioButtonGroupLayout {
         didSet {
             guard groupLayout != oldValue else { return }
@@ -144,6 +148,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
         return self.valueSubject
     }
 
+    /// Set the accessibilityIdentifier. This identifier will be used as the accessibility identifier prefix of each radio button item, the suffix of that accessibility identifier being the index of the item within it's array.
     public override var accessibilityIdentifier: String? {
         didSet {
             guard let identifier = accessibilityIdentifier else { return }
@@ -159,7 +164,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
     /// - theme: The current theme.
     /// - title: The title of the radio button group. This is optional, if it's not given, no title will be shown.
     /// - selectedID: The current selected value of the radio button group.
-    /// - items: A list of `RadioButtonItem` which represent each item in the radio button group.
+    /// - items: A list of `RadioButtonUIItem` which represent each item in the radio button group.
     /// - radioButtonLabelPosition: The position of the label in each radio button item according to the toggle. The default value is, that the label is to the `right` of the toggle.
     /// - groupLayout: The layout of the items within the group. These can be `horizontal` or `vertical`. The defalt is `vertical`.
     /// - state: The state of the radiobutton group, see `RadioButtonGroupState`

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
@@ -140,7 +140,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
     public weak var delegate: (any RadioButtonUIGroupViewDelegate)?
 
     /// A change of the selected item will be published. This is an alternative method to the `delegate` of being notified of changes to the selected item.
-    public var publisher: any Publisher<ID, Never> {
+    public var publisher: some Publisher<ID, Never> {
         return self.valueSubject
     }
 

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
@@ -24,9 +24,10 @@ private enum Constants {
 /// When the radio button is selected, it will change the binding value.
 public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: UIView {
 
-    // MARK: Injected Properties
+    // MARK: - Injected Properties
     private let viewModel: RadioButtonViewModel<ID>
 
+    // MARK: - Public Properties
     /// The general theme
     public var theme: Theme {
         get {
@@ -57,6 +58,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         }
     }
 
+    /// The label position, right of left of the toggle
     public var labelPosition: RadioButtonLabelPosition {
         get {
             return self.viewModel.labelPosition
@@ -66,7 +68,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         }
     }
 
-    // MARK: Private Properties
+    // MARK: - Private Properties
     @ScaledUIMetric private var toggleSize = Constants.toggleViewHeight
     @ScaledUIMetric private var spacing: CGFloat
     @ScaledUIMetric private var textLabelTopSpacing = Constants.textLabelTopSpacing
@@ -100,7 +102,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
     private var toggleViewTrailingConstraint: NSLayoutConstraint?
     private var labelPositionConstraints: [NSLayoutConstraint] = []
 
-    //  MARK: - Initialization
+    // MARK: - Initialization
 
     /// The radio button component takes a theme, an id, a label and a binding
     ///
@@ -143,7 +145,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: Public Functions
+    // MARK: - Public Functions
     public func toggleNeedsRedisplay() {
         self.viewModel.updateColors()
         self.updateColors(self.viewModel.colors)
@@ -170,7 +172,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
     }
 
 
-    // MARK: - Private functions
+    // MARK: - Private Functions
 
     private func setupSubscriptions() {
 
@@ -366,7 +368,7 @@ private extension UILabel {
     }
 }
 
-// MARK: - Label priorities
+// MARK: - Label Priorities
 public extension RadioButtonUIView {
     func setLabelContentCompressionResistancePriority(_ priority: UILayoutPriority,
                                                       for axis: NSLayoutConstraint.Axis) {

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroupViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroupViewController.swift
@@ -192,14 +192,7 @@ final class CheckboxGroupViewController: UIViewController {
         let groupView = CheckboxGroupUIView(
             title: "Checkbox-group title (UIKit)",
             checkedImage: checkedImage,
-            items: .init(
-                get: { [weak self] in
-                    self?.items ?? []
-                },
-                set: { [weak self] in
-                    self?.items = $0
-                }
-            ),
+            items: self.items,
             layout: self.checkboxGroupLayout,
             checkboxPosition: .left,
             theme: theme,
@@ -207,6 +200,9 @@ final class CheckboxGroupViewController: UIViewController {
         )
         self.checkboxGroup = groupView
         groupView.translatesAutoresizingMaskIntoConstraints = false
+        groupView.publisher.sink { [weak self] in
+            self?.items = $0
+        }.store(in: &self.cancellables)
 
         view.addSubview(groupView)
 

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroupViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroupViewController.swift
@@ -202,7 +202,8 @@ final class CheckboxGroupViewController: UIViewController {
         groupView.translatesAutoresizingMaskIntoConstraints = false
         groupView.publisher.sink { [weak self] in
             self?.items = $0
-        }.store(in: &self.cancellables)
+        }
+        .store(in: &self.cancellables)
 
         view.addSubview(groupView)
 

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
@@ -11,8 +11,6 @@ import Spark
 import SparkCore
 import SwiftUI
 
-// swiftlint: disable no_debugging_method
-
 // MARK: - SwiftUI-wrapper
 
 struct CheckboxUIViewControllerBridge: UIViewControllerRepresentable {
@@ -144,7 +142,8 @@ final class CheckboxViewController: UIViewController {
         checkbox.translatesAutoresizingMaskIntoConstraints = false
         checkbox.publisher.sink { [weak self] in
             self?.checkboxValue1 = $0
-        }.store(in: &self.cancellables)
+        }
+        .store(in: &self.cancellables)
 
         view.addSubview(checkbox)
         checkboxes.append(checkbox)
@@ -160,7 +159,8 @@ final class CheckboxViewController: UIViewController {
         checkbox2.translatesAutoresizingMaskIntoConstraints = false
         checkbox2.publisher.sink { [weak self] in
             self?.checkboxValue2 = $0
-        }.store(in: &self.cancellables)
+        }
+        .store(in: &self.cancellables)
         view.addSubview(checkbox2)
         checkboxes.append(checkbox2)
 
@@ -176,7 +176,8 @@ final class CheckboxViewController: UIViewController {
         errorCheckbox.translatesAutoresizingMaskIntoConstraints = false
         errorCheckbox.publisher.sink { [weak self] in
             self?.checkboxValue3 = $0
-        }.store(in: &self.cancellables)
+        }
+        .store(in: &self.cancellables)
 
         view.addSubview(errorCheckbox)
         checkboxes.append(errorCheckbox)
@@ -192,7 +193,8 @@ final class CheckboxViewController: UIViewController {
         successCheckbox.translatesAutoresizingMaskIntoConstraints = false
         successCheckbox.publisher.sink { [weak self] in
             self?.checkboxValue4 = $0
-        }.store(in: &self.cancellables)
+        }
+        .store(in: &self.cancellables)
 
         view.addSubview(successCheckbox)
         checkboxes.append(successCheckbox)
@@ -208,7 +210,8 @@ final class CheckboxViewController: UIViewController {
         attributedCheckbox.attributedText = self.attributedCheckboxLabel
         attributedCheckbox.publisher.sink { [weak self] in
             self?.checkboxValue4 = $0
-        }.store(in: &self.cancellables)
+        }
+        .store(in: &self.cancellables)
 
         view.addSubview(attributedCheckbox)
         checkboxes.append(attributedCheckbox)

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
@@ -137,13 +137,15 @@ final class CheckboxViewController: UIViewController {
             text: "Hello world!",
             checkedImage: image,
             state: .enabled,
-            selectionState: .init(
-                get: { return self.checkboxValue1 },
-                set: { self.checkboxValue1 = $0 }
-            ),
+            selectionState: self.checkboxValue1,
             checkboxPosition: .left
         )
+
         checkbox.translatesAutoresizingMaskIntoConstraints = false
+        checkbox.publisher.sink { [weak self] in
+            self?.checkboxValue1 = $0
+        }.store(in: &self.cancellables)
+
         view.addSubview(checkbox)
         checkboxes.append(checkbox)
 
@@ -152,13 +154,13 @@ final class CheckboxViewController: UIViewController {
             text: "Second checkbox! This is a very very long descriptive text.",
             checkedImage: image,
             state: .disabled,
-            selectionState: .init(
-                get: { return self.checkboxValue2 },
-                set: { self.checkboxValue2 = $0 }
-            ),
+            selectionState: self.checkboxValue2,
             checkboxPosition: .left
         )
         checkbox2.translatesAutoresizingMaskIntoConstraints = false
+        checkbox2.publisher.sink { [weak self] in
+            self?.checkboxValue2 = $0
+        }.store(in: &self.cancellables)
         view.addSubview(checkbox2)
         checkboxes.append(checkbox2)
 
@@ -168,13 +170,14 @@ final class CheckboxViewController: UIViewController {
             text: "Error checkbox",
             checkedImage: image,
             state: .error(message: "Error message"),
-            selectionState: .init(
-                get: { return self.checkboxValue3 },
-                set: { self.checkboxValue3 = $0 }
-            ),
+            selectionState: self.checkboxValue3,
             checkboxPosition: .left
         )
         errorCheckbox.translatesAutoresizingMaskIntoConstraints = false
+        errorCheckbox.publisher.sink { [weak self] in
+            self?.checkboxValue3 = $0
+        }.store(in: &self.cancellables)
+
         view.addSubview(errorCheckbox)
         checkboxes.append(errorCheckbox)
 
@@ -183,13 +186,14 @@ final class CheckboxViewController: UIViewController {
             text: "Right checkbox",
             checkedImage: image,
             state: .success(message: "Success message"),
-            selectionState: .init(
-                get: { return self.checkboxValue4 },
-                set: { self.checkboxValue4 = $0 }
-            ),
+            selectionState: self.checkboxValue4,
             checkboxPosition: .right
         )
         successCheckbox.translatesAutoresizingMaskIntoConstraints = false
+        successCheckbox.publisher.sink { [weak self] in
+            self?.checkboxValue4 = $0
+        }.store(in: &self.cancellables)
+
         view.addSubview(successCheckbox)
         checkboxes.append(successCheckbox)
 
@@ -198,13 +202,14 @@ final class CheckboxViewController: UIViewController {
             text: "Right checkbox",
             checkedImage: image,
             state: .success(message: "Success message"),
-            selectionState: .init(
-                get: { return self.checkboxValue4 },
-                set: { self.checkboxValue4 = $0 }
-            ),
+            selectionState: self.checkboxValue4,
             checkboxPosition: .right
         )
         attributedCheckbox.attributedText = self.attributedCheckboxLabel
+        attributedCheckbox.publisher.sink { [weak self] in
+            self?.checkboxValue4 = $0
+        }.store(in: &self.cancellables)
+
         view.addSubview(attributedCheckbox)
         checkboxes.append(attributedCheckbox)
 

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
@@ -242,6 +242,5 @@ final class CheckboxViewController: UIViewController {
 
 extension CheckboxViewController: CheckboxUIViewDelegate {
     func checkbox(_ checkbox: SparkCore.CheckboxUIView, didChangeSelection state: SparkCore.CheckboxSelectionState) {
-        print("checkbox", checkbox.text ?? "", "did switch to", state)
     }
 }


### PR DESCRIPTION
# What was implemented
- The state change interactions of the checkbox and the checkbox group UIKit components have changed from bindings to the changed values being both sent to an optional delegate and to a publisher.

- In the checkbox the tap action function `actionTapped` has been made internally accessible for unit testing
- In the checkbox group the `checkboxes` have internally accessible via get for unit testing
- Unit tests have been added to test the tap action and calls to the delegates and publishers