### PR TITLE
[Button] Fix text color when attributedText is set

### DIFF
--- a/core/Sources/Common/DisplayedText/ViewModel/DisplayedTextViewModel.swift
+++ b/core/Sources/Common/DisplayedText/ViewModel/DisplayedTextViewModel.swift
@@ -10,6 +10,7 @@
 protocol DisplayedTextViewModel {
     var text: String? { get }
     var attributedText: AttributedStringEither? { get }
+    var displayedTextType: DisplayedTextType { get }
 
     func textChanged(_ text: String?) -> Bool
     func attributedTextChanged(_ attributedText: AttributedStringEither?) -> Bool
@@ -22,10 +23,9 @@ final class DisplayedTextViewModelDefault: DisplayedTextViewModel {
 
     private(set) var text: String?
     private(set) var attributedText: AttributedStringEither?
+    private(set) var displayedTextType: DisplayedTextType
 
     // MARK: - Private Properties
-
-    private var displayedTextType: DisplayedTextType
 
     private let getDisplayedTextTypeUseCase: GetDisplayedTextTypeUseCaseable
     private let getDidDisplayedTextChangeUseCase: GetDidDisplayedTextChangeUseCaseable

--- a/core/Sources/Common/DisplayedText/ViewModel/DisplayedTextViewModelTests.swift
+++ b/core/Sources/Common/DisplayedText/ViewModel/DisplayedTextViewModelTests.swift
@@ -17,9 +17,10 @@ final class DisplayedTextViewModelTests: XCTestCase {
         // GIVEN
         let textMock = "Hello"
         let attributedTextMock: AttributedStringEither = .left(.init(string: "Holà"))
+        let displayedTextTypeMock: DisplayedTextType = .text
 
         let getDisplayedTextTypeUseCaseMock = GetDisplayedTextTypeUseCaseableGeneratedMock()
-        getDisplayedTextTypeUseCaseMock.executeWithTextAndAttributedTextReturnValue = .text
+        getDisplayedTextTypeUseCaseMock.executeWithTextAndAttributedTextReturnValue = displayedTextTypeMock
         
         // WHEN
         let viewModel = DisplayedTextViewModelDefault(
@@ -35,6 +36,12 @@ final class DisplayedTextViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.attributedText,
                        attributedTextMock,
                        "Wrong attributed text value")
+        XCTAssertEqual(viewModel.text,
+                       textMock,
+                       "Wrong text value")
+        XCTAssertEqual(viewModel.displayedTextType,
+                       displayedTextTypeMock,
+                       "Wrong displayedTextType value")
 
         // **
         // GetDisplayedTextTypeUseCase
@@ -66,12 +73,12 @@ final class DisplayedTextViewModelTests: XCTestCase {
         givenGetDidDisplayedTextChange: Bool
     ) {
         // GIVEN
-        let displayedTextType: DisplayedTextType = .text
+        let displayedTextTypeMock: DisplayedTextType = .text
         let newText = "Hey"
         let textMock = "Hello"
 
         let getDisplayedTextTypeUseCaseMock = GetDisplayedTextTypeUseCaseableGeneratedMock()
-        getDisplayedTextTypeUseCaseMock.executeWithTextAndAttributedTextReturnValue = displayedTextType
+        getDisplayedTextTypeUseCaseMock.executeWithTextAndAttributedTextReturnValue = displayedTextTypeMock
         getDisplayedTextTypeUseCaseMock.executeWithTextReturnValue = DisplayedTextType.none
 
         let getDidDisplayedTextChangeUseCaseMock = GetDidDisplayedTextChangeUseCaseableGeneratedMock()
@@ -95,6 +102,9 @@ final class DisplayedTextViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.text,
                        givenGetDidDisplayedTextChange ? newText : textMock,
                        "Wrong text value")
+        XCTAssertEqual(viewModel.displayedTextType,
+                       givenGetDidDisplayedTextChange ? .none : displayedTextTypeMock,
+                       "Wrong displayedTextType value")
 
         // **
         // GetDidDisplayedTextChangeUseCase
@@ -111,7 +121,7 @@ final class DisplayedTextViewModelTests: XCTestCase {
                        newText,
                        "Wrong newText parameter on execute on getDidDisplayedTextChangeUseCase")
         XCTAssertEqual(getDidDisplayedTextChangeUseCaseMockArgs?.displayedTextType,
-                       displayedTextType,
+                       displayedTextTypeMock,
                        "Wrong displayedTextType parameter on execute on getDidDisplayedTextChangeUseCase")
         // **
 
@@ -143,12 +153,12 @@ final class DisplayedTextViewModelTests: XCTestCase {
         givenGetIsDisplayedAttributedTextChanged: Bool
     ) {
         // GIVEN
-        let displayedTextType: DisplayedTextType = .attributedText
-        let newAttributedText: AttributedStringEither = .left(.init(string: "Hey"))
+        let displayedTextTypeMock: DisplayedTextType = .attributedText
+        let newAttributedTextMock: AttributedStringEither = .left(.init(string: "Hey"))
         let attributedTextMock: AttributedStringEither = .left(.init(string: "Hello"))
 
         let getDisplayedTextTypeUseCaseMock = GetDisplayedTextTypeUseCaseableGeneratedMock()
-        getDisplayedTextTypeUseCaseMock.executeWithTextAndAttributedTextReturnValue = displayedTextType
+        getDisplayedTextTypeUseCaseMock.executeWithTextAndAttributedTextReturnValue = displayedTextTypeMock
         getDisplayedTextTypeUseCaseMock.executeWithAttributedTextReturnValue = DisplayedTextType.none
 
         let getDidDisplayedTextChangeUseCaseMock = GetDidDisplayedTextChangeUseCaseableGeneratedMock()
@@ -162,7 +172,7 @@ final class DisplayedTextViewModelTests: XCTestCase {
         )
 
         // WHEN
-        let attributedTextChanged = viewModel.attributedTextChanged(newAttributedText)
+        let attributedTextChanged = viewModel.attributedTextChanged(newAttributedTextMock)
 
         // THEN
         XCTAssertEqual(attributedTextChanged,
@@ -170,8 +180,11 @@ final class DisplayedTextViewModelTests: XCTestCase {
                       "Wrong attributedTextChanged value")
 
         XCTAssertEqual(viewModel.attributedText,
-                       givenGetIsDisplayedAttributedTextChanged ? newAttributedText : attributedTextMock,
+                       givenGetIsDisplayedAttributedTextChanged ? newAttributedTextMock : attributedTextMock,
                        "Wrong attributedText value")
+        XCTAssertEqual(viewModel.displayedTextType,
+                       givenGetIsDisplayedAttributedTextChanged ? .none : displayedTextTypeMock,
+                       "Wrong displayedTextType value")
 
         // **
         // GetDidDisplayedTextChangeUseCase
@@ -184,10 +197,10 @@ final class DisplayedTextViewModelTests: XCTestCase {
                        attributedTextMock,
                        "Wrong currentAttributedText parameter on execute on getDidDisplayedTextChangeUseCase")
         XCTAssertEqual(getDidDisplayedTextChangeUseCaseMockArgs?.newAttributedText,
-                       newAttributedText,
+                       newAttributedTextMock,
                        "Wrong newAttributedText parameter on execute on getDidDisplayedTextChangeUseCase")
         XCTAssertEqual(getDidDisplayedTextChangeUseCaseMockArgs?.displayedTextType,
-                       displayedTextType,
+                       displayedTextTypeMock,
                        "Wrong displayedTextType parameter on execute on getDidDisplayedTextChangeUseCase")
         // **
 
@@ -199,7 +212,7 @@ final class DisplayedTextViewModelTests: XCTestCase {
 
         if givenGetIsDisplayedAttributedTextChanged {
             XCTAssertEqual(getDisplayedTextTypeUseCaseMock.executeWithAttributedTextReceivedAttributedText,
-                           newAttributedText,
+                           newAttributedTextMock,
                            "Wrong attributedText parameter on execute on getDisplayedTextTypeUseCase")
         }
         // **

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors+ExtensionTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors+ExtensionTests.swift
@@ -13,12 +13,14 @@ extension ButtonCurrentColors {
     // MARK: - Properties
 
     static func mocked(
-        foregroundColor: any ColorToken = ColorTokenGeneratedMock.random(),
+        iconTintColor: any ColorToken = ColorTokenGeneratedMock.random(),
+        textColor: (any ColorToken)? = ColorTokenGeneratedMock.random(),
         backgroundColor: any ColorToken = ColorTokenGeneratedMock.random(),
         borderColor: any ColorToken = ColorTokenGeneratedMock.random()
     ) -> Self {
         return .init(
-            foregroundColor: foregroundColor,
+            iconTintColor: iconTintColor,
+            textColor: textColor,
             backgroundColor: backgroundColor,
             borderColor: borderColor
         )

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
@@ -11,7 +11,8 @@ struct ButtonCurrentColors {
 
     // MARK: - Properties
 
-    let foregroundColor: any ColorToken
+    let iconTintColor: any ColorToken
+    let textColor: (any ColorToken)?
     let backgroundColor: any ColorToken
     let borderColor: any ColorToken
 }
@@ -21,7 +22,10 @@ struct ButtonCurrentColors {
 extension ButtonCurrentColors: Hashable, Equatable {
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(self.foregroundColor)
+        hasher.combine(self.iconTintColor)
+        if let textColor {
+            hasher.combine(textColor)
+        }
         hasher.combine(self.backgroundColor)
         hasher.combine(self.borderColor)
     }
@@ -32,4 +36,3 @@ extension ButtonCurrentColors: Hashable, Equatable {
         lhs.borderColor.equals(rhs.borderColor)
     }
 }
-

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
@@ -31,7 +31,8 @@ extension ButtonCurrentColors: Hashable, Equatable {
     }
 
     static func == (lhs: ButtonCurrentColors, rhs: ButtonCurrentColors) -> Bool {
-        return lhs.foregroundColor.equals(rhs.foregroundColor) &&
+        return lhs.iconTintColor.equals(rhs.iconTintColor) &&
+        lhs.textColor.equals(rhs.textColor) == true &&
         lhs.backgroundColor.equals(rhs.backgroundColor) &&
         lhs.borderColor.equals(rhs.borderColor)
     }

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
@@ -23,7 +23,7 @@ extension ButtonCurrentColors: Hashable, Equatable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.iconTintColor)
-        if let textColor {
+        if let textColor = self.textColor {
             hasher.combine(textColor)
         }
         hasher.combine(self.backgroundColor)

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColorsTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColorsTests.swift
@@ -16,13 +16,16 @@ final class ButtonCurrentColorsTests: XCTestCase {
 
     func test_buttonCurrentColors_equal() {
         let colors = SparkTheme.shared.colors
+
         let given1 = ButtonCurrentColors(
-            foregroundColor: colors.base.onSurface,
+            iconTintColor: colors.base.onSurface,
+            textColor: colors.base.onSurfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.primary.primary)
 
         let given2 = ButtonCurrentColors(
-            foregroundColor: colors.base.onSurface,
+            iconTintColor: colors.base.onSurface,
+            textColor: colors.base.onSurfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.primary.primary)
 
@@ -33,16 +36,17 @@ final class ButtonCurrentColorsTests: XCTestCase {
         let colors = SparkTheme.shared.colors
 
         let given1 = ButtonCurrentColors(
-            foregroundColor: colors.base.onSurface,
+            iconTintColor: colors.base.surface,
+            textColor: colors.base.surfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.primary.primary)
 
         let given2 = ButtonCurrentColors(
-            foregroundColor: colors.base.onSurface,
+            iconTintColor: colors.base.onSurface,
+            textColor: colors.base.onSurfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.primary.onPrimary)
 
         XCTAssertNotEqual(given1, given2)
     }
-
 }

--- a/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCase.swift
@@ -8,7 +8,9 @@
 
 // sourcery: AutoMockable
 protocol ButtonGetCurrentColorsUseCaseable {
-    func execute(colors: ButtonColors, isPressed: Bool) -> ButtonCurrentColors
+    func execute(colors: ButtonColors,
+                 isPressed: Bool,
+                 displayedTextType: DisplayedTextType) -> ButtonCurrentColors
 }
 
 struct ButtonGetCurrentColorsUseCase: ButtonGetCurrentColorsUseCaseable {
@@ -17,17 +19,24 @@ struct ButtonGetCurrentColorsUseCase: ButtonGetCurrentColorsUseCaseable {
 
     func execute(
         colors: ButtonColors,
-        isPressed: Bool
+        isPressed: Bool,
+        displayedTextType: DisplayedTextType
     ) -> ButtonCurrentColors {
+        // Reload text foreground color only if the text is displayed and not the attributedText
+        let isTextColor = (displayedTextType == .text)
+        let textColor = isTextColor ? colors.foregroundColor : nil
+
         if isPressed {
             return .init(
-                foregroundColor: colors.foregroundColor,
+                iconTintColor: colors.foregroundColor,
+                textColor: textColor,
                 backgroundColor: colors.pressedBackgroundColor,
                 borderColor: colors.pressedBorderColor
             )
         } else {
             return .init(
-                foregroundColor: colors.foregroundColor,
+                iconTintColor: colors.foregroundColor,
+                textColor: textColor,
                 backgroundColor: colors.backgroundColor,
                 borderColor: colors.borderColor
             )

--- a/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCaseTests.swift
+++ b/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCaseTests.swift
@@ -30,12 +30,12 @@ final class ButtonGetCurrentColorsUseCaseTests: XCTestCase {
         )
     }()
 
-    // MARK: - Tests
+    // MARK: - IsPressed Tests
 
     func test_execute_when_isPressed_is_true() throws {
         try self.testExecute(
             givenIsPressed: true,
-            expectedForegroundColor: self.foregroundColorMock,
+            expectedIconTintColor: self.foregroundColorMock,
             expectedBackgroundColor: self.pressedBackgroundColorMock,
             expectedBorderColor: self.pressedBorderColorMock
         )
@@ -44,9 +44,32 @@ final class ButtonGetCurrentColorsUseCaseTests: XCTestCase {
     func test_execute_when_isPressed_is_false() throws {
         try self.testExecute(
             givenIsPressed: false,
-            expectedForegroundColor: self.foregroundColorMock,
+            expectedIconTintColor: self.foregroundColorMock,
             expectedBackgroundColor: self.backgroundColorMock,
             expectedBorderColor: self.borderColorMock
+        )
+    }
+
+    // MARK: - DisplayedTextType Tests
+
+    func test_execute_when_displayedTextType_is_none() throws {
+        try self.testExecute(
+            givenDisplayedTextType: .none,
+            expectedTextColor: nil
+        )
+    }
+
+    func test_execute_when_displayedTextType_is_text() throws {
+        try self.testExecute(
+            givenDisplayedTextType: .text,
+            expectedTextColor: self.foregroundColorMock
+        )
+    }
+
+    func test_execute_when_displayedTextType_is_attributedText() throws {
+        try self.testExecute(
+            givenDisplayedTextType: .attributedText,
+            expectedTextColor: nil
         )
     }
 }
@@ -57,7 +80,7 @@ private extension ButtonGetCurrentColorsUseCaseTests {
 
     func testExecute(
         givenIsPressed: Bool,
-        expectedForegroundColor: ColorTokenGeneratedMock,
+        expectedIconTintColor: ColorTokenGeneratedMock,
         expectedBackgroundColor: ColorTokenGeneratedMock,
         expectedBorderColor: ColorTokenGeneratedMock
     ) throws {
@@ -69,18 +92,43 @@ private extension ButtonGetCurrentColorsUseCaseTests {
         // GIVEN
         let currentColors = useCase.execute(
             colors: self.colorsMock,
-            isPressed: givenIsPressed
+            isPressed: givenIsPressed,
+            displayedTextType: .none
         )
 
         // THEN
-        XCTAssertIdentical(currentColors.foregroundColor as? ColorTokenGeneratedMock,
-                           expectedForegroundColor,
-                           "Wrong foregroundColor" + errorSuffixMessage)
+        XCTAssertIdentical(currentColors.iconTintColor as? ColorTokenGeneratedMock,
+                           expectedIconTintColor,
+                           "Wrong iconTintColor" + errorSuffixMessage)
+        XCTAssertNil(currentColors.textColor,
+                     "Wrong textColor" + errorSuffixMessage)
         XCTAssertIdentical(currentColors.backgroundColor as? ColorTokenGeneratedMock,
                            expectedBackgroundColor,
                            "Wrong foregroundColor" + errorSuffixMessage)
         XCTAssertIdentical(currentColors.borderColor as? ColorTokenGeneratedMock,
                            expectedBorderColor,
                            "Wrong foregroundColor" + errorSuffixMessage)
+    }
+
+    func testExecute(
+        givenDisplayedTextType: DisplayedTextType,
+        expectedTextColor: ColorTokenGeneratedMock?
+    ) throws {
+        // GIVEN
+        let errorSuffixMessage = " for \(givenDisplayedTextType) givenDisplayedTextType"
+
+        let useCase = ButtonGetCurrentColorsUseCase()
+
+        // GIVEN
+        let currentColors = useCase.execute(
+            colors: self.colorsMock,
+            isPressed: true,
+            displayedTextType: givenDisplayedTextType
+        )
+
+        // THEN
+        XCTAssertIdentical(currentColors.textColor as? ColorTokenGeneratedMock,
+                           expectedTextColor,
+                           "Wrong textColor" + errorSuffixMessage)
     }
 }

--- a/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
@@ -632,8 +632,10 @@ public final class ButtonUIView: UIView {
             self.setBorderColor(from: colors.borderColor)
 
             // Foreground Color
-            self.iconImageView.tintColor = colors.foregroundColor.uiColor
-            self.textLabel.textColor = colors.foregroundColor.uiColor
+            self.iconImageView.tintColor = colors.iconTintColor.uiColor
+            if let textColor = colors.textColor {
+                self.textLabel.textColor = textColor.uiColor
+            }
         }
 
         // **

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModel.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModel.swift
@@ -239,7 +239,8 @@ final class ButtonViewModel: ObservableObject {
 
         self.currentColors = self.dependencies.getCurrentColorsUseCase.execute(
             colors: colors,
-            isPressed: self.isPressed
+            isPressed: self.isPressed,
+            displayedTextType: self.displayedTextViewModel.displayedTextType
         )
     }
 

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
@@ -36,6 +36,7 @@ final class ButtonViewModelTests: XCTestCase {
         let mock = DisplayedTextViewModelGeneratedMock()
         mock.text = "Text"
         mock.attributedText = .left(.init(string: "AText"))
+        mock.underlyingDisplayedTextType = .text
         return mock
     }()
 
@@ -56,7 +57,7 @@ final class ButtonViewModelTests: XCTestCase {
     }()
     private lazy var getCurrentColorsUseCaseMock: ButtonGetCurrentColorsUseCaseableGeneratedMock = {
         let mock = ButtonGetCurrentColorsUseCaseableGeneratedMock()
-        mock.executeWithColorsAndIsPressedReturnValue = self.currentColorsMock
+        mock.executeWithColorsAndIsPressedAndDisplayedTextTypeReturnValue = self.currentColorsMock
         return mock
     }()
     private lazy var getIsIconOnlyUseCaseMock: ButtonGetIsOnlyIconUseCaseableGeneratedMock = {
@@ -1319,12 +1320,12 @@ private extension ButtonViewModelTests {
         givenColors: ButtonColors? = nil,
         givenIsPressed: Bool? = nil
     ) {
-        XCTAssertEqual(self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedCallsCount,
+        XCTAssertEqual(self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeCallsCount,
                        numberOfCalls,
                        "Wrong call number on execute on getCurrentColorsUseCase")
 
         if numberOfCalls > 0, let givenColors, let givenIsPressed {
-            let getCurrentColorsUseCaseArgs = self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedReceivedArguments
+            let getCurrentColorsUseCaseArgs = self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReceivedArguments
             XCTAssertEqual(try XCTUnwrap(getCurrentColorsUseCaseArgs?.colors),
                                givenColors,
                                "Wrong colors parameter on execute on getCurrentColorsUseCase")
@@ -1430,9 +1431,9 @@ private extension ButtonViewModelTests {
         self.getContentUseCaseMock.executeWithAlignmentAndIconImageAndTextAndAttributedTextReceivedArguments = nil
         self.getContentUseCaseMock.executeWithAlignmentAndIconImageAndTextAndAttributedTextReceivedInvocations = []
 
-        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedCallsCount = 0
-        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedReceivedArguments = nil
-        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedReceivedInvocations = []
+        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeCallsCount = 0
+        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReceivedArguments = nil
+        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReceivedInvocations = []
 
         self.getIsIconOnlyUseCaseMock.executeWithIconImageAndTextAndAttributedTextCallsCount = 0
         self.getIsIconOnlyUseCaseMock.executeWithIconImageAndTextAndAttributedTextReceivedArguments = nil

--- a/core/Sources/Theming/Content/Colors/Colors.swift
+++ b/core/Sources/Theming/Content/Colors/Colors.swift
@@ -44,6 +44,13 @@ public extension ColorToken {
     }
 }
 
+public extension Optional where Wrapped == any ColorToken {
+
+    func equals(_ other: (any ColorToken)?) -> Bool {
+        return self?.color == other?.color && self?.uiColor == other?.uiColor
+    }
+}
+
 public extension ColorToken {
     static var clear: any ColorToken {
         return ColorTokenClear()


### PR DESCRIPTION
Actually, when consumer set an attributedText and user tap on the button, the text color changed so we lost the attributedText color.
The review removed this problem.
