### PR TITLE
[Tab#336] Fix removing tab items in demo.

### DIFF
--- a/core/Sources/Components/Tab/View/UIKit/TabItemUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabItemUIViewSnapshotTests.swift
@@ -38,29 +38,6 @@ final class TabItemUIViewSnapshotTests: UIKitComponentTestCase {
         assertSnapshotInDarkAndLight(matching: sut, sizes: [.medium])
     }
 
-    func test_tab_with_intent_support() throws {
-        let sut = TabItemUIView(
-            theme: self.theme,
-            intent: .support,
-            title: "Label")
-
-        sut.badge = badge
-
-        assertSnapshotInDarkAndLight(matching: sut, sizes: [.medium])
-    }
-
-    func x_test_selected_tab_with_intent_support() throws {
-        let sut = TabItemUIView(
-            theme: self.theme,
-            intent: .support,
-            title: "Label")
-
-        sut.badge = badge
-        sut.isSelected = true
-
-        assertSnapshotInDarkAndLight(matching: sut, sizes: [.medium])
-    }
-
     func test_selected_tab_with_intent_main() throws {
         let sut = TabItemUIView(
             theme: self.theme,

--- a/core/Sources/Components/Tab/View/UIKit/TabItemUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabItemUIViewSnapshotTests.swift
@@ -38,7 +38,18 @@ final class TabItemUIViewSnapshotTests: UIKitComponentTestCase {
         assertSnapshotInDarkAndLight(matching: sut, sizes: [.medium])
     }
 
-    func test_selected_tab_with_intent_support() throws {
+    func test_tab_with_intent_support() throws {
+        let sut = TabItemUIView(
+            theme: self.theme,
+            intent: .support,
+            title: "Label")
+
+        sut.badge = badge
+
+        assertSnapshotInDarkAndLight(matching: sut, sizes: [.medium])
+    }
+
+    func x_test_selected_tab_with_intent_support() throws {
         let sut = TabItemUIView(
             theme: self.theme,
             intent: .support,

--- a/spark/Demo/Classes/View/Components/Tab/TabUIComponentView.swift
+++ b/spark/Demo/Classes/View/Components/Tab/TabUIComponentView.swift
@@ -124,8 +124,6 @@ struct TabUIComponentRepresentableView: UIViewRepresentable {
             tab.title = self.showText ? "Label \(index)" : nil
         }
 
-        let oldSelectedIndex = uiView.selectedSegmentIndex
-
         if self.numberOfTabs > uiView.numberOfSegments {
             guard let content: (icon: UIImage, title: String) = (0..<self.numberOfTabs).map({ (icon: .image(at: $0), title: "Label \($0)") }).last else { return }
 
@@ -139,6 +137,9 @@ struct TabUIComponentRepresentableView: UIViewRepresentable {
                 uiView.addSegment(with: "")
                 uiView.segments[self.numberOfTabs].label.text = nil
             }
+        } else if self.numberOfTabs < uiView.numberOfSegments {
+            uiView.removeSegment(at: uiView.numberOfSegments - 1, animated: true)
+            uiView.selectedSegmentIndex = min(uiView.selectedSegmentIndex, uiView.numberOfSegments - 1)
         }
 
         self.badge.size = self.tabSize.badgeSize


### PR DESCRIPTION
There was a bug in the demo, when removing a tab item.

![tabs-remove-item](https://github.com/adevinta/spark-ios/assets/128726463/6b446ef8-35f7-4aeb-a275-9bb6c933f986)
