### PR TITLE
[Tech] PublisherMock: add missing data and method

### DIFF
--- a/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
@@ -1108,7 +1108,6 @@ final class ButtonViewModelTests: XCTestCase {
     }
 
     func test_set_isEnabled_with_same_new_value() {
-        let valueMock = true
         self.testSetIsEnabled(
             givenIsDifferentNewValue: false
         )

--- a/core/Unit-tests/Classes/Publisher/PublisherMock.swift
+++ b/core/Unit-tests/Classes/Publisher/PublisherMock.swift
@@ -46,10 +46,15 @@ final class PublisherMock<T: Publisher> {
 extension PublisherMock where T.Failure == Never {
 
     func loadTesting(on subscriptions: inout Set<AnyCancellable>) {
-        self.publisher.sink { value in
-            self.sinkValue = value
-            self.sinkValues.append(value)
+        self.publisher.sink { [weak self] value in
+            guard let self = self else { return }
             self.sinkCount += 1
+
+            // T.Output is optional and nil ? We don't set the value
+            if !((value as AnyObject) is NSNull) {
+                self.sinkValue = value
+                self.sinkValues.append(value)
+            }
         }.store(in: &subscriptions)
     }
 }

--- a/core/Unit-tests/Classes/Publisher/XCTest+PublisherMock.swift
+++ b/core/Unit-tests/Classes/Publisher/XCTest+PublisherMock.swift
@@ -15,41 +15,71 @@ extension XCTest {
 
     func XCTAssertPublisherSinkCountEqual<T: Publisher>(
         on mock: PublisherMock<T>,
-        _ expression: Int
+        _ expression: Int,
+        function: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) {
         XCTAssertEqual(
             mock.sinkCount,
             expression,
-            Self.errorMessage(on: mock, for: .count)
+            Self.errorMessage(
+                on: mock,
+                for: .count,
+                function: function,
+                file: file,
+                line: line
+            )
         )
     }
 
     func XCTAssertPublisherSinkIsCalled<T: Publisher>(
         on mock: PublisherMock<T>,
-        _ expression: Bool
+        _ expression: Bool,
+        function: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) {
         XCTAssertEqual(
             mock.sinkCalled,
             expression,
-            Self.errorMessage(on: mock, for: .isCalled)
+            Self.errorMessage(
+                on: mock,
+                for: .isCalled,
+                function: function,
+                file: file,
+                line: line
+            )
         )
     }
 
     func XCTAssertPublisherSinkValueEqual<T: Publisher>(
         on mock: PublisherMock<T>,
-        _ expression: T.Output
+        _ expression: T.Output,
+        function: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) where T.Output: Equatable {
         XCTAssertEqual(
             mock.sinkValue,
             expression,
-            Self.errorMessage(on: mock, for: .value)
+            Self.errorMessage(
+                on: mock,
+                for: .value,
+                function: function,
+                file: file,
+                line: line
+            )
         )
     }
 
     func XCTAssertPublisherSinkValueIdentical<T: Publisher, Z: AnyObject>(
         on mock: PublisherMock<T>,
         _ expression: Z?,
-        expressionShouldBeSet: Bool = true
+        expressionShouldBeSet: Bool = true,
+        function: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) {
         guard (expressionShouldBeSet && expression != nil) || !expressionShouldBeSet else {
             XCTFail("\(Z.self) expression should be set")
@@ -59,18 +89,51 @@ extension XCTest {
         XCTAssertIdentical(
             mock.sinkValue as? Z,
             expression,
-            Self.errorMessage(on: mock, for: .value)
+            Self.errorMessage(
+                on: mock,
+                for: .value,
+                function: function,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    func XCTAssertPublisherSinkValueNil<T: Publisher>(
+        on mock: PublisherMock<T>,
+        function: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertNil(
+            mock.sinkValue,
+            Self.errorMessage(
+                on: mock,
+                for: .valueNil,
+                function: function,
+                file: file,
+                line: line
+            )
         )
     }
 
     func XCTAssertPublisherSinkValuesEqual<T: Publisher>(
         on mock: PublisherMock<T>,
-        _ expression: [T.Output]
+        _ expression: [T.Output],
+        function: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) where T.Output: Equatable {
         XCTAssertEqual(
             mock.sinkValues,
             expression,
-            Self.errorMessage(on: mock, for: .values)
+            Self.errorMessage(
+                on: mock,
+                for: .values,
+                function: function,
+                file: file,
+                line: line
+            )
         )
     }
 
@@ -80,6 +143,7 @@ extension XCTest {
         case count
         case isCalled
         case value
+        case valueNil
         case values
     }
 
@@ -87,8 +151,11 @@ extension XCTest {
 
     private static func errorMessage<T: Publisher>(
         on mock: PublisherMock<T>,
-        for type: TestingSinkType
+        for type: TestingSinkType,
+        function: String,
+        file: StaticString,
+        line: UInt
     ) -> String {
-        return "Wrong \(mock.name) sink \(type.rawValue) value"
+        return "Wrong \(mock.name) sink \(type.rawValue) value on \(function) function, \(file) file, line \(line)"
     }
 }


### PR DESCRIPTION
- Add parameters on XCT methods (function, file, line)
- Add missing method (XCTAssertPublisherSinkValueNil)
- Improve set of value on PublisherMock (we don't want set value if it's nil)