### PR TITLE
[Badge#1138] Fixed height of BadgeUIView. 

### DIFF
--- a/core/Sources/Components/Badge/Constants/BadgeConstants.swift
+++ b/core/Sources/Components/Badge/Constants/BadgeConstants.swift
@@ -10,4 +10,5 @@ import Foundation
 
 enum BadgeConstants {
     static let emptySize = CGSize(width: 12, height: 12)
+    static let height: CGFloat = 24
 }

--- a/core/Sources/Components/Badge/View/UIKit/BadgeUIView.swift
+++ b/core/Sources/Components/Badge/View/UIKit/BadgeUIView.swift
@@ -69,6 +69,7 @@ public class BadgeUIView: UIView {
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Public variables
+    /// The current theme of the view
     public var theme: Theme {
         get {
             return self.viewModel.theme
@@ -78,6 +79,7 @@ public class BadgeUIView: UIView {
         }
     }
 
+    /// The current intent
     public var intent: BadgeIntentType {
         get {
             return self.viewModel.intent
@@ -87,6 +89,7 @@ public class BadgeUIView: UIView {
         }
     }
 
+    /// The badge size
     public var size: BadgeSize {
         get {
             return self.viewModel.size
@@ -96,6 +99,7 @@ public class BadgeUIView: UIView {
         }
     }
 
+    /// The current value of the badge
     public var value: Int? {
         get {
             return self.viewModel.value
@@ -105,6 +109,7 @@ public class BadgeUIView: UIView {
         }
     }
 
+    /// The formatter of the badge
     public var format: BadgeFormat {
         get {
             return self.viewModel.format
@@ -114,6 +119,7 @@ public class BadgeUIView: UIView {
         }
     }
 
+    /// Shows/hides the border around the badge
     public var isBorderVisible: Bool {
         get {
             return self.viewModel.isBorderVisible

--- a/core/Sources/Components/Badge/View/UIKit/BadgeUIView.swift
+++ b/core/Sources/Components/Badge/View/UIKit/BadgeUIView.swift
@@ -22,6 +22,7 @@ public class BadgeUIView: UIView {
     @ScaledUIMetric private var horizontalSpacing: CGFloat = 0
     @ScaledUIMetric private var verticalSpacing: CGFloat = 0
     @ScaledUIMetric private var borderWidth: CGFloat = 0
+    @ScaledUIMetric private var badgeHeight: CGFloat = 0
 
     // Constraints for badge size
     // Thess constraints containes text size with
@@ -67,6 +68,60 @@ public class BadgeUIView: UIView {
 
     private var cancellables = Set<AnyCancellable>()
 
+    // MARK: - Public variables
+    public var theme: Theme {
+        get {
+            return self.viewModel.theme
+        }
+        set {
+            self.viewModel.theme = newValue
+        }
+    }
+
+    public var intent: BadgeIntentType {
+        get {
+            return self.viewModel.intent
+        }
+        set {
+            self.viewModel.intent = newValue
+        }
+    }
+
+    public var size: BadgeSize {
+        get {
+            return self.viewModel.size
+        }
+        set {
+            self.viewModel.size = newValue
+        }
+    }
+
+    public var value: Int? {
+        get {
+            return self.viewModel.value
+        }
+        set {
+            self.viewModel.value = newValue
+        }
+    }
+
+    public var format: BadgeFormat {
+        get {
+            return self.viewModel.format
+        }
+        set {
+            self.viewModel.format = newValue
+        }
+    }
+
+    public var isBorderVisible: Bool {
+        get {
+            return self.viewModel.isBorderVisible
+        }
+        set {
+            self.viewModel.isBorderVisible = newValue
+        }
+    }
     // MARK: - Init
 
     public init(theme: Theme, intent: BadgeIntentType, size: BadgeSize = .normal, value: Int? = nil, format: BadgeFormat = .default, isBorderVisible: Bool = true) {
@@ -94,6 +149,7 @@ public class BadgeUIView: UIView {
 
     private func setupScalables() {
         self.emptyBadgeSize = BadgeConstants.emptySize.width
+        self.badgeHeight = BadgeConstants.height
         self.horizontalSpacing = self.viewModel.horizontalOffset
         self.verticalSpacing = self.viewModel.verticalOffset
         self.borderWidth = self.viewModel.isBorderVisible ? self.viewModel.border.width : .zero
@@ -133,20 +189,22 @@ public class BadgeUIView: UIView {
 
     private func setupSizeConstraint(for textSize: CGSize) {
         let widht = self.viewModel.isBadgeEmpty ? self.emptyBadgeSize : textSize.width + (self.horizontalSpacing * 2)
-        let height = self.viewModel.isBadgeEmpty ? self.emptyBadgeSize : textSize.height + (self.verticalSpacing * 2)
+        let height = self.viewModel.isBadgeEmpty ? self.emptyBadgeSize : self.badgeHeight
 
         if let widthConstraint, let heightConstraint {
             widthConstraint.constant = widht
             heightConstraint.constant = height
         } else {
-            widthConstraint = self.widthAnchor.constraint(equalToConstant: widht)
-            heightConstraint = self.heightAnchor.constraint(equalToConstant: height)
-            NSLayoutConstraint.activate(sizeConstraints.compactMap({ $0 }))
+            self.widthConstraint = self.widthAnchor.constraint(equalToConstant: widht)
+            self.widthConstraint?.priority = .required
+            self.heightConstraint = self.heightAnchor.constraint(equalToConstant: height)
+            self.heightConstraint?.priority = .required
+            NSLayoutConstraint.activate(self.sizeConstraints.compactMap({ $0 }))
         }
     }
 
     private func setupBadgeConstraintsIfNeeded(for textSize: CGSize) {
-        guard shouldSetupLabelConstrains else {
+        guard self.shouldSetupLabelConstrains else {
             return
         }
 
@@ -154,7 +212,7 @@ public class BadgeUIView: UIView {
         self.labelTopConstraint = self.textLabel.topAnchor.constraint(equalTo: topAnchor)
         self.labelTrailingConstraint = self.textLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         self.labelBottomConstraint = self.textLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
-        NSLayoutConstraint.activate(labelConstraints.compactMap({ $0 }))
+        NSLayoutConstraint.activate(self.labelConstraints.compactMap({ $0 }))
     }
 
     public override func layoutSubviews() {
@@ -171,7 +229,6 @@ public class BadgeUIView: UIView {
             self.removeConstraint($0)
         }
     }
-
 
     /// Attach badge to another view by using constraints
     /// Triggers detach() if it was already attached to a view
@@ -292,6 +349,7 @@ extension BadgeUIView {
             self._horizontalSpacing.update(traitCollection: self.traitCollection)
             self._verticalSpacing.update(traitCollection: self.traitCollection)
         }
+        self._badgeHeight.update(traitCollection: traitCollection)
     }
 
     private func reloadBorderWidth() {

--- a/core/Sources/Components/Badge/View/UIKit/BadgeUIView.swift
+++ b/core/Sources/Components/Badge/View/UIKit/BadgeUIView.swift
@@ -16,11 +16,11 @@ public class BadgeUIView: UIView {
 
     // Dynamicaly sized properties for badge
     // emptyBadgeSize represents size of the circle in empty state of Badge
-    // horizontalSpacing and verticalSpacing are properties
-    // that are used for space between badge background and text
+    // horizontalSpacing is the padding to the left and right of the text
+    // borderWidth is the width of the border when it's shown
+    // badgeHeight is the height of the badge
     @ScaledUIMetric private var emptyBadgeSize: CGFloat = 0
     @ScaledUIMetric private var horizontalSpacing: CGFloat = 0
-    @ScaledUIMetric private var verticalSpacing: CGFloat = 0
     @ScaledUIMetric private var borderWidth: CGFloat = 0
     @ScaledUIMetric private var badgeHeight: CGFloat = 0
 
@@ -157,7 +157,6 @@ public class BadgeUIView: UIView {
         self.emptyBadgeSize = BadgeConstants.emptySize.width
         self.badgeHeight = BadgeConstants.height
         self.horizontalSpacing = self.viewModel.horizontalOffset
-        self.verticalSpacing = self.viewModel.verticalOffset
         self.borderWidth = self.viewModel.isBorderVisible ? self.viewModel.border.width : .zero
     }
 
@@ -353,7 +352,6 @@ extension BadgeUIView {
             self._emptyBadgeSize.update(traitCollection: self.traitCollection)
         } else {
             self._horizontalSpacing.update(traitCollection: self.traitCollection)
-            self._verticalSpacing.update(traitCollection: self.traitCollection)
         }
         self._badgeHeight.update(traitCollection: traitCollection)
     }

--- a/core/Sources/Components/Badge/ViewModel/BadgeViewModel.swift
+++ b/core/Sources/Components/Badge/ViewModel/BadgeViewModel.swift
@@ -26,30 +26,30 @@ import SwiftUI
 /// - format -- see ``BadgeFormat`` as a formater of **Badge Text**
 ///
 /// - theme  -- represents ``Theme`` used in the app
-public final class BadgeViewModel: ObservableObject {
+final class BadgeViewModel: ObservableObject {
 
     // MARK: - Badge Configuration Public Properties
-    public var value: Int? = nil {
+    var value: Int? = nil {
         didSet {
             updateText()
         }
     }
-    public var intent: BadgeIntentType {
+    var intent: BadgeIntentType {
         didSet {
             updateColors()
         }
     }
-    public var size: BadgeSize {
+    var size: BadgeSize {
         didSet {
             updateFont()
         }
     }
-    public var format: BadgeFormat {
+    var format: BadgeFormat {
         didSet {
             updateText()
         }
     }
-    public var theme: Theme {
+    var theme: Theme {
         didSet {
             updateColors()
             updateScalings()

--- a/core/Sources/Components/Badge/ViewModel/BadgeViewModel.swift
+++ b/core/Sources/Components/Badge/ViewModel/BadgeViewModel.swift
@@ -61,10 +61,8 @@ public final class BadgeViewModel: ObservableObject {
     @Published var textFont: TypographyFontToken
     @Published var textColor: any ColorToken
     @Published var isBadgeEmpty: Bool
-
     @Published var backgroundColor: any ColorToken
     @Published var border: BadgeBorder
-
     @Published var isBorderVisible: Bool
 
     // MARK: - Internal Appearance Properties

--- a/spark/Demo/Classes/View/Components/Badge/Badge+UIPresentable.swift
+++ b/spark/Demo/Classes/View/Components/Badge/Badge+UIPresentable.swift
@@ -7,9 +7,9 @@
 //
 
 import Combine
+import Spark
+import SparkCore
 import SwiftUI
-@testable import SparkCore
-@testable import Spark
 
 private struct BadgePreviewFormatter: BadgeFormatting {
     func formatText(for value: Int?) -> String {
@@ -21,10 +21,6 @@ private struct BadgePreviewFormatter: BadgeFormatting {
 }
 
 struct UIBadgeView: UIViewRepresentable {
-
-//    var views: [BadgeUIView]
-
-//    @ObservedObject private var themePublisher = SparkThemePublisher.shared
 
     let theme: Theme
     let intent: BadgeIntentType

--- a/spark/Demo/Classes/View/Components/Badge/Badge+UIPresentable.swift
+++ b/spark/Demo/Classes/View/Components/Badge/Badge+UIPresentable.swift
@@ -8,8 +8,8 @@
 
 import Combine
 import SwiftUI
-import SparkCore
-import Spark
+@testable import SparkCore
+@testable import Spark
 
 private struct BadgePreviewFormatter: BadgeFormatting {
     func formatText(for value: Int?) -> String {
@@ -22,52 +22,44 @@ private struct BadgePreviewFormatter: BadgeFormatting {
 
 struct UIBadgeView: UIViewRepresentable {
 
-    var views: [BadgeUIView]
+//    var views: [BadgeUIView]
 
-    @ObservedObject private var themePublisher = SparkThemePublisher.shared
+//    @ObservedObject private var themePublisher = SparkThemePublisher.shared
 
-    var theme: Theme {
-        self.themePublisher.theme
+    let theme: Theme
+    let intent: BadgeIntentType
+    let size: BadgeSize
+    let value: Int?
+    let format: BadgeFormat
+    let isBorderVisible: Bool
+
+    init(theme: Theme, intent: BadgeIntentType, size: BadgeSize = .normal, value: Int? = nil, format: BadgeFormat = .default, isBorderVisible: Bool = true) {
+        self.theme = theme
+        self.intent = intent
+        self.size = size
+        self.value = value
+        self.format = format
+        self.isBorderVisible = isBorderVisible
     }
 
-    func makeUIView(context: Context) -> some UIView {
-        let badgesStackView = UIStackView()
-        for view in self.views {
-            view.setTheme(self.theme)
-        }
-        views.enumerated().forEach { index, badgeView in
-            let containerView = UIView()
-            containerView.translatesAutoresizingMaskIntoConstraints = false
-            let label = UILabel()
-            label.translatesAutoresizingMaskIntoConstraints = false
-            label.text = "badge_\(index)"
-            containerView.addSubview(label)
-            containerView.addSubview(badgeView)
-            containerView.backgroundColor = .blue
-
-            label.activateConstraint(from: .leading, to: .leading, ofView: containerView, relation: .greaterThanOrEqual)
-            label.activateConstraint(from: .top, to: .top, ofView: containerView)
-            label.activateConstraint(from: .bottom, to: .bottom, ofView: containerView)
-
-            if index >= 3 && index <= 6 {
-                badgeView.activateConstraint(from: .centerX, to: .trailing, ofView: label, constant: 5)
-                badgeView.activateConstraint(from: .centerY, to: .top, ofView: label, constant: -5)
-            } else {
-                badgeView.activateConstraint(from: .leading, to: .trailing, ofView: label, constant: 5)
-                badgeView.activateConstraint(from: .centerY, to: .centerY, ofView: label)
-            }
-
-            badgesStackView.addArrangedSubview(containerView)
-        }
-        badgesStackView.axis = .vertical
-        badgesStackView.alignment = .leading
-        badgesStackView.spacing = 30
-        badgesStackView.distribution = .fill
-
-        return badgesStackView
+    func makeUIView(context: Context) -> BadgeUIView {
+        return BadgeUIView(
+            theme: theme,
+            intent: intent,
+            size: size,
+            value: value,
+            format: format,
+            isBorderVisible: isBorderVisible
+        )
     }
 
-    func updateUIView(_ uiView: UIViewType, context: Context) {
+    func updateUIView(_ badge: BadgeUIView, context: Context) {
+        badge.theme = theme
+        badge.intent = intent
+        badge.size = size
+        badge.format = format
+        badge.value = value
+        badge.isBorderVisible = isBorderVisible
     }
 }
 

--- a/spark/Demo/Classes/View/Components/Badge/BadgeComponentView.swift
+++ b/spark/Demo/Classes/View/Components/Badge/BadgeComponentView.swift
@@ -27,189 +27,157 @@ struct BadgeComponentView: View {
         self.themePublisher.theme
     }
 
-    private var views = [
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .alert,
-            value: 6
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .main,
-            size: .normal,
-            value: 22,
-            format: .overflowCounter(maxValue: 20)
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .danger,
-            value: 10,
-            format: .custom(
-                formatter: BadgePreviewFormatter()
-            )
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .info,
-            value: 20
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .main
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .neutral,
-            isBorderVisible: false
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .support,
-            value: 23
-        ),
-        BadgeUIView(
-            theme: SparkThemePublisher.shared.theme,
-            intent: .success
-        )
-    ]
+    @State var version: ComponentVersion = .uiKit
+    @State var isVersionPresented = false
 
-    @State var standartBadgeValue: Int? = 3
-    @State var standartBadgeIsOutlined: Bool = true
+    @State var intent: BadgeIntentType = .danger
+    @State var isIntentPresented = false
 
-    @State var smallCustomBadgeValue: Int? = 14
-    @State var smallCustomBadgeSize: BadgeSize = .small
-    @State var smallCustomBadgeIsOutlined: Bool = true
-    @State var smallCustomBadgeType: BadgeIntentType = .alert
-    @State var badgeFormat: BadgeFormat = .default
+    @State var size: BadgeSize = .normal
+    @State var isSizePresented = false
 
-    @State var standartDangerBadgeType: BadgeIntentType = .danger
+    @State var value: Int? = 99
+
+    @State var format: BadgeFormat = .default
+    @State var isFormatPresented = false
+
+    @State var isBorderVisible: CheckboxSelectionState = .unselected
 
     var body: some View {
-        List {
-            Section(header: Text("UIKit Badge")) {
-                Button("Change UIKit Badge 0 Type") {
-                    views[0].setIntent(BadgeIntentType.allCases.randomElement() ?? .alert)
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Configuration")
+                .font(.title2)
+                .bold()
+                .padding(.bottom, 6)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack() {
+                    Text("Version: ").bold()
+                    Button(self.version.name) {
+                        self.isVersionPresented = true
+                    }
+                    .confirmationDialog("Select a version",
+                                        isPresented: self.$isVersionPresented) {
+                        ForEach(ComponentVersion.allCases, id: \.self) { version in
+                            Button(version.name) {
+                                self.version = version
+                            }
+                        }
+                    }
+                    Spacer()
                 }
-                Button("Change UIKit Badge 1 Value") {
-                    views[1].setValue(2)
+                HStack() {
+                    Text("Intent: ").bold()
+                    Button(self.intent.name) {
+                        self.isIntentPresented = true
+                    }
+                    .confirmationDialog("Select an intent", isPresented: self.$isIntentPresented) {
+                        ForEach(BadgeIntentType.allCases, id: \.self) { intent in
+                            Button(intent.name) {
+                                self.intent = intent
+                            }
+                        }
+                    }
                 }
-                Button("Change UIKit Badge 2 Outline") {
-                    views[2].setBorderVisible(false)
+                HStack() {
+                    Text("Badge Size: ").bold()
+                    Button(self.size.name) {
+                        self.isSizePresented = true
+                    }
+                    .confirmationDialog("Select a size", isPresented: self.$isSizePresented) {
+                        ForEach(BadgeSize.allCases, id: \.self) { size in
+                            Button(size.name) {
+                                self.size = size
+                            }
+                        }
+                    }
                 }
-                Button("Change UIKit Badge 3 Size") {
-                    views[3].setSize(.small)
+                HStack() {
+                    Text("Format ").bold()
+                    Button(self.format.name) {
+                        self.isFormatPresented = true
+                    }
+                    .confirmationDialog("Select a format", isPresented: self.$isFormatPresented) {
+                        ForEach(BadgeFormat.allNames, id: \.self) { name in
+                            Button(name) {
+                                self.format = BadgeFormat.from(name: name)
+                            }
+                        }
+                    }
                 }
-                UIBadgeView(views: views)
-                    .frame(height: 400)
-                    .listRowBackground(Color.gray.opacity(0.3))
+                HStack() {
+                    Text("Value ").bold()
+                    TextField("Value", value: self.$value, formatter: NumberFormatter())
+                }
+
+                CheckboxView(
+                    text: "With Border",
+                    checkedImage: DemoIconography.shared.checkmark,
+                    theme: theme,
+                    state: .enabled,
+                    selectionState: self.$isBorderVisible
+                )
             }
-            .listRowBackground(Color.gray.opacity(0.3))
 
-            Section(header: Text("SwiftUI Badge")) {
-                Button("Change Default Badge Value") {
-                    standartBadgeValue = 23
-                    standartBadgeIsOutlined.toggle()
-                    badgeFormat = .overflowCounter(maxValue: 20)
-                }
-                Button("Change Small Custom Badge") {
-                    smallCustomBadgeValue = 18
-                    smallCustomBadgeSize = .normal
-                    smallCustomBadgeIsOutlined.toggle()
-                    smallCustomBadgeType = .main
-                }
-                Button("Change Dange Badge") {
-                    standartDangerBadgeType = .neutral
-                }
-                VStack(spacing: 100) {
-                    HStack(spacing: 50) {
-                        ZStack(alignment: .leading) {
-                            Text("Default Badge")
-                            BadgeView(
-                                theme: theme,
-                                intent: .main,
-                                value: standartBadgeValue
-                            )
-                            .format(badgeFormat)
-                            .borderVisible(standartBadgeIsOutlined)
-                            .offset(x: 100, y: -15)
-                        }
-                        ZStack(alignment: .leading) {
-                            Text("Small Custom")
-                            BadgeView(
-                                theme: SparkTheme.shared,
-                                intent: smallCustomBadgeType,
-                                value: 22
-                            )
-                            .borderVisible(smallCustomBadgeIsOutlined)
-                            .size(smallCustomBadgeSize)
-                            .offset(x: 100, y: -15)
-                        }
-                    }
+            Divider()
 
-                    HStack(spacing: 55) {
-                        ZStack(alignment: .leading) {
-                            Text("Danger Badge")
-                            BadgeView(
-                                theme: self.theme,
-                                intent: standartDangerBadgeType,
-                                value: 10
-                            )
-                            .format(.custom(
-                                formatter: BadgePreviewFormatter()
-                            ))
-                                .offset(x: 100, y: -15)
-                        }
-                        ZStack(alignment: .leading) {
-                            Text("Text")
-                            BadgeView(
-                                theme: self.theme,
-                                intent: .info
-                            )
-                                .offset(x: 25, y: -15)
-                        }
-                        ZStack(alignment: .leading) {
-                            Text("Text")
-                            BadgeView(
-                                theme: self.theme,
-                                intent: .neutral
-                            )
-                                .offset(x: 25, y: -15)
-                        }
-                    }
+            Text("Integration")
+                .font(.title2)
+                .bold()
 
-                    HStack(spacing: 50) {
-                        HStack {
-                            Text("Text")
-                            BadgeView(
-                                theme: self.theme,
-                                intent: .main
-                            )
-                        }
-                        HStack {
-                            Text("Text")
-                            BadgeView(
-                                theme: self.theme,
-                                intent: .support
-                            )
-                        }
-                        HStack {
-                            Text("Text")
-                            BadgeView(
-                                theme: self.theme,
-                                intent: .success
-                            )
-                        }
-                    }
-                }
-                .padding(.vertical, 15)
-                .listRowBackground(Color.gray.opacity(0.3))
+
+            if version == .swiftUI {
+                BadgeView(theme: self.theme, intent: self.intent, value: self.value)
+                    .size(self.size)
+                    .format(self.format)
+                    .borderVisible(self.isBorderVisible == .selected)
+            } else {
+                UIBadgeView(theme: self.theme,
+                            intent: self.intent,
+                            size: self.size,
+                            value: self.value,
+                            format: self.format,
+                            isBorderVisible: self.isBorderVisible == .selected)
+                .fixedSize()
             }
+
+            Spacer()
         }
+        .padding(.horizontal, 16)
+        .navigationBarTitle(Text("Badge"))
     }
 }
 
 struct BadgeComponentView_Previews: PreviewProvider {
     static var previews: some View {
         BadgeComponentView()
+    }
+}
+
+private extension BadgeFormat {
+    enum Names {
+        static let `default` = "Default"
+        static let custom = "Custom"
+        static let overflowCounter = "Overflow Counter"
+    }
+
+    static var allNames: [String] = [Names.default, Names.custom, Names.overflowCounter]
+
+    var name: String {
+        switch self {
+        case .default: return Names.default
+        case .custom: return Names.custom
+        case .overflowCounter: return Names.overflowCounter
+        @unknown default:
+            fatalError("Unknown Badge Format")
+        }
+    }
+
+    static func from(name: String) -> BadgeFormat {
+        switch name {
+        case Names.custom: return .custom(formatter: BadgePreviewFormatter())
+        case Names.overflowCounter: return .overflowCounter(maxValue: 99)
+        default: return .default
+        }
     }
 }

--- a/spark/Demo/Classes/View/Components/Badge/BadgeComponentView.swift
+++ b/spark/Demo/Classes/View/Components/Badge/BadgeComponentView.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
-import SparkCore
 import Spark
+import SparkCore
 import SwiftUI
 
 private struct BadgePreviewFormatter: BadgeFormatting {

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Spark
-@testable import SparkCore
+import SparkCore
 import SwiftUI
 
 // MARK: - SwiftUI-wrapper
@@ -76,10 +76,15 @@ final class CheckboxViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.addSubviewSizedEqually(self.scrollView)
-
+        self.view.addSubview(self.scrollView)
         self.scrollView.addSubview(self.contentView)
+
         NSLayoutConstraint.activate([
+            self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            self.scrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            self.scrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+
             self.contentView.centerXAnchor.constraint(equalTo: self.scrollView.centerXAnchor),
             self.contentView.widthAnchor.constraint(equalTo: self.scrollView.widthAnchor),
             self.contentView.topAnchor.constraint(equalTo: self.scrollView.topAnchor),

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxViewController.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Spark
-import SparkCore
+@testable import SparkCore
 import SwiftUI
 
 // MARK: - SwiftUI-wrapper

--- a/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
+++ b/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
@@ -141,7 +141,8 @@ struct ChipComponent: View {
             Spacer()
         }
         .padding(.horizontal, 16)
-        .navigationBarTitle(Text("Chip"))    }
+        .navigationBarTitle(Text("Chip"))
+    }
 }
 
 struct ChipComponent_Previews: PreviewProvider {


### PR DESCRIPTION
In the UI-Kit variation of the Badge, the height was not correct. I noticed this, when implementing the tab item.
- The height has been fixed
- The presentation in the demo has been adapted to the new style with the possibility of interactively changing attributes.
- Properties of the UI-Kit component had to made public as modifiers of the view.
- Reduced access of BadgeViewModel from public to internal.

Please also approve the [updated snapshots](https://github.com/adevinta/spark-ios-snapshots/pull/43):

<img width="577" alt="Screenshot 2023-08-01 at 15 29 28" src="https://github.com/adevinta/spark-ios/assets/128726463/f7419b53-e56c-4f35-9e75-78ea937953a7">

