### PR TITLE
[Badge#1189] Corrected autoscaling and badge height depending on size.

### DIFF
--- a/core/Sources/Components/Badge/Constants/BadgeConstants.swift
+++ b/core/Sources/Components/Badge/Constants/BadgeConstants.swift
@@ -10,5 +10,8 @@ import Foundation
 
 enum BadgeConstants {
     static let emptySize = CGSize(width: 12, height: 12)
-    static let height: CGFloat = 24
+    enum height {
+        static let normal: CGFloat = 24
+        static let small: CGFloat = 16
+    }
 }

--- a/core/Sources/Components/Badge/Properties/Private/BadgeSizeDependentAttributes.swift
+++ b/core/Sources/Components/Badge/Properties/Private/BadgeSizeDependentAttributes.swift
@@ -1,0 +1,24 @@
+//
+//  BadgeSizeDependentAttributes.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 03.08.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct BadgeSizeDependentAttributes: Equatable {
+
+    let offset: EdgeInsets
+    let height: CGFloat
+    let font: TypographyFontToken
+
+    static func == (lhs: BadgeSizeDependentAttributes, rhs: BadgeSizeDependentAttributes) -> Bool {
+        return lhs.offset == rhs.offset &&
+        lhs.height == rhs.height &&
+        lhs.font.font == rhs.font.font &&
+        lhs.font.uiFont == rhs.font.uiFont
+    }
+}

--- a/core/Sources/Components/Badge/UseCase/BadgeGetSizeAttributesUseCase.swift
+++ b/core/Sources/Components/Badge/UseCase/BadgeGetSizeAttributesUseCase.swift
@@ -1,0 +1,57 @@
+//
+//  BadgeGetSizeUseCase.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 03.08.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+// sourcery: AutoMockable
+protocol BadgeGetSizeAttributesUseCaseable {
+    func execute(theme: Theme, size: BadgeSize) -> BadgeSizeDependentAttributes
+}
+
+/// A use case that returns size specific attributes according to the theme
+struct BadgeGetSizeAttributesUseCase: BadgeGetSizeAttributesUseCaseable {
+
+    // MARK: - Functions
+    func execute(theme: Theme, size: BadgeSize) -> BadgeSizeDependentAttributes {
+        return .init(offset: size.offset(spacing: theme.layout.spacing),
+                     height: size.badgeHeight(),
+                     font: size.font(typography: theme.typography))
+    }
+}
+
+// MARK: - Private helper extension
+private extension BadgeSize {
+    func offset(spacing: LayoutSpacing) -> EdgeInsets {
+        switch self {
+        case .normal: return  .init(vertical: spacing.small,
+                                    horizontal: spacing.medium)
+        case .small: return .init(vertical: 0,
+                                  horizontal: spacing.small)
+        }
+    }
+
+    func badgeHeight() -> CGFloat {
+        switch self {
+        case .normal:
+            return BadgeConstants.height.normal
+        case .small:
+            return BadgeConstants.height.small
+        }
+    }
+
+    func font(typography: Typography) -> TypographyFontToken {
+        switch self {
+        case .normal:
+            return typography.captionHighlight
+        case .small:
+            return typography.smallHighlight
+        }
+    }
+
+}

--- a/core/Sources/Components/Badge/UseCase/BadgeGetSizeAttributesUseCaseTests.swift
+++ b/core/Sources/Components/Badge/UseCase/BadgeGetSizeAttributesUseCaseTests.swift
@@ -1,0 +1,47 @@
+//
+//  BadgeGetSizeAttributesUseCase.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 03.08.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import SparkCore
+import XCTest
+
+final class BadgeGetSizeAttributesUseCaseTests: TestCase {
+
+    // MARK: - Properties
+    var sut: BadgeGetSizeAttributesUseCase!
+    var theme: ThemeGeneratedMock!
+
+    // MARK: - Setup
+    override func setUp()  {
+        super.setUp()
+        self.theme = .mocked()
+        self.sut = BadgeGetSizeAttributesUseCase()
+    }
+
+    // MARK: - Tests
+    func test_size_small() throws {
+        let attributes = sut.execute(theme: self.theme, size: .small)
+
+        let expectedAttributes = BadgeSizeDependentAttributes(
+            offset: .init(vertical: 0, horizontal: 3),
+            height: 16,
+            font: self.theme.typography.smallHighlight)
+
+        XCTAssertEqual(attributes, expectedAttributes)
+    }
+
+    func test_size_normal() throws {
+        let attributes = sut.execute(theme: self.theme, size: .normal)
+
+        let expectedAttributes = BadgeSizeDependentAttributes(
+            offset: .init(vertical: 3, horizontal: 5),
+            height: 24,
+            font: self.theme.typography.captionHighlight)
+
+        XCTAssertEqual(attributes, expectedAttributes)
+    }
+}

--- a/core/Sources/Components/Badge/View/SwiftUI/BadgeView.swift
+++ b/core/Sources/Components/Badge/View/SwiftUI/BadgeView.swift
@@ -25,8 +25,8 @@ import SwiftUI
 /// ```
 public struct BadgeView: View {
     @ObservedObject private var viewModel: BadgeViewModel
-    @ScaledMetric private var smallOffset: CGFloat
-    @ScaledMetric private var mediumOffset: CGFloat
+    @ScaledMetric private var horizontalOffset: CGFloat
+    @ScaledMetric private var verticalOffset: CGFloat
     @ScaledMetric private var emptySize: CGFloat
     @ScaledMetric private var borderWidth: CGFloat
 
@@ -45,7 +45,7 @@ public struct BadgeView: View {
             Text(self.viewModel.text)
                 .font(self.viewModel.textFont.font)
                 .foregroundColor(self.viewModel.textColor.color)
-                .padding(.init(vertical: self.smallOffset, horizontal: self.mediumOffset))
+                .padding(.init(vertical: self.verticalOffset, horizontal: self.horizontalOffset))
                 .background(self.viewModel.backgroundColor.color)
                 .border(
                     width: self.viewModel.isBorderVisible ? borderWidth : 0,
@@ -64,13 +64,13 @@ public struct BadgeView: View {
         let viewModel = BadgeViewModel(theme: theme, intent: intent, value: value)
         self.viewModel = viewModel
 
-        self._smallOffset =
+        self._horizontalOffset =
             .init(wrappedValue:
-                    viewModel.verticalOffset
+                    viewModel.offset.leading
             )
-        self._mediumOffset =
+        self._verticalOffset =
             .init(wrappedValue:
-                    viewModel.horizontalOffset
+                    viewModel.offset.top
             )
         self._emptySize = .init(wrappedValue: BadgeConstants.emptySize.width)
         self._borderWidth = .init(wrappedValue: viewModel.border.width)


### PR DESCRIPTION
With the fix for the badge height [(PR),](https://github.com/adevinta/spark-ios/pull/280) I missed that the badge can have two sizes.

This is fixed in this PR.
Additionally, autoscaling didn't appear to work correctly, in my opinion, because the width constraint of the badge was calculated on the text size. This calculation is not necessary, adding leading and trialing constraints to the label are sufficient.
The width constraint of the badge is now a minimum width. It should not be smaller than the height.

Please also review the [updated snapshots](https://github.com/adevinta/spark-ios-snapshots/pull/45).