### PR TITLE
[Fix-559] Demo: Open the alignment of the integration StackView

### DIFF
--- a/spark/Demo/Classes/View/Components/Main/ComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Main/ComponentUIView.swift
@@ -58,7 +58,7 @@ class ComponentUIView: UIView {
             ]
         )
         stackView.axis = .vertical
-        stackView.alignment = .fill
+        stackView.alignment = self.integrationStackViewAlignment
         stackView.spacing = 12
         return stackView
     }()
@@ -132,13 +132,17 @@ class ComponentUIView: UIView {
         }
     }
 
+    private let integrationStackViewAlignment: UIStackView.Alignment
+
     private var subscriptions: Set<AnyCancellable> = []
 
     // MARK: - Initialization
 
     init(viewModel: ComponentUIViewModel,
+         integrationStackViewAlignment: UIStackView.Alignment = .leading,
          componentView: UIView) {
         self.viewModel = viewModel
+        self.integrationStackViewAlignment = integrationStackViewAlignment
 
         self.componentView = componentView
 

--- a/spark/Demo/Classes/View/Components/Main/ComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Main/ComponentUIViewModel.swift
@@ -9,14 +9,6 @@
 import Combine
 import Foundation
 
-// protocol ComponentUIViewModel {
-//
-//    // MARK: - Properties
-//
-//    var identifier: String { get }
-//    var configurationViewModel: ComponentsConfigurationUIViewModel { get }
-// }
-
 class ComponentUIViewModel {
 
     // MARK: - Properties


### PR DESCRIPTION
Many components should have a **.leading** alignment value for the integrationStackView on ComponentUIView.
But at least the ProgressBar must have a **.fill** alignment.

So I added a property on the ComponentUIView init with the **.leading** default value.