### PR TITLE
[Chip#307] Added intrinsic content size,  isEnabled state and trailing icon support.

### DIFF
--- a/core/Sources/Components/Chip/Enum/ChipAlignment.swift
+++ b/core/Sources/Components/Chip/Enum/ChipAlignment.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 public enum ChipAlignment: CaseIterable {
-    /// Icon on the leading edge of the button.
-    /// Text on the trailing edge of the button.
+    /// Icon on the leading edge of the chip.
+    /// Text on the trailing edge of the chip.
     /// Not interpreted if chip contains just an icon or just text.
     case leadingIcon
-    /// Icon on the trailing edge of the button.
-    /// Text on the leading edge of the button
+    /// Icon on the trailing edge of the chip.
+    /// Text on the leading edge of the chip
     /// Not interpreted if the chip contains just an icon or just text.
     case trailingIcon
 }

--- a/core/Sources/Components/Chip/Enum/ChipAlignment.swift
+++ b/core/Sources/Components/Chip/Enum/ChipAlignment.swift
@@ -1,0 +1,20 @@
+//
+//  ChipAlignment.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 21.08.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+public enum ChipAlignment: CaseIterable {
+    /// Icon on the leading edge of the button.
+    /// Text on the trailing edge of the button.
+    /// Not interpreted if chip contains just an icon or just text.
+    case leadingIcon
+    /// Icon on the trailing edge of the button.
+    /// Text on the leading edge of the button
+    /// Not interpreted if the chip contains just an icon or just text.
+    case trailingIcon
+}

--- a/core/Sources/Components/Chip/Model/ChipState.swift
+++ b/core/Sources/Components/Chip/Model/ChipState.swift
@@ -1,0 +1,21 @@
+//
+//  ChipState.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 21.08.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+struct ChipState {
+
+    static let `default` = ChipState(isEnabled: true, isPressed: false)
+
+    let isEnabled: Bool
+    let isPressed: Bool
+
+    var isDisabled: Bool {
+        return !self.isEnabled
+    }
+}

--- a/core/Sources/Components/Chip/Model/ChipStateColors.swift
+++ b/core/Sources/Components/Chip/Model/ChipStateColors.swift
@@ -6,17 +6,27 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
+import Foundation
+
 /// The colors definie a chip
 struct ChipStateColors {
     let background: any ColorToken
     let border: any ColorToken
     let foreground: any ColorToken
+    var opacity: CGFloat
+
+    init(background: any ColorToken, border: any ColorToken, foreground: any ColorToken, opacity: CGFloat = 1.0) {
+        self.background = background
+        self.border = border
+        self.foreground = foreground
+        self.opacity = opacity
+    }
 }
 
 extension ChipStateColors: Equatable {
     static func == (lhs: ChipStateColors, rhs: ChipStateColors) -> Bool {
         return lhs.background.equals(rhs.background) &&
         lhs.border.equals(rhs.border) &&
-        lhs.foreground.equals(rhs.foreground)
+        lhs.foreground.equals(rhs.foreground) && lhs.opacity == rhs.opacity
     }
 }

--- a/core/Sources/Components/Chip/Model/ChipStateTests.swift
+++ b/core/Sources/Components/Chip/Model/ChipStateTests.swift
@@ -1,0 +1,30 @@
+//
+//  ChipStateTests.swift
+//  SparkCoreTests
+//
+//  Created by michael.zimmermann on 23.08.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+@testable import SparkCore
+import XCTest
+
+final class ChipStateTests: XCTestCase {
+
+    func test_default() {
+        let sut = ChipState.default
+
+        XCTAssertTrue(sut.isEnabled, "By default enabled should be true.")
+        XCTAssertFalse(sut.isDisabled, "Expected isDisabled to be the oposite of enabled.")
+        XCTAssertFalse(sut.isPressed, "By default, the pressed state is not set")
+    }
+
+    func test_disabled() {
+        let sut = ChipState(isEnabled: false, isPressed: true)
+
+        XCTAssertFalse(sut.isEnabled, "Expeted the state not to be enabled.")
+        XCTAssertTrue(sut.isDisabled, "Expected the state to be disabled.")
+        XCTAssertTrue(sut.isPressed, "The pressed state should be true.")
+    }
+
+}

--- a/core/Sources/Components/Chip/UseCase/GetChipColorsUseCaseTests.swift
+++ b/core/Sources/Components/Chip/UseCase/GetChipColorsUseCaseTests.swift
@@ -38,19 +38,38 @@ final class GetChipColorsUseCaseTests: XCTestCase {
             tintedPrincipal: .purple,
             tintedSubordinate: .blue)
 
-        let expected = ChipColors(
-            default: ChipStateColors(
+        let expected = ChipStateColors(
                 background: .red,
                 border: .red,
-                foreground: .green),
-            pressed: ChipStateColors(
-                background: .purple,
-                border: .purple,
-                foreground: .red))
+                foreground: .green)
 
         // When
         for intentColor in [ChipIntent.main, .support, .alert, .danger, .info, .neutral, .success, .accent, .basic] {
-            let given = sut.execute(theme: theme, variant: .filled, intent: intentColor)
+            let given = sut.execute(theme: theme, variant: .filled, intent: intentColor, state: .default)
+
+            // Then
+            XCTAssertEqual(given, expected)
+        }
+    }
+
+    func test_all_standard_filled_pressed_colors() {
+        // Given
+        self.theme.border = BorderGeneratedMock()
+        self.theme.colors = ColorsGeneratedMock()
+        self.intentColorsUseCase.executeWithColorsAndIntentColorReturnValue = ChipIntentColors(
+            principal: .red,
+            subordinate: .green,
+            tintedPrincipal: .purple,
+            tintedSubordinate: .blue)
+
+        let expected = ChipStateColors(
+                background: .purple,
+                border: .purple,
+                foreground: .red)
+
+        // When
+        for intentColor in [ChipIntent.main, .support, .alert, .danger, .info, .neutral, .success, .accent, .basic] {
+            let given = sut.execute(theme: theme, variant: .filled, intent: intentColor, state: .pressed)
 
             // Then
             XCTAssertEqual(given, expected)
@@ -67,21 +86,43 @@ final class GetChipColorsUseCaseTests: XCTestCase {
             tintedPrincipal: .purple,
             tintedSubordinate: .blue)
 
-        let expected = ChipColors(
-            default: ChipStateColors(
+        let expected = ChipStateColors(
                 background: .clear,
                 border: .red,
-                foreground: .red),
-            pressed: ChipStateColors(
-                background: .purple,
-                border: .purple,
-                foreground: .red))
+                foreground: .red)
 
         for variant in [ChipVariant.outlined, .dashed] {
             // When
             for intentColor in [ChipIntent.main, .support, .alert, .danger, .info, .neutral, .success, .accent, .basic] {
 
-                let given = sut.execute(theme: theme, variant: variant, intent: intentColor)
+                let given = sut.execute(theme: theme, variant: variant, intent: intentColor, state: .default)
+
+                // Then
+                XCTAssertEqual(given, expected)
+            }
+        }
+    }
+
+    func test_all_standard_bordered_pressed_colors() {
+        // Given
+        self.theme.border = BorderGeneratedMock()
+        self.theme.colors = ColorsGeneratedMock()
+        self.intentColorsUseCase.executeWithColorsAndIntentColorReturnValue = ChipIntentColors(
+            principal: .red,
+            subordinate: .green,
+            tintedPrincipal: .purple,
+            tintedSubordinate: .blue)
+
+        let expected = ChipStateColors(
+                background: .purple,
+                border: .purple,
+                foreground: .red)
+
+        for variant in [ChipVariant.outlined, .dashed] {
+            // When
+            for intentColor in [ChipIntent.main, .support, .alert, .danger, .info, .neutral, .success, .accent, .basic] {
+
+                let given = sut.execute(theme: theme, variant: variant, intent: intentColor, state: .pressed)
 
                 // Then
                 XCTAssertEqual(given, expected)
@@ -99,20 +140,40 @@ final class GetChipColorsUseCaseTests: XCTestCase {
             tintedPrincipal: .purple,
             tintedSubordinate: .blue)
 
-        let expected = ChipColors(
-            default: ChipStateColors(
+        let expected = ChipStateColors(
                 background: .purple,
                 border: .purple,
-                foreground: .blue),
-            pressed: ChipStateColors(
-                background: .blue,
-                border: .blue,
-                foreground: .purple))
+                foreground: .blue)
 
         // When
         for intentColor in [ChipIntent.main, .support, .alert, .danger, .info, .neutral, .success, .accent, .basic] {
 
-            let given = sut.execute(theme: theme, variant: .tinted, intent: intentColor)
+            let given = sut.execute(theme: theme, variant: .tinted, intent: intentColor, state: .default)
+
+            // Then
+            XCTAssertEqual(given, expected)
+        }
+    }
+
+    func test_all_standard_tinted_pressed_colors() {
+        // Given
+        self.theme.border = BorderGeneratedMock()
+        self.theme.colors = ColorsGeneratedMock()
+        self.intentColorsUseCase.executeWithColorsAndIntentColorReturnValue = ChipIntentColors(
+            principal: .red,
+            subordinate: .green,
+            tintedPrincipal: .purple,
+            tintedSubordinate: .blue)
+
+        let expected = ChipStateColors(
+                background: .blue,
+                border: .blue,
+                foreground: .purple)
+
+        // When
+        for intentColor in [ChipIntent.main, .support, .alert, .danger, .info, .neutral, .success, .accent, .basic] {
+
+            let given = sut.execute(theme: theme, variant: .tinted, intent: intentColor, state: .pressed)
 
             // Then
             XCTAssertEqual(given, expected)
@@ -129,20 +190,39 @@ final class GetChipColorsUseCaseTests: XCTestCase {
             tintedPrincipal: .purple,
             tintedSubordinate: .blue)
 
-        let expected = ChipColors(
-            default: ChipStateColors(
+        let expected = ChipStateColors(
                 background: .clear,
                 border: .green,
-                foreground: .green),
-            pressed: ChipStateColors(
+                foreground: .green)
+        // When
+        for variant in [ChipVariant.outlined, .dashed] {
+
+            let given = sut.execute(theme: theme, variant: variant, intent: .surface, state: .default)
+
+            // Then
+            XCTAssertEqual(given, expected)
+        }
+    }
+
+    func test_surface_bordered_pressed_colors() {
+        // Given
+        self.theme.border = BorderGeneratedMock()
+        self.theme.colors = ColorsGeneratedMock()
+        self.intentColorsUseCase.executeWithColorsAndIntentColorReturnValue = ChipIntentColors(
+            principal: .red,
+            subordinate: .green,
+            tintedPrincipal: .purple,
+            tintedSubordinate: .blue)
+
+        let expected = ChipStateColors(
                 background: .blue,
                 border: .blue,
-                foreground: .red))
+                foreground: .red)
 
         // When
         for variant in [ChipVariant.outlined, .dashed] {
 
-            let given = sut.execute(theme: theme, variant: variant, intent: .surface)
+            let given = sut.execute(theme: theme, variant: variant, intent: .surface, state: .pressed)
 
             // Then
             XCTAssertEqual(given, expected)
@@ -159,19 +239,35 @@ final class GetChipColorsUseCaseTests: XCTestCase {
             tintedPrincipal: .purple,
             tintedSubordinate: .blue)
 
-        let expected = ChipColors(
-            default: ChipStateColors(
+        let expected = ChipStateColors(
                 background: .red,
                 border: .red,
-                foreground: .green),
-            pressed: ChipStateColors(
+                foreground: .green)
+
+        // When
+        let given = sut.execute(theme: theme, variant: .filled, intent: .surface, state: .default)
+
+        // Then
+        XCTAssertEqual(given, expected)
+    }
+
+    func test_surface_filled_pressed_colors() {
+        // Given
+        self.theme.border = BorderGeneratedMock()
+        self.theme.colors = ColorsGeneratedMock()
+        self.intentColorsUseCase.executeWithColorsAndIntentColorReturnValue = ChipIntentColors(
+            principal: .red,
+            subordinate: .green,
+            tintedPrincipal: .purple,
+            tintedSubordinate: .blue)
+
+        let expected = ChipStateColors(
                 background: .blue,
                 border: .blue,
                 foreground: .red)
-        )
 
         // When
-        let given = sut.execute(theme: theme, variant: .filled, intent: .surface)
+        let given = sut.execute(theme: theme, variant: .filled, intent: .surface, state: .pressed)
 
         // Then
         XCTAssertEqual(given, expected)
@@ -205,4 +301,9 @@ private extension ChipStateColors {
                   border: ColorTokenGeneratedMock(uiColor:border),
                   foreground: ColorTokenGeneratedMock(uiColor:foreground))
     }
+}
+
+private extension ChipState {
+    static let pressed = ChipState(isEnabled: true, isPressed: true)
+    static let disabled = ChipState(isEnabled: false, isPressed: false)
 }

--- a/core/Sources/Components/Chip/View/ChipUIViewTests.swift
+++ b/core/Sources/Components/Chip/View/ChipUIViewTests.swift
@@ -52,6 +52,31 @@ final class ChipUIViewTests: UIKitComponentTestCase {
         }
     }
 
+    func test_support_with_icon_trailing_and_label() {
+        let icon: UIImage = UIImage(systemName: "pencil.circle")!
+        let chipView = ChipUIView(theme: SparkTheme.shared,
+                                  intent: .support,
+                                  variant: .filled,
+                                  alignment: .trailingIcon,
+                                  label: "Label",
+                                  iconImage: icon)
+
+        assertSnapshotInDarkAndLight(matching: chipView, sizes: [.medium])
+    }
+
+    func test_basic_disabled_with_icon_trailing_and_label() {
+        let icon: UIImage = UIImage(systemName: "pencil.circle")!
+        let chipView = ChipUIView(theme: SparkTheme.shared,
+                                  intent: .basic,
+                                  variant: .filled,
+                                  alignment: .trailingIcon,
+                                  label: "Label",
+                                  iconImage: icon)
+        chipView.isEnabled = false
+
+        assertSnapshotInDarkAndLight(matching: chipView, sizes: [.medium])
+    }
+
     func test_info_with_icon_and_label_and_component() {
         for variant in ChipVariant.allCases {
             let icon = UIImage(systemName: "pencil.circle")!

--- a/core/Sources/Components/Chip/View/ChipViewModelTests.swift
+++ b/core/Sources/Components/Chip/View/ChipViewModelTests.swift
@@ -32,13 +32,12 @@ final class ChipViewModelTests: TestCase {
 
         let colorToken = ColorTokenGeneratedMock()
 
-        self.useCase.executeWithThemeAndVariantAndIntentReturnValue = ChipColors(
-            default: ChipStateColors(background: colorToken, border: colorToken, foreground: colorToken),
-            pressed: ChipStateColors(background: colorToken, border: colorToken, foreground: colorToken))
+        self.useCase.executeWithThemeAndVariantAndIntentAndStateReturnValue = ChipStateColors(background: colorToken, border: colorToken, foreground: colorToken)
 
         self.sut = ChipViewModel(theme: theme,
                                  variant: .filled,
                                  intent: .main,
+                                 alignment: .leadingIcon,
                                  useCase: useCase)
     }
 

--- a/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
+++ b/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
@@ -164,7 +164,6 @@ struct ChipComponent: View {
                     Button("OK", role: .cancel) { }
                 }
             }
-
             Spacer()
         }
         .padding(.horizontal, 16)

--- a/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
+++ b/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
@@ -29,13 +29,12 @@ struct ChipComponent: View {
 
     @State var showLabel = CheckboxSelectionState.selected
     @State var showIcon = CheckboxSelectionState.selected
-    @State var withAction = CheckboxSelectionState.unselected
+    @State var withAction = CheckboxSelectionState.selected
     @State var withComponent = CheckboxSelectionState.unselected
     @State var isEnabled = CheckboxSelectionState.selected
 
     @State var showingAlert = false
 
-    private var component = UIImageView(image: UIImage.strokedCheckmark).withTint(.red)
     private let label = "Label"
     private let icon = UIImage(imageLiteralResourceName: "alert")
 
@@ -157,17 +156,26 @@ struct ChipComponent: View {
                     alignment: self.alignment,
                     label: self.showLabel == .selected ? self.label : nil,
                     icon: self.showIcon == .selected ? self.icon : nil,
-                    component: self.withComponent == .selected ? self.component : nil,
+                    component: self.withComponent == .selected ? badge() : nil,
                     isEnabled: self.isEnabled == .selected,
                     action: self.withAction == .selected ? { self.showingAlert = true} : nil)
                 .alert("Chip Pressed", isPresented: self.$showingAlert) {
                     Button("OK", role: .cancel) { }
                 }
+                .fixedSize()
             }
             Spacer()
         }
         .padding(.horizontal, 16)
         .navigationBarTitle(Text("Chip"))
+    }
+
+    func badge() -> UIView {
+        return BadgeUIView(theme: self.theme,
+                           intent: .danger,
+                           size: .small,
+                           value: 99
+        )
     }
 }
 

--- a/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
+++ b/spark/Demo/Classes/View/Components/Chip/ChipComponent.swift
@@ -24,10 +24,15 @@ struct ChipComponent: View {
     @State var isIntentPresented = false
     @State var variant: ChipVariant = .filled
     @State var isVariantPresented = false
+    @State var alignment: ChipAlignment = .leadingIcon
+    @State var isAlignmentPressed = false
+
     @State var showLabel = CheckboxSelectionState.selected
     @State var showIcon = CheckboxSelectionState.selected
     @State var withAction = CheckboxSelectionState.unselected
     @State var withComponent = CheckboxSelectionState.unselected
+    @State var isEnabled = CheckboxSelectionState.selected
+
     @State var showingAlert = false
 
     private var component = UIImageView(image: UIImage.strokedCheckmark).withTint(.red)
@@ -82,7 +87,19 @@ struct ChipComponent: View {
                         }
                     }
                 }
-
+                HStack() {
+                    Text("Alignment: ").bold()
+                    Button(self.alignment.name) {
+                        self.isAlignmentPressed = true
+                    }
+                    .confirmationDialog("Select an alignment", isPresented: self.$isAlignmentPressed) {
+                        ForEach(ChipAlignment.allCases, id: \.self) { alignment in
+                            Button(alignment.name) {
+                                self.alignment = alignment
+                            }
+                        }
+                    }
+                }
                 CheckboxView(
                     text: "With Label",
                     checkedImage: DemoIconography.shared.checkmark,
@@ -114,6 +131,14 @@ struct ChipComponent: View {
                     state: .enabled,
                     selectionState: self.$withComponent
                 )
+
+                CheckboxView(
+                    text: "Is Enabled",
+                    checkedImage: DemoIconography.shared.checkmark,
+                    theme: theme,
+                    state: .enabled,
+                    selectionState: self.$isEnabled
+                )
             }
 
             Divider()
@@ -129,9 +154,11 @@ struct ChipComponent: View {
                     theme: self.theme,
                     intent: self.intent,
                     variant: self.variant,
+                    alignment: self.alignment,
                     label: self.showLabel == .selected ? self.label : nil,
                     icon: self.showIcon == .selected ? self.icon : nil,
                     component: self.withComponent == .selected ? self.component : nil,
+                    isEnabled: self.isEnabled == .selected,
                     action: self.withAction == .selected ? { self.showingAlert = true} : nil)
                 .alert("Chip Pressed", isPresented: self.$showingAlert) {
                     Button("OK", role: .cancel) { }
@@ -155,5 +182,16 @@ private extension UIView {
     func withTint(_ color: UIColor) -> Self {
         self.tintColor = color
         return self
+    }
+}
+
+private extension ChipAlignment {
+    var name: String {
+        switch self {
+        case .leadingIcon: return "Leading Icon"
+        case .trailingIcon: return "Trailing Icon"
+        @unknown default:
+            return "Unknown"
+        }
     }
 }

--- a/spark/Demo/Classes/View/Components/Chip/ChipComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Chip/ChipComponentUIView.swift
@@ -16,29 +16,23 @@ struct ChipComponentUIView: View {
     let theme: Theme
     let intent: ChipIntent
     let variant: ChipVariant
+    let alignment: ChipAlignment
     let label: String?
     let icon: UIImage?
     let component: UIView?
+    let isEnabled: Bool
     let action: (() -> Void)?
-
-//    init(theme: Theme, intent: ChipIntent, variant: ChipVariant, label: String?, icon: UIImage?, component: UIView?, action: (() -> Void)?) {
-//        self.theme = theme
-//        self.intent = intent
-//        self.variant = variant
-//        self.showComponent = showComponent
-//        self.label = label
-//        self.icon = icon
-//        self.action = action
-//    }
 
     var body: some View {
         ChipComponentUIViewRepresentation(
             theme: self.theme,
             intent: self.intent,
             variant: self.variant,
+            alignment: self.alignment,
             label: self.label,
             icon: self.icon,
             component: self.component,
+            isEnabled: self.isEnabled,
             action: self.action
         )
     }
@@ -49,9 +43,11 @@ struct ChipComponentUIViewRepresentation: UIViewRepresentable {
     let theme: Theme
     let intent: ChipIntent
     let variant: ChipVariant
+    let alignment: ChipAlignment
     let label: String?
     let icon: UIImage?
     let component: UIView?
+    let isEnabled: Bool
     let action: (()->Void)?
 
     func makeUIView(context: Context) -> ChipUIView {
@@ -61,6 +57,7 @@ struct ChipComponentUIViewRepresentation: UIViewRepresentable {
                 theme: self.theme,
                 intent: self.intent,
                 variant: self.variant,
+                alignment: self.alignment,
                 label: label,
                 iconImage: icon)
         } else if let icon = icon {
@@ -68,16 +65,19 @@ struct ChipComponentUIViewRepresentation: UIViewRepresentable {
                 theme: self.theme,
                 intent: self.intent,
                 variant: self.variant,
+                alignment: self.alignment,
                 iconImage: icon)
         } else {
             chipView = ChipUIView(
                 theme: self.theme,
                 intent: self.intent,
                 variant: self.variant,
+                alignment: self.alignment,
                 label: "")
         }
         chipView.action = self.action
         chipView.component = self.component
+        chipView.isEnabled = self.isEnabled
         return chipView
     }
 
@@ -89,5 +89,7 @@ struct ChipComponentUIViewRepresentation: UIViewRepresentable {
         chipView.icon = self.icon
         chipView.action = self.action
         chipView.component = self.component
+        chipView.alignment = self.alignment
+        chipView.isEnabled = self.isEnabled
     }
 }


### PR DESCRIPTION
Added calculation of intrinsic content size.
If the width can't be calculated because a component doesn't support intrinsic content size, then UIView.noIntrinsicMetric will be returned as the width. The height is always defined.
Additionally:
- the view was changed to a control. 
- the position of the icon aligned with the text can be changed (leading/trailing).
-  The chip may be disabled

The new snapshots are in a [PR](https://github.com/adevinta/spark-ios-snapshots/pull/51).

### Pull requests template

This pull request has:
- [/] Code documentation on publics
- [/] Accessibility
	- [/] Dynamic sizes
	- [/] Identifiers
- [/] Tests
- [/] Demo update
- [/] Wiki
