### PR TITLE
[Tests] Add reset method on Sourcery

### DIFF
--- a/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
@@ -1419,37 +1419,17 @@ private extension ButtonViewModelTests {
 
     private func resetMockedData() {
         // Clear UseCases Mock
-        self.getBorderUseCaseMock.executeWithShapeAndBorderAndVariantCallsCount = 0
-        self.getBorderUseCaseMock.executeWithShapeAndBorderAndVariantReceivedArguments = nil
-        self.getBorderUseCaseMock.executeWithShapeAndBorderAndVariantReceivedInvocations = []
-
-        self.getColorsUseCaseMock.executeWithThemeAndIntentAndVariantCallsCount = 0
-        self.getColorsUseCaseMock.executeWithThemeAndIntentAndVariantReceivedArguments = nil
-        self.getColorsUseCaseMock.executeWithThemeAndIntentAndVariantReceivedInvocations = []
-
-        self.getContentUseCaseMock.executeWithAlignmentAndIconImageAndTextAndAttributedTextCallsCount = 0
-        self.getContentUseCaseMock.executeWithAlignmentAndIconImageAndTextAndAttributedTextReceivedArguments = nil
-        self.getContentUseCaseMock.executeWithAlignmentAndIconImageAndTextAndAttributedTextReceivedInvocations = []
-
-        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeCallsCount = 0
-        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReceivedArguments = nil
-        self.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReceivedInvocations = []
-
-        self.getIsIconOnlyUseCaseMock.executeWithIconImageAndTextAndAttributedTextCallsCount = 0
-        self.getIsIconOnlyUseCaseMock.executeWithIconImageAndTextAndAttributedTextReceivedArguments = nil
-        self.getIsIconOnlyUseCaseMock.executeWithIconImageAndTextAndAttributedTextReceivedInvocations = []
-
-        self.getSizesUseCaseMock.executeWithSizeAndIsOnlyIconCallsCount = 0
-        self.getSizesUseCaseMock.executeWithSizeAndIsOnlyIconReceivedArguments = nil
-        self.getSizesUseCaseMock.executeWithSizeAndIsOnlyIconReceivedInvocations = []
-
-        self.getSpacingsUseCaseMock.executeWithSpacingAndIsOnlyIconCallsCount = 0
-        self.getSpacingsUseCaseMock.executeWithSpacingAndIsOnlyIconReceivedArguments = nil
-        self.getSpacingsUseCaseMock.executeWithSpacingAndIsOnlyIconReceivedInvocations = []
-
-        self.getStateUseCaseMock.executeWithIsEnabledAndDimsCallsCount = 0
-        self.getStateUseCaseMock.executeWithIsEnabledAndDimsReceivedArguments = nil
-        self.getStateUseCaseMock.executeWithIsEnabledAndDimsReceivedInvocations = []
+        let useCases: [ResetGeneratedMock] = [
+            self.getBorderUseCaseMock,
+            self.getColorsUseCaseMock,
+            self.getContentUseCaseMock,
+            self.getCurrentColorsUseCaseMock,
+            self.getIsIconOnlyUseCaseMock,
+            self.getSizesUseCaseMock,
+            self.getSpacingsUseCaseMock,
+            self.getStateUseCaseMock
+        ]
+        useCases.forEach { $0.reset() }
 
         // Reset published sink counter
         self.statePublishedSinkCount = 0

--- a/stencil/sourcery-template/SparkCoreAutoMockable.stencil
+++ b/stencil/sourcery-template/SparkCoreAutoMockable.stencil
@@ -183,6 +183,25 @@ final class {{ type.name }}GeneratedMock: {{ import }}.{{ type.name }} {
     {% call mockMethod method %}
 {% endfor %}
 }
+
+extension  {{ type.name }}GeneratedMock: ResetGeneratedMock {
+
+    func reset() {
+    {% for method in type.allMethods|!definedInExtension %}
+
+        {% call swiftifyMethodNameV2 method %}CallsCount = 0
+        {% if method.parameters.count == 1 %}
+            {% call swiftifyMethodNameV2 method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = nil {% endfor %}
+        {% elif not method.parameters.count == 0 %}
+            {% call swiftifyMethodNameV2 method %}ReceivedArguments = nil
+        {% endif %}
+        {% call swiftifyMethodNameV2 method %}ReceivedInvocations = []
+    {% endfor %}
+    }
+}
 {% endif %}{% endfor %}
 
 {% endfor %}
+protocol ResetGeneratedMock {
+    func reset()
+}


### PR DESCRIPTION
The goal of the PR is to simplify some part of our tests.

- The sourcery.yml is updated to add ResetGeneratedMock protocol
- Replace manual reset on mock to reset method on Button