### PR TITLE
[Fix-548] Switch: Space position inside toggle

### DIFF
--- a/core/Sources/Components/Switch/View/SwiftUI/SwitchView.swift
+++ b/core/Sources/Components/Switch/View/SwiftUI/SwitchView.swift
@@ -127,6 +127,7 @@ public struct SwitchView: View {
                     // Dot
                     Circle()
                         .fill(self.viewModel.toggleDotBackgroundColorToken?.color ?? .clear)
+                        .aspectRatio(1, contentMode: .fit)
                         .accessibilityIdentifier(AccessibilityIdentifier.toggleDotView)
 
                     ZStack {

--- a/core/Sources/Components/Tag/View/UIKit/TagUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Tag/View/UIKit/TagUIViewSnapshotTests.swift
@@ -9,8 +9,6 @@
 import XCTest
 import SnapshotTesting
 
-// TODO: rename SUT to Configuration
-
 @testable import SparkCore
 
 final class TagUIViewSnapshotTests: UIKitComponentSnapshotTestCase {


### PR DESCRIPTION
Add an **aspectRatio** on the circle to have a 1:1 circle. 
