### PR TITLE
[Sourcery-491] Add new stencil

### DIFF
--- a/.sourcery.yml
+++ b/.sourcery.yml
@@ -8,3 +8,34 @@ configurations:
     args:
       autoMockableImports: [Combine]
       autoMockableTestableImports: [SparkCore]
+  - sources:
+      include:
+        - core/Sources
+    templates:
+      - stencil/sourcery-template/SparkCoreAutoMockTest.stencil
+    output: core/Unit-tests/Sourcery/Generated/AutoMockTest.generated.swift
+    args:
+      autoMockableImports: [Combine]
+      autoMockableTestableImports: [SparkCore]
+  - sources:
+      include:
+        - core/Sources
+    templates:
+      - stencil/sourcery-template/SparkCoreAutoPublisherTest.stencil
+    output: core/Unit-tests/Sourcery/Generated/AutoPublisherTest.generated.swift
+    args:
+      autoMockableImports: [Combine]
+      autoMockableTestableImports: [SparkCore]
+  - sources:
+      include:
+        - core/Sources
+    templates:
+      - stencil/sourcery-template/SparkCoreAutoViewModelStub.stencil
+    output: core/Unit-tests/Sourcery/Generated/AutoViewModelStub.generated.swift
+    args:
+      autoMockableImports: [Combine]
+      autoMockableTestableImports: [SparkCore]
+
+
+
+      

--- a/stencil/sourcery-template/SparkCoreAutoMockTest.stencil
+++ b/stencil/sourcery-template/SparkCoreAutoMockTest.stencil
@@ -1,0 +1,144 @@
+// swiftlint:disable all
+
+import Foundation
+import UIKit
+import SwiftUI
+import XCTest
+
+{% for import in argument.autoMockableImports %}
+import {{ import }}
+{% endfor %}
+{% for import in argument.autoMockableTestableImports %}
+@testable import {{ import }}
+{% endfor %}
+
+{% macro removeGenericContentInMethodName name %}{% if method.shortName| hasSuffix:">" %}{% for element in name|split:"<" %}{% if forloop.first %}{{ element }}{% endif %}{% endfor %}{% else %}{{name}}{% endif %}{% endmacro %}
+{% macro swiftifyMethodNameV2 method %}{% if method.parameters.count > 0 %}{% call removeGenericContentInMethodName method.shortName %}With{% for param in method.parameters %}{{ param.name | snakeToCamelCase }}{% if not forloop.last %}And{% endif %}{% endfor %}{% else %}{{method.shortName}}{% endif %}{% endmacro %}
+{% macro mockName protocol %}{{ protocol.name }}GeneratedMock{% endmacro %}
+{% macro dynamicTypeName name %}_{{ name | upperFirstLetter }}{% endmacro %}
+{% macro givenParameter name %}given{{ param.name | snakeToCamelCase }}{% endmacro %}
+
+{% for protocol in types.protocols where protocol|annotated:"AutoMockTest" %}{% if protocol.name != "AutoMockTest" %}
+final class {{ protocol.name }}MockTest {
+
+    // MARK: - Initialization
+
+    private init(){
+    }
+
+    // MARK: - Tests
+
+    {% for method in protocol.allMethods|!definedInExtension %}
+        
+    static func XCTCallsCount(
+        _ mock: {% call mockName protocol %},
+        {% call swiftifyMethodNameV2 method %}NumberOfCalls numberOfCalls: Int
+    ) {
+        XCTAssertEqual(
+            mock.{% call swiftifyMethodNameV2 method %}CallsCount,
+            numberOfCalls,
+            "Wrong {{ method.name }} number of called on {{ protocol.name }}"
+        )
+    }
+
+    static func XCTAssert{% for key, value in method.annotations where value == "Identical" %}{% if forloop.first %}<
+    {% for param in method.parameters where method.annotations[param.name] == "Identical" %}
+        {% call dynamicTypeName param.name %}: AnyObject{% if not forloop.last or method.annotations["return"] == "Identical" %},{% endif %}
+    {% endfor %}
+    {% if method.annotations["return"] == "Identical" %}
+        {% call dynamicTypeName "return" %}: AnyObject
+    {% endif %}
+    >{% endif %}{% endfor %}(
+        _ mock: {% call mockName protocol %},
+        expectedNumberOfCalls: Int,
+    {% for param in method.parameters %}
+        {% call givenParameter param %}: {% if method.annotations[param.name] == "Identical" %}{% call dynamicTypeName param.name %}{% elif protocol.associatedTypes[param.typeName] != nil %}{% call mockName protocol %}.{{ protocol.associatedTypes[param.typeName].name }}Mock{% else %}{{ param.typeName | replace:"?","" }}{% endif %}? = nil{% if not forloop.last or not method.returnTypeName.isVoid %}, {% endif %}
+    {% endfor %}
+        {% if not method.returnTypeName.isVoid %}expectedReturnValue: {% if method.annotations["return"] == "Identical" %}{% call dynamicTypeName "return" %}{% elif protocol.associatedTypes["Return"] != nil %}{% call mockName protocol %}.ReturnMock{% if method.isOptionalReturnType %}?{% endif %}{% else %}{{ method.returnTypeName }}{% endif %}{% endif %}
+    ) {
+        // Count
+        XCTAssertEqual(
+            mock.{% call swiftifyMethodNameV2 method %}CallsCount,
+            expectedNumberOfCalls,
+            "Wrong {{ method.name }} number of called on {{ protocol.name }}"
+        )
+
+        // Parameters
+        if expectedNumberOfCalls > 0 {
+            {% if method.parameters.count > 1 %}
+            let args = mock.{% call swiftifyMethodNameV2 method %}ReceivedArguments
+
+            {% endif %}
+            {% for param in method.parameters %}
+            // {{ param.name|upperFirstLetter }}
+            if let {% call givenParameter param %} {
+        
+                {% if method.annotations[param.name] == "Identical" %}
+                    {% if method.parameters.count == 1 %}
+                XCTAssertIdentical(
+                    mock.{% call swiftifyMethodNameV2 method %}Received{{ param.name|upperFirstLetter }} as? _{{ param.name|upperFirstLetter }},
+                    given{{ param.name | snakeToCamelCase }},
+                    "Wrong {{ method.name }} {{ param.name }} parameter on {{ protocol.name }}"
+                )
+                    {% else %}
+                XCTAssertIdentical(
+                    args?.{{ param.name }} as? _{{ param.name|upperFirstLetter }},
+                    given{{ param.name | snakeToCamelCase }},
+                    "Wrong {{ method.name }} {{ param.name }} parameter on {{ protocol.name }}"
+                )
+                    {% endif %}
+                {% else %}
+                    {% if method.parameters.count == 1 %}
+                XCTAssertEqual(
+                    mock.{% call swiftifyMethodNameV2 method %}Received{{ param.name|upperFirstLetter }},
+                    given{{ param.name | snakeToCamelCase }},
+                    "Wrong {{ method.name }} {{ param.name }} parameter on {{ protocol.name }}"
+                )
+                    {% else %}
+                XCTAssertEqual(
+                    args?.{{ param.name }},
+                    given{{ param.name | snakeToCamelCase }},
+                    "Wrong {{ method.name }} {{ param.name }} parameter on {{ protocol.name }}"
+                )
+                    {% endif %}
+                {% endif %}
+            } else {
+                XCTAssertNil(
+                    {% if method.parameters.count == 1 %}mock.{% call swiftifyMethodNameV2 method %}Received{{ param.name|upperFirstLetter }}{% else %}args?.{{ param.name }}{% endif %},
+                    "Wrong {{ method.name }} {{ param.name }} parameter value on {{ protocol.name }}. Should be nil"
+                )
+            }
+
+            {% endfor %}
+        }
+
+        {% if not method.returnTypeName.isVoid %}
+        // Return
+        {% if method.isOptionalReturnType %}if let expectedReturnValue { {% endif %}
+            {% if method.annotations["return"] == "Identical" %}
+        XCTAssertIdentical(
+            mock.{% call swiftifyMethodNameV2 method %}ReturnValue as? _Return,
+            expectedReturnValue,
+            "Wrong {{ method.name }} return value on {{ protocol.name }}"
+        )
+            {% else %}
+            XCTAssertEqual(
+                mock.{% call swiftifyMethodNameV2 method %}ReturnValue,
+                expectedReturnValue,
+                "Wrong {{ method.name }} return value on {{ protocol.name }}"
+            )
+            {% endif %}
+        {% endif %}
+        {% if method.isOptionalReturnType %} } else {
+            XCTAssertNil(
+                mock.{% call swiftifyMethodNameV2 method %}ReturnValue,
+                "Wrong {{ method.name }} return value on {{ protocol.name }}. Should be nil"
+            )
+        }
+        {% endif %}
+    }
+
+    {% endfor %}
+}
+
+{% endif %}{% endfor %}

--- a/stencil/sourcery-template/SparkCoreAutoMockable.stencil
+++ b/stencil/sourcery-template/SparkCoreAutoMockable.stencil
@@ -172,36 +172,63 @@ import {{ import }}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 
-final class {{ type.name }}GeneratedMock: {{ import }}.{{ type.name }} {
+final class {{ type.name }}GeneratedMock: {{ import }}.{{ type.name }}{% if type.allMethods|!definedInExtension|count > 0 %}, ResetGeneratedMock{% endif %} {
 
+{% for key, value in type.associatedTypes %}
+    {% if value.typeName | contains:"Equatable" %}
+        {% if forloop.first %}
+    // MARK: - Type Alias
+
+         {% endif%}
+    typealias {{ key }} = {{ key }}Mock
+    {% else %}
+    #error ("The protocol with associatedtype should work only with Equatable.")
+    {% endif%}
+{% endfor %}
+{% for key, value in type.associatedTypes %}
+    {% if value.typeName | contains:"Equatable" %}
+        {% if forloop.first %}
+
+    // MARK: - Associated Type
+
+        {% endif%}
+    struct {{ key }}Mock: {{ value.typeName }} {
+        let id = UUID().uuidString
+    }
+    {% endif%}
+{% endfor %}
 {% for variable in type.allVariables|!definedInExtension %}
     {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
 {% endfor %}
+
+    // MARK: - Initialization
+
     init() {}
 
 {% for method in type.allMethods|!definedInExtension %}
     {% call mockMethod method %}
 {% endfor %}
-}
-
-extension  {{ type.name }}GeneratedMock: ResetGeneratedMock {
+{% if type.allMethods|!definedInExtension|count > 0 %}
+    // MARK: Reset 
 
     func reset() {
     {% for method in type.allMethods|!definedInExtension %}
-
         {% call swiftifyMethodNameV2 method %}CallsCount = 0
         {% if method.parameters.count == 1 %}
-            {% call swiftifyMethodNameV2 method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = nil {% endfor %}
+        {% call swiftifyMethodNameV2 method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = nil {% endfor %}
         {% elif not method.parameters.count == 0 %}
-            {% call swiftifyMethodNameV2 method %}ReceivedArguments = nil
+        {% call swiftifyMethodNameV2 method %}ReceivedArguments = nil
         {% endif %}
         {% call swiftifyMethodNameV2 method %}ReceivedInvocations = []
     {% endfor %}
     }
+{% endif %}
 }
 {% endif %}{% endfor %}
-
 {% endfor %}
+
+// MARK: - Reset
+
 protocol ResetGeneratedMock {
     func reset()
 }

--- a/stencil/sourcery-template/SparkCoreAutoPublisherTest.stencil
+++ b/stencil/sourcery-template/SparkCoreAutoPublisherTest.stencil
@@ -1,0 +1,85 @@
+// swiftlint:disable all
+ 
+import Foundation
+import UIKit
+import SwiftUI
+import XCTest
+
+{% for import in argument.autoMockableImports %}
+import {{ import }}
+{% endfor %}
+{% for import in argument.autoMockableTestableImports %}
+@testable import {{ import }}
+{% endfor %}
+
+{% macro expectedSinkCount variable %}expected{{ variable.name | upperFirstLetter }}SinkCount{% endmacro %}
+
+{% for class in types.classes where class|annotated:"AutoPublisherTest" %}{% if class.name != "AutoPublisherTest" %}
+final class {{ class.name }}PublisherTest {
+
+    {% for key, value in class.annotations where key|contains: "<" and key|contains: ">" %}{% if forloop.first %}// MARK: - Type Alias
+
+    {% endif %}
+    typealias {{ key|replace:"<", ""|replace:">", "" }} = {{ value }}
+    {% endfor %}
+
+    // MARK: - Initialization
+
+    private init(){
+    }
+
+    // MARK: - Tests
+
+    {% for variable in class.allVariables|!definedInExtension where variable.readAccess != "private" and variable.attributes["Published"] != nil %}
+        
+    static func XCTSinksCount(
+        {{ variable.name }} mock: PublisherMock<Published<{{ variable.typeName }}>.Publisher>,
+        expectedNumberOfSinks: Int
+    ) {
+        XCTAssertPublisherSinkCountEqual(
+            on: mock,
+            expectedNumberOfSinks
+        )
+    }
+
+    static func XCTAssert{% if class.annotations[variable.name] == "Identical" %}<
+        Value: AnyObject
+    >{% endif %}(
+        {{ variable.name }} mock: PublisherMock<Published<{{ variable.typeName }}>.Publisher>,
+        expectedNumberOfSinks: Int,
+        expectedValue: {% if class.annotations[variable.name] == "Identical" %}Value{% if variable.isOptional %}?{% endif %}{% else %}{{ variable.typeName }}{% endif %}{% if variable.isOptional %} = nil{% endif %}
+    ) {
+        // Count
+        XCTAssertPublisherSinkCountEqual(
+            on: mock,
+            expectedNumberOfSinks
+        )
+
+        // Value
+        if expectedNumberOfSinks > 0 {
+            {% if variable.isOptional %}if let expectedValue { {% endif %}
+                {% if class.annotations[variable.name] == "Identical" %}
+                XCTAssertPublisherSinkValueIdentical(
+                    on: mock,
+                    expectedValue
+                )
+                {% else %}
+                XCTAssertPublisherSinkValueEqual(
+                    on: mock,
+                    expectedValue
+                )
+                {% endif %}
+            {% if variable.isOptional %}
+            } else {
+                XCTAssertPublisherSinkValueNil(
+                    on: mock
+                )
+            }
+            {% endif %}
+        }
+    }
+
+    {% endfor %}
+}
+
+{% endif %}{% endfor %}

--- a/stencil/sourcery-template/SparkCoreAutoViewModelStub.stencil
+++ b/stencil/sourcery-template/SparkCoreAutoViewModelStub.stencil
@@ -1,0 +1,88 @@
+// swiftlint:disable all
+ 
+import Combine
+import UIKit
+import SwiftUI
+import XCTest
+
+{% for import in argument.autoMockableImports %}
+import {{ import }}
+{% endfor %}
+{% for import in argument.autoMockableTestableImports %}
+@testable import {{ import }}
+{% endfor %}
+
+{% macro publisherName variable %}{{ variable.name }}PublisherMock{% endmacro %}
+{% macro viewModelType class %}{{ class.name }}{% for key in class.annotations where key|contains: "<" and key|contains: ">" %}{% if forloop.first %}<{% endif %}{{ key|replace:"<", "" | replace:">", "" | upperFirstLetter }}{% if forloop.last %}>{% else %},{% endif %}{% endfor %}{% endmacro %}
+{% macro useCaseName variable %}{{ variable.name }}Mock{% endmacro %}
+{% macro useCaseMock class variable %}{{ variable.typeName }}GeneratedMock{% endmacro %}
+{% macro genericTypeName class variable %}{% if class.annotations[variable.name] %}{{ class.annotations[variable.name] }}{% else %}{% call useCaseMock class variable %}{% endif %}{% endmacro %}
+{% macro genericTypeFromAnnotation key %}{{ key|replace:"<", ""|replace:">", "" }}{% endmacro %}
+
+{% for class in types.classes where class|annotated:"AutoViewModelStub" %}{% if class.name != "AutoViewModelStub" %}
+class {{ class.name }}Stub {
+
+    {% for key, value in class.annotations where key|contains: "<" and key|contains: ">" %}{% if forloop.first %}// MARK: - Type Alias
+
+    {% endif %}
+    typealias {% call genericTypeFromAnnotation key %} = {{ value }}
+    typealias {% call genericTypeFromAnnotation key %}GeneratedMock = {% call genericTypeFromAnnotation key %}
+    {% endfor %}
+
+    // MARK: - Properties
+
+    let viewModel: {% call viewModelType class %}
+
+    // MARK: - Published Properties
+
+    {% for variable in class.allVariables|!definedInExtension where variable.readAccess != "private" and variable.attributes["Published"] != nil %}
+    let {% call publisherName variable %}: PublisherMock<Published<{{ variable.typeName }}>.Publisher>
+    {% endfor %}
+
+    // MARK: Dependencies
+
+    {% for variable in class.allVariables|!definedInExtension where variable.name|contains: "UseCase" %}
+    let {% call useCaseName variable %}: {% call genericTypeName class variable %}
+    {% endfor %}
+
+    // MARK: - Initialization
+
+    init(
+        viewModel: {% call viewModelType class %}{% for variable in class.allVariables|!definedInExtension where variable.name|contains: "UseCase" %}{% if forloop.first %},{% endif %}
+        {% call useCaseName variable %}: {% call genericTypeName class variable %}{% if not forloop.last %},{% endif %}{% endfor %}
+    ) {
+        self.viewModel = viewModel
+
+        // UseCases
+        {% for variable in class.allVariables|!definedInExtension where variable.name|contains: "UseCase" %}
+        self.{% call useCaseName variable %} = {% call useCaseName variable %}
+        {% endfor %}
+
+        // Publishers
+        {% for variable in class.allVariables|!definedInExtension where variable.readAccess != "private" and variable.attributes["Published"] != nil %}
+        self.{% call publisherName variable %} = .init(publisher: viewModel.${{ variable.name }})
+        {% endfor %}
+    }
+
+    // MARK: - Subscription
+
+    func subscribePublishers(on subscriptions: inout Set<AnyCancellable>) {
+        {% for variable in class.allVariables|!definedInExtension where variable.readAccess != "private" and variable.attributes["Published"] != nil %}
+        self.{% call publisherName variable %}.loadTesting(on: &subscriptions)
+        {% endfor %}
+    }
+
+    // MARK: - Reset
+
+    func resetMockedData() {
+        {% for variable in class.allVariables|!definedInExtension where variable.name|contains: "UseCase" %}{% if forloop.first %}// Clear UseCases Mock{% endif %}
+        self.{% call useCaseName variable %}.reset()
+        {% endfor %}
+
+        {% for variable in class.allVariables|!definedInExtension where variable.readAccess != "private" and variable.attributes["Published"] != nil %}{% if forloop.first %}// Reset published sink counter{% endif %}
+        self.{% call publisherName variable %}.reset()
+        {% endfor %}
+    }
+}
+
+{% endif %}{% endfor %}


### PR DESCRIPTION
Add three new template for Sourcery:
- AutoMockTestto generate a file to test a function
- AutoPublisherTest to generate a file to test a Publisher property
- AutoViewModelStub to generate a ViewModel Stub

Add documentation on the [Wiki](https://github.com/adevinta/spark-ios/wiki/Sourcery#sourcery) page
