### PR TITLE
[Fix] Equals.

### DIFF
--- a/core/Sources/Components/Button/Properties/Internal/Colors/ButtonColors.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Colors/ButtonColors.swift
@@ -31,6 +31,10 @@ extension ButtonColors: Hashable, Equatable {
     }
 
     static func == (lhs: ButtonColors, rhs: ButtonColors) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.backgroundColor.equals(rhs.backgroundColor) &&
+        lhs.borderColor.equals(rhs.borderColor) &&
+        lhs.foregroundColor.equals(rhs.foregroundColor) &&
+        lhs.pressedBorderColor.equals(rhs.pressedBorderColor) &&
+        lhs.pressedBackgroundColor.equals(rhs.pressedBackgroundColor)
     }
 }

--- a/core/Sources/Components/Button/Properties/Internal/Colors/ButtonColorsTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Colors/ButtonColorsTests.swift
@@ -1,0 +1,53 @@
+//
+//  ButtonColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 21.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class ButtonColorsTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_buttonColors_equal() {
+        let colors = SparkTheme.shared.colors
+        let given1 = ButtonColors(
+            foregroundColor: colors.primary.primary,
+            backgroundColor: colors.base.background,
+            pressedBackgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.base.background,
+            pressedBorderColor: colors.states.primaryPressed)
+        let given2 = ButtonColors(
+            foregroundColor: colors.primary.primary,
+            backgroundColor: colors.base.background,
+            pressedBackgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.base.background,
+            pressedBorderColor: colors.states.primaryPressed)
+
+        XCTAssertEqual(given1, given2)
+    }
+
+    func test_buttonColors_not_equal() {
+        let colors = SparkTheme.shared.colors
+        let given1 = ButtonColors(
+            foregroundColor: colors.primary.primary,
+            backgroundColor: colors.base.background,
+            pressedBackgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.base.background,
+            pressedBorderColor: colors.states.primaryPressed)
+        let given2 = ButtonColors(
+            foregroundColor: colors.primary.primary,
+            backgroundColor: colors.base.background,
+            pressedBackgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.base.background,
+            pressedBorderColor: colors.states.alertPressed)
+
+        XCTAssertNotEqual(given1, given2)
+    }
+
+}

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
@@ -27,7 +27,9 @@ extension ButtonCurrentColors: Hashable, Equatable {
     }
 
     static func == (lhs: ButtonCurrentColors, rhs: ButtonCurrentColors) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.foregroundColor.equals(rhs.foregroundColor) &&
+        lhs.backgroundColor.equals(rhs.backgroundColor) &&
+        lhs.borderColor.equals(rhs.borderColor)
     }
 }
 

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColorsTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColorsTests.swift
@@ -1,0 +1,48 @@
+//
+//  ButtonCurrentColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 21.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class ButtonCurrentColorsTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_buttonCurrentColors_equal() {
+        let colors = SparkTheme.shared.colors
+        let given1 = ButtonCurrentColors(
+            foregroundColor: colors.base.onSurface,
+            backgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.primary.primary)
+
+        let given2 = ButtonCurrentColors(
+            foregroundColor: colors.base.onSurface,
+            backgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.primary.primary)
+
+        XCTAssertEqual(given1, given2)
+    }
+
+    func test_buttonColorColors_not_equal() {
+        let colors = SparkTheme.shared.colors
+
+        let given1 = ButtonCurrentColors(
+            foregroundColor: colors.base.onSurface,
+            backgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.primary.primary)
+
+        let given2 = ButtonCurrentColors(
+            foregroundColor: colors.base.onSurface,
+            backgroundColor: colors.base.backgroundVariant,
+            borderColor: colors.primary.onPrimary)
+
+        XCTAssertNotEqual(given1, given2)
+    }
+
+}

--- a/core/Sources/Components/Chip/Model/ChipStateColors.swift
+++ b/core/Sources/Components/Chip/Model/ChipStateColors.swift
@@ -15,8 +15,8 @@ struct ChipStateColors {
 
 extension ChipStateColors: Equatable {
     static func == (lhs: ChipStateColors, rhs: ChipStateColors) -> Bool {
-        return lhs.background.hashValue == rhs.background.hashValue &&
-        lhs.border.hashValue  == rhs.border.hashValue &&
-        lhs.foreground.hashValue  == rhs.foreground.hashValue
+        return lhs.background.equals(rhs.background) &&
+        lhs.border.equals(rhs.border) &&
+        lhs.foreground.equals(rhs.foreground)
     }
 }

--- a/core/Sources/Components/Chip/Model/ChipStateColorsTests.swift
+++ b/core/Sources/Components/Chip/Model/ChipStateColorsTests.swift
@@ -1,0 +1,47 @@
+//
+//  ChipStateColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 24.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class ChipStateColorsTests: XCTestCase {
+
+    func testEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = ChipStateColors(
+            background: colors.base.background,
+            border: colors.base.onBackgroundVariant,
+            foreground: colors.feedback.alert)
+
+        let colors2 = ChipStateColors(
+            background: colors.base.background,
+            border: colors.base.onBackgroundVariant,
+            foreground: colors.feedback.alert)
+
+        XCTAssertEqual(colors1, colors2)
+    }
+
+    func testNotEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = ChipStateColors(
+            background: colors.base.background,
+            border: colors.base.onBackgroundVariant,
+            foreground: colors.feedback.alert)
+
+        let colors2 = ChipStateColors(
+            background: colors.base.backgroundVariant,
+            border: colors.base.onBackgroundVariant,
+            foreground: colors.feedback.alert)
+
+        XCTAssertNotEqual(colors1, colors2)
+    }
+
+}

--- a/core/Sources/Components/Switch/Model/Internal/Colors/SwitchColors.swift
+++ b/core/Sources/Components/Switch/Model/Internal/Colors/SwitchColors.swift
@@ -13,7 +13,6 @@ struct SwitchColors {
     let toggleBackgroundColors: SwitchStatusColors
     let toggleDotForegroundColors: SwitchStatusColors
     let toggleDotBackgroundColor: any ColorToken
-
     let textForegroundColor: any ColorToken
 }
 
@@ -29,6 +28,9 @@ extension SwitchColors: Hashable, Equatable {
     }
 
     static func == (lhs: SwitchColors, rhs: SwitchColors) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.toggleBackgroundColors == rhs.toggleBackgroundColors &&
+        lhs.toggleDotForegroundColors == rhs.toggleDotForegroundColors &&
+        lhs.toggleDotBackgroundColor.equals(rhs.toggleDotBackgroundColor) &&
+        lhs.textForegroundColor.equals(rhs.textForegroundColor)
     }
 }

--- a/core/Sources/Components/Switch/Model/Internal/Colors/SwitchColorsTests.swift
+++ b/core/Sources/Components/Switch/Model/Internal/Colors/SwitchColorsTests.swift
@@ -1,0 +1,67 @@
+//
+//  SwitchColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 24.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class SwitchColorsTests: XCTestCase {
+
+    func testEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = SwitchColors(
+            toggleBackgroundColors: SwitchStatusColors(
+                onColorToken: colors.feedback.info,
+                offColorToken: colors.feedback.alert),
+            toggleDotForegroundColors: SwitchStatusColors(
+                onColorToken: colors.primary.primary,
+                offColorToken: colors.secondary.secondary),
+            toggleDotBackgroundColor: colors.base.background,
+            textForegroundColor: colors.primary.onPrimary)
+
+        let colors2 = SwitchColors(
+            toggleBackgroundColors: SwitchStatusColors(
+                onColorToken: colors.feedback.info,
+                offColorToken: colors.feedback.alert),
+            toggleDotForegroundColors: SwitchStatusColors(
+                onColorToken: colors.primary.primary,
+                offColorToken: colors.secondary.secondary),
+            toggleDotBackgroundColor: colors.base.background,
+            textForegroundColor: colors.primary.onPrimary)
+
+        XCTAssertEqual(colors1, colors2)
+    }
+
+    func testNotEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = SwitchColors(
+            toggleBackgroundColors: SwitchStatusColors(
+                onColorToken: colors.feedback.info,
+                offColorToken: colors.feedback.alert),
+            toggleDotForegroundColors: SwitchStatusColors(
+                onColorToken: colors.primary.primary,
+                offColorToken: colors.secondary.secondary),
+            toggleDotBackgroundColor: colors.base.background,
+            textForegroundColor: colors.primary.onPrimary)
+
+        let colors2 = SwitchColors(
+            toggleBackgroundColors: SwitchStatusColors(
+                onColorToken: colors.feedback.error,
+                offColorToken: colors.feedback.alert),
+            toggleDotForegroundColors: SwitchStatusColors(
+                onColorToken: colors.primary.primary,
+                offColorToken: colors.secondary.secondary),
+            toggleDotBackgroundColor: colors.base.background,
+            textForegroundColor: colors.primary.onPrimary)
+
+        XCTAssertNotEqual(colors1, colors2)
+    }
+
+}

--- a/core/Sources/Components/Switch/Model/Internal/Colors/SwitchStatusColors.swift
+++ b/core/Sources/Components/Switch/Model/Internal/Colors/SwitchStatusColors.swift
@@ -24,6 +24,7 @@ extension SwitchStatusColors: Hashable, Equatable {
     }
 
     static func == (lhs: SwitchStatusColors, rhs: SwitchStatusColors) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.onColorToken.equals(rhs.onColorToken) &&
+        lhs.offColorToken.equals(rhs.offColorToken)
     }
 }

--- a/core/Sources/Components/Switch/Model/Internal/Colors/SwitchStatusColorsTests.swift
+++ b/core/Sources/Components/Switch/Model/Internal/Colors/SwitchStatusColorsTests.swift
@@ -1,0 +1,42 @@
+//
+//  SwitchStatusColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 24.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class SwitchStatusColorsTests: XCTestCase {
+
+    func testEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = SwitchStatusColors(
+                onColorToken: colors.feedback.info,
+                offColorToken: colors.feedback.alert)
+
+        let colors2 = SwitchStatusColors(
+            onColorToken: colors.feedback.info,
+            offColorToken: colors.feedback.alert)
+
+        XCTAssertEqual(colors1, colors2)
+    }
+
+    func testNotEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = SwitchStatusColors(
+                onColorToken: colors.feedback.info,
+                offColorToken: colors.feedback.alert)
+
+        let colors2 = SwitchStatusColors(
+                onColorToken: colors.primary.primary,
+                offColorToken: colors.secondary.secondary)
+
+        XCTAssertNotEqual(colors1, colors2)
+    }
+}

--- a/core/Sources/Components/Tag/Model/Colors/TagColors.swift
+++ b/core/Sources/Components/Tag/Model/Colors/TagColors.swift
@@ -26,6 +26,8 @@ extension TagColors: Hashable, Equatable {
     }
 
     static func == (lhs: TagColors, rhs: TagColors) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.backgroundColor.equals(rhs.backgroundColor) &&
+        lhs.borderColor.equals(rhs.borderColor) &&
+        lhs.foregroundColor.equals(rhs.foregroundColor)
     }
 }

--- a/core/Sources/Components/Tag/Model/Colors/TagColorsTests.swift
+++ b/core/Sources/Components/Tag/Model/Colors/TagColorsTests.swift
@@ -1,0 +1,47 @@
+//
+//  TagColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 24.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class TagColorsTests: XCTestCase {
+
+    func testEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = TagColors(
+            backgroundColor: colors.base.background,
+            borderColor: colors.primary.primary,
+            foregroundColor: colors.feedback.info)
+
+        let colors2 = TagColors(
+            backgroundColor: colors.base.background,
+            borderColor: colors.primary.primary,
+            foregroundColor: colors.feedback.info)
+
+        XCTAssertEqual(colors1, colors2)
+    }
+
+    func testNotEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = TagColors(
+            backgroundColor: colors.base.background,
+            borderColor: colors.primary.primary,
+            foregroundColor: colors.feedback.info)
+
+        let colors2 = TagColors(
+            backgroundColor: colors.base.background,
+            borderColor: colors.primary.primary,
+            foregroundColor: colors.feedback.alert)
+
+        XCTAssertNotEqual(colors1, colors2)
+    }
+}

--- a/core/Sources/Components/Tag/Model/ContentColors/TagContentColors.swift
+++ b/core/Sources/Components/Tag/Model/ContentColors/TagContentColors.swift
@@ -30,6 +30,10 @@ extension TagContentColors: Hashable, Equatable {
     }
 
     static func == (lhs: TagContentColors, rhs: TagContentColors) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.color.equals(rhs.color) &&
+        lhs.onColor.equals(rhs.onColor) &&
+        lhs.containerColor.equals(rhs.containerColor) &&
+        lhs.onContainerColor.equals(rhs.onContainerColor) &&
+        lhs.surfaceColor.equals(rhs.surfaceColor)
     }
 }

--- a/core/Sources/Components/Tag/Model/ContentColors/TagContentColorsTests.swift
+++ b/core/Sources/Components/Tag/Model/ContentColors/TagContentColorsTests.swift
@@ -1,0 +1,58 @@
+//
+//  TagContentColorsTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 24.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+import XCTest
+@testable import Spark
+@testable import SparkCore
+import XCTest
+
+final class TagContentColorsTests: XCTestCase {
+
+    func testEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = TagContentColors(
+            color: colors.primary.primary,
+            onColor: colors.primary.onPrimary,
+            containerColor: colors.base.background,
+            onContainerColor: colors.base.onBackground,
+            surfaceColor: colors.base.surface)
+
+        let colors2 = TagContentColors(
+            color: colors.primary.primary,
+            onColor: colors.primary.onPrimary,
+            containerColor: colors.base.background,
+            onContainerColor: colors.base.onBackground,
+            surfaceColor: colors.base.surface)
+
+        XCTAssertEqual(colors1, colors2)
+    }
+
+    func testNotEqual() {
+        let colors = SparkTheme.shared.colors
+
+        let colors1 = TagContentColors(
+            color: colors.primary.primary,
+            onColor: colors.primary.onPrimary,
+            containerColor: colors.base.background,
+            onContainerColor: colors.base.onBackground,
+            surfaceColor: colors.base.surface)
+
+        let colors2 = TagContentColors(
+            color: colors.secondary.secondary,
+            onColor: colors.secondary.onSecondary,
+            containerColor: colors.base.background,
+            onContainerColor: colors.base.onBackground,
+            surfaceColor: colors.base.surface)
+
+        XCTAssertNotEqual(colors1, colors2)
+    }
+}
+

--- a/core/Sources/Theming/Content/Colors/ColorTokenTests.swift
+++ b/core/Sources/Theming/Content/Colors/ColorTokenTests.swift
@@ -1,0 +1,23 @@
+//
+//  ColorTokenTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 21.07.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import Spark
+import XCTest
+
+final class ColorTokenTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_colorTokens_equal() {
+        XCTAssertTrue(SparkTheme.shared.colors.base.surface.equals(SparkTheme.shared.colors.base.surface))
+    }
+
+    func test_colorTokens_not_equal() {
+        XCTAssertFalse(SparkTheme.shared.colors.base.surface.equals(SparkTheme.shared.colors.base.onSurface))
+    }
+}

--- a/core/Sources/Theming/Content/Colors/Colors.swift
+++ b/core/Sources/Theming/Content/Colors/Colors.swift
@@ -35,8 +35,12 @@ public extension ColorToken {
         hasher.combine(self.uiColor)
     }
 
+    func equals(_ other: any ColorToken) -> Bool {
+        return self.color == other.color && self.uiColor == other.uiColor
+    }
+
     static func == (lhs: any ColorToken, rhs: any ColorToken) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.equals(rhs)
     }
 }
 
@@ -61,7 +65,8 @@ public extension ColorToken {
 
 fileprivate struct OpacityColorToken: ColorToken {
     static func == (lhs: OpacityColorToken, rhs: OpacityColorToken) -> Bool {
-        return lhs.hashValue == rhs.hashValue && lhs.opacity == rhs.opacity
+        return lhs.colorToken.equals(rhs.colorToken) &&
+        lhs.opacity == rhs.opacity
     }
 
     let colorToken: any ColorToken


### PR DESCRIPTION
In the PR, the use of the hash value to check for equality is removed. This was technically incorrect. Two objects which are equal must always have the same hash value, but two objects with the same hash value may not be equal.

See [Hashable](https://developer.apple.com/documentation/swift/hashable)

### Pull requests template

This pull request has:
- [-] Code documentation on publics
- [-] Accessibility
	- [ ] Dynamic sizes
	- [ ] Identifiers
- [x] Tests
- [-] Demo update
- [-] Wiki
