### PR TITLE
[Fix-462] Fix constraints on UIKit & image color on SwiftUI

### DIFF
--- a/core/Sources/Components/Switch/View/SwiftUI/SwitchView.swift
+++ b/core/Sources/Components/Switch/View/SwiftUI/SwitchView.swift
@@ -144,6 +144,7 @@ public struct SwitchView: View {
                                 viewModel: self.viewModel
                             )
                     }
+                    .opacity(self.viewModel.toggleOpacity ?? .zero)
                     .padding(.init(
                         all: self.toggleDotPadding
                     ))

--- a/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
+++ b/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
@@ -135,8 +135,7 @@ public final class SwitchUIView: UIView {
             return self.viewModel.isOn
         }
         set {
-            self.viewModel.isOn = newValue
-            self.viewModel.reloadToggle()
+            self.viewModel.set(isOn: newValue)
         }
     }
 
@@ -775,6 +774,13 @@ public final class SwitchUIView: UIView {
         // Show spaces
         self.viewModel.$showToggleLeftSpace.subscribe(in: &self.subscriptions) { [weak self] showSpace in
             guard let self, let showSpace else { return }
+
+            // showSpace MUST be different to continue
+            // Or if the both space have the same isHidden (default state)
+            guard self.toggleLeftSpaceView.isHidden == showSpace ||
+            self.toggleRightSpaceView.isHidden == self.toggleLeftSpaceView.isHidden else {
+                return
+            }
 
             // Lock interaction before animation
             let currentUserInteraction = self.toggleView.isUserInteractionEnabled

--- a/core/Sources/Components/Switch/ViewModel/SwitchViewModel.swift
+++ b/core/Sources/Components/Switch/ViewModel/SwitchViewModel.swift
@@ -12,7 +12,7 @@ final class SwitchViewModel: ObservableObject {
 
     // MARK: - Properties
 
-    var isOn: Bool
+    private(set) var isOn: Bool
 
     private let frameworkType: FrameworkType
     private(set) var theme: Theme
@@ -104,18 +104,24 @@ final class SwitchViewModel: ObservableObject {
             // Manual action: update isOnChanged value
             self.isOnChanged = self.isOn
 
-            self.reloadToggle()
+            self.colorsDidUpdate()
+            self.toggleStateDidUpdate()
+            self.toggleDotImageDidUpdate()
+            self.toggleSpacesVisibilityDidUpdate()
         }
     }
 
-    func reloadToggle() {
-        self.colorsDidUpdate()
-        self.toggleStateDidUpdate()
-        self.toggleDotImageDidUpdate()
-        self.toggleSpacesVisibilityDidUpdate()
-    }
-
     // MARK: - Setter
+
+    func set(isOn: Bool) {
+        if self.isOn != isOn {
+            self.isOn = isOn
+
+            self.colorsDidUpdate()
+            self.toggleDotImageDidUpdate()
+            self.toggleSpacesVisibilityDidUpdate()
+        }
+    }
 
     func set(theme: Theme) {
         self.theme = theme

--- a/core/Sources/Components/Switch/ViewModel/SwitchViewModelTests.swift
+++ b/core/Sources/Components/Switch/ViewModel/SwitchViewModelTests.swift
@@ -316,6 +316,10 @@ final class SwitchViewModelTests: XCTestCase {
 
         // **
         // Use Cases
+        self.testGetColorsUseCaseMock(
+            on: stub,
+            numberOfCalls: 0
+        )
         self.testGetImageUseCaseMock(
             on: stub,
             numberOfCalls: 1
@@ -382,6 +386,10 @@ final class SwitchViewModelTests: XCTestCase {
 
         // **
         // Use Cases
+        self.testGetColorsUseCaseMock(
+            on: stub,
+            numberOfCalls: 0
+        )
         self.testGetImageUseCaseMock(
             on: stub,
             numberOfCalls: 0
@@ -398,6 +406,88 @@ final class SwitchViewModelTests: XCTestCase {
     }
 
     // MARK: - Setter Tests
+
+    func test_set_isOn_with_different_new_value() {
+        self.testSetIsOn(
+            givenIsDifferentNewValue: true
+        )
+    }
+
+    func test_set_isOn_with_same_new_value() {
+        self.testSetIsOn(
+            givenIsDifferentNewValue: false
+        )
+    }
+
+    func testSetIsOn(
+        givenIsDifferentNewValue: Bool
+    ) {
+        // GIVEN
+        let defaultValue = true
+        let newValue = givenIsDifferentNewValue ? !defaultValue : defaultValue
+
+        let stub = Stub(
+            isOn: defaultValue,
+            isImages: true
+        )
+        let viewModel = stub.viewModel
+
+        stub.subscribePublishers(on: &self.subscriptions)
+
+        viewModel.load() // Needed to get colors from usecase one time
+
+        // Reset all UseCase mock
+        stub.resetMockedData()
+
+        // WHEN
+        viewModel.set(isOn: newValue)
+
+        // THEN
+        XCTAssertEqual(viewModel.isOn,
+                       newValue,
+                       "Wrong isOn value")
+
+        // **
+        // Published properties
+        self.testIsOnChanged(on: stub, expectedValue: nil)
+        self.testToggleState(on: stub, expectedContainsValue: false)
+        self.testColors(on: stub, expectedContainsValue: givenIsDifferentNewValue)
+        self.testPosition(on: stub, expectedContainsValue: false)
+        self.testToggleDotImage(on: stub, expectedContainsValue: givenIsDifferentNewValue)
+        self.testDisplayedText(on: stub, expectedContainsValue: false)
+        self.testTextFont(on: stub, expectedContainsValue: false)
+        self.testShowToggleLeftSpace(on: stub, expectedValue: givenIsDifferentNewValue ? newValue : nil)
+
+        let publishedExpectedContainsValue = givenIsDifferentNewValue ? 1 : 0
+        self.testAllPublishedSinkCount(
+            on: stub,
+            expectedToggleBackgroundColorTokenPublishedSinkCount: publishedExpectedContainsValue,
+            expectedToggleDotBackgroundColorTokenPublishedSinkCount: publishedExpectedContainsValue,
+            expectedToggleDotForegroundColorTokenPublishedSinkCount: publishedExpectedContainsValue,
+            expectedTextForegroundColorTokenPublishedSinkCount: publishedExpectedContainsValue,
+            expectedIsToggleOnLeftPublishedSinkCount: publishedExpectedContainsValue,
+            expectedShowToggleLeftSpacePublishedSinkCount: publishedExpectedContainsValue,
+            expectedToggleDotImagePublishedSinkCount: publishedExpectedContainsValue
+        )
+        // **
+
+        // **
+        // Use Cases
+        self.testGetColorsUseCaseMock(
+            on: stub,
+            numberOfCalls: 0
+        )
+        self.testGetImageUseCaseMock(
+            on: stub,
+            numberOfCalls: givenIsDifferentNewValue ? 1 : 0
+        )
+        self.testGetToggleColorUseCaseMock(
+            on: stub,
+            numberOfCalls: givenIsDifferentNewValue ? 2 : 0,
+            givenIsOn: newValue
+        )
+        // **
+    }
 
     func test_set_theme() {
         // GIVEN

--- a/spark/Demo/Classes/View/Components/Switch/UIKit/SwitchComponentUIViewController.swift
+++ b/spark/Demo/Classes/View/Components/Switch/UIKit/SwitchComponentUIViewController.swift
@@ -60,8 +60,8 @@ final class SwitchComponentUIViewController: UIViewController {
             }
             .store(in: &self.cancellables)
 
-        self.viewModel.showThemeSheet.subscribe(in: &self.cancellables) { intents in
-            self.presentThemeActionSheet(intents)
+        self.viewModel.showThemeSheet.subscribe(in: &self.cancellables) { theme in
+            self.presentThemeActionSheet(theme)
         }
 
         self.viewModel.showIntentSheet.subscribe(in: &self.cancellables) { intents in


### PR DESCRIPTION
- UIKit: Fix the constraints bugs when user set many time the same iOn value
- SwiftUI: Fix the icon color when the switch is disabled