### PR TITLE
[Fix-563] Switch: UserInteraction bug

### DIFF
--- a/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
+++ b/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
@@ -772,23 +772,23 @@ public final class SwitchUIView: UIView {
 
         // **
         // Show spaces
-        self.viewModel.$showToggleLeftSpace.subscribe(in: &self.subscriptions) { [weak self] showSpace in
-            guard let self, let showSpace else { return }
+        self.viewModel.$showToggleLeftSpace.subscribe(in: &self.subscriptions) { [weak self] showLeftSpace in
+            guard let self, let showLeftSpace else { return }
 
-            // showSpace MUST be different to continue
+            // showLeftSpace MUST be different to continue
             // Or if the both space have the same isHidden (default state)
-            guard self.toggleLeftSpaceView.isHidden == showSpace ||
+            guard self.toggleLeftSpaceView.isHidden == showLeftSpace ||
             self.toggleRightSpaceView.isHidden == self.toggleLeftSpaceView.isHidden else {
                 return
             }
 
             // Lock interaction before animation
-            let currentUserInteraction = self.toggleView.isUserInteractionEnabled
+            let currentUserInteraction = self.viewModel.isToggleInteractionEnabled ?? true
             self.toggleView.isUserInteractionEnabled = false
 
             UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
-                self?.toggleLeftSpaceView.isHidden = !showSpace
-                self?.toggleRightSpaceView.isHidden = showSpace
+                self?.toggleLeftSpaceView.isHidden = !showLeftSpace
+                self?.toggleRightSpaceView.isHidden = showLeftSpace
             } completion: { [weak self] _ in
                 // Unlock interaction after animation
                 self?.toggleView.isUserInteractionEnabled = currentUserInteraction


### PR DESCRIPTION
One developer on Polaris found this problem on the switch:

1. Init the switch with isOn to false (or true)
2. set directly the isOn to a different value true (or false)

-> the switch userInteraction is disabled.

**Why**:
The userInteraction is always set to false before update the space position inside the toggle and reset to the old value when the animation is finished. But if a new value is set before the completion of the previous animation, **the bug appears**.

**Solution**:
- get the current userInteraction from the viewModel and not from the UIView