### PR TITLE
[Fix] Button: set real height on setup

### DIFF
--- a/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
@@ -456,6 +456,9 @@ public final class ButtonUIView: UIView {
         self.addSubview(self.contentStackView)
         self.addSubview(self.clearButton)
 
+        // Needed values from viewModel (important for superview)
+        self.height = self.viewModel.sizes?.height ?? 0
+
         // Setup constraints
         self.setupConstraints()
 

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModel.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModel.swift
@@ -81,10 +81,18 @@ final class ButtonViewModel: ObservableObject {
         self.isEnabled = isEnabled
 
         self.dependencies = dependencies
+
+        self.loadRequired()
     }
 
     // MARK: - Load
 
+    /// Load required published properties when the view is init
+    private func loadRequired() {
+        self.sizesDidUpdate()
+    }
+
+    /// Load all published values. Should be called when all published values are subscribed by the view
     func load() {
         // Update all values when view is ready to receive published values
         self.updateAll()

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
@@ -198,10 +198,13 @@ final class ButtonViewModelTests: XCTestCase {
             numberOfCalls: 0
         )
         self.testGetIsIconOnlyUseCaseMock(
-            numberOfCalls: 0
+            numberOfCalls: 1,
+            givenIconImage: self.iconImageMock
         )
         self.testGetSizesUseCaseMock(
-            numberOfCalls: 0
+            numberOfCalls: 1,
+            givenSize: sizeMock,
+            givenIsOnlyIcon: self.isIconOnlyMock
         )
         self.testGetSpacingsUseCaseMock(
             numberOfCalls: 0
@@ -300,6 +303,7 @@ final class ButtonViewModelTests: XCTestCase {
             givenIconImage: self.iconImageMock
         )
         self.testGetSizesUseCaseMock(
+            numberOfCalls: 2,
             givenSize: sizeMock,
             givenIsOnlyIcon: self.isIconOnlyMock
         )
@@ -1336,7 +1340,7 @@ private extension ButtonViewModelTests {
     }
 
     private func testGetIsIconOnlyUseCaseMock(
-        numberOfCalls: Int = 2,
+        numberOfCalls: Int = 3,
         givenIconImage: UIImage? = nil
     ) {
         XCTAssertEqual(self.getIsIconOnlyUseCaseMock.executeWithIconImageAndTextAndAttributedTextCallsCount,


### PR DESCRIPTION
Depending on the component implementation, there may be a problem with the size of the button.

So, to fix this issue, we need to get the height value from viewModel directly on the view initialization
