### PR TITLE
[Fix#433] Subscribe on RunLoop.main.

### DIFF
--- a/core/Sources/Common/Combine/Global/Publisher-Subscribe.swift
+++ b/core/Sources/Common/Combine/Global/Publisher-Subscribe.swift
@@ -12,7 +12,7 @@ import Foundation
 extension Publisher where Failure == Never {
     func subscribe<S>(
         in subscriptions: inout Set<AnyCancellable>,
-        on scheduler: S = DispatchQueue.main,
+        on scheduler: S = RunLoop.main,
         action: @escaping (Self.Output) -> Void ) where S: Scheduler {
             self
                 .receive(on: scheduler)

--- a/spark/Demo/Classes/View/Components/Chip/UIKit/ChipComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Chip/UIKit/ChipComponentUIView.swift
@@ -351,7 +351,7 @@ final class ChipComponentUIView: UIView {
 
         self.withComponentCheckBox.publisher.subscribe(in: &self.cancellables) { [weak self] state in
             guard let self = self else { return }
-            let component: UIView = UIImageView(image: UIImage.strokedCheckmark).withTint(.red)
+            let component: UIView = UIImageView(image: UIImage.strokedCheckmark)
             self.viewModel.component = state == .selected ? component : nil
         }
     }


### PR DESCRIPTION
The default subscriptions of the view models were on DispachQueue.main, but it is better to have them on the RunLoop.main.