### PR TITLE
[Refacto-557] Button: rename all text to title

### DIFF
--- a/core/Sources/Components/Button/Properties/Internal/Content/ButtonContent+ExtensionTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Content/ButtonContent+ExtensionTests.swift
@@ -16,13 +16,13 @@ extension ButtonContent {
         shouldShowIconImage: Bool = true ,
         isIconImageTrailing: Bool = false,
         iconImage: ImageEither? = .left(IconographyTests.shared.arrow),
-        shouldShowText: Bool = true
+        shouldShowTitle: Bool = true
     ) -> Self {
         return .init(
             shouldShowIconImage: shouldShowIconImage,
             isIconImageTrailing: isIconImageTrailing,
             iconImage: iconImage,
-            shouldShowText: shouldShowText
+            shouldShowTitle: shouldShowTitle
         )
     }
 }

--- a/core/Sources/Components/Button/Properties/Internal/Content/ButtonContent.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Content/ButtonContent.swift
@@ -14,5 +14,5 @@ struct ButtonContent: Equatable {
     let isIconImageTrailing: Bool
     let iconImage: ImageEither?
 
-    let shouldShowText: Bool
+    let shouldShowTitle: Bool
 }

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors+ExtensionTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors+ExtensionTests.swift
@@ -14,13 +14,13 @@ extension ButtonCurrentColors {
 
     static func mocked(
         iconTintColor: any ColorToken = ColorTokenGeneratedMock.random(),
-        textColor: (any ColorToken)? = ColorTokenGeneratedMock.random(),
+        titleColor: (any ColorToken)? = ColorTokenGeneratedMock.random(),
         backgroundColor: any ColorToken = ColorTokenGeneratedMock.random(),
         borderColor: any ColorToken = ColorTokenGeneratedMock.random()
     ) -> Self {
         return .init(
             iconTintColor: iconTintColor,
-            textColor: textColor,
+            titleColor: titleColor,
             backgroundColor: backgroundColor,
             borderColor: borderColor
         )

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColors.swift
@@ -12,7 +12,7 @@ struct ButtonCurrentColors {
     // MARK: - Properties
 
     let iconTintColor: any ColorToken
-    let textColor: (any ColorToken)?
+    let titleColor: (any ColorToken)?
     let backgroundColor: any ColorToken
     let borderColor: any ColorToken
 }
@@ -23,8 +23,8 @@ extension ButtonCurrentColors: Hashable, Equatable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.iconTintColor)
-        if let textColor = self.textColor {
-            hasher.combine(textColor)
+        if let titleColor = self.titleColor {
+            hasher.combine(titleColor)
         }
         hasher.combine(self.backgroundColor)
         hasher.combine(self.borderColor)
@@ -32,7 +32,7 @@ extension ButtonCurrentColors: Hashable, Equatable {
 
     static func == (lhs: ButtonCurrentColors, rhs: ButtonCurrentColors) -> Bool {
         return lhs.iconTintColor.equals(rhs.iconTintColor) &&
-        lhs.textColor.equals(rhs.textColor) == true &&
+        lhs.titleColor.equals(rhs.titleColor) == true &&
         lhs.backgroundColor.equals(rhs.backgroundColor) &&
         lhs.borderColor.equals(rhs.borderColor)
     }

--- a/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColorsTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/CurrentColors/ButtonCurrentColorsTests.swift
@@ -19,13 +19,13 @@ final class ButtonCurrentColorsTests: XCTestCase {
 
         let given1 = ButtonCurrentColors(
             iconTintColor: colors.base.onSurface,
-            textColor: colors.base.onSurfaceInverse,
+            titleColor: colors.base.onSurfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.main.main)
 
         let given2 = ButtonCurrentColors(
             iconTintColor: colors.base.onSurface,
-            textColor: colors.base.onSurfaceInverse,
+            titleColor: colors.base.onSurfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.main.main)
 
@@ -37,13 +37,13 @@ final class ButtonCurrentColorsTests: XCTestCase {
 
         let given1 = ButtonCurrentColors(
             iconTintColor: colors.base.surface,
-            textColor: colors.base.surfaceInverse,
+            titleColor: colors.base.surfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.main.main)
 
         let given2 = ButtonCurrentColors(
             iconTintColor: colors.base.onSurface,
-            textColor: colors.base.onSurfaceInverse,
+            titleColor: colors.base.onSurfaceInverse,
             backgroundColor: colors.base.backgroundVariant,
             borderColor: colors.main.onMain)
 

--- a/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCase.swift
@@ -10,7 +10,7 @@
 protocol ButtonGetContentUseCaseable {
     func execute(alignment: ButtonAlignment,
                  iconImage: ImageEither?,
-                 containsText: Bool) -> ButtonContent
+                 containsTitle: Bool) -> ButtonContent
 }
 
 struct ButtonGetContentUseCase: ButtonGetContentUseCaseable {
@@ -20,7 +20,7 @@ struct ButtonGetContentUseCase: ButtonGetContentUseCaseable {
     func execute(
         alignment: ButtonAlignment,
         iconImage: ImageEither?,
-        containsText: Bool
+        containsTitle: Bool
     ) -> ButtonContent {
         let shouldShowIconImage = (iconImage != nil) ? true : false
         let isIconImageTrailing = (shouldShowIconImage && alignment == .trailingIcon) ? true : false
@@ -30,7 +30,7 @@ struct ButtonGetContentUseCase: ButtonGetContentUseCaseable {
             shouldShowIconImage: shouldShowIconImage,
             isIconImageTrailing: isIconImageTrailing,
             iconImage: iconImage,
-            shouldShowText: containsText
+            shouldShowTitle: containsTitle
         )
     }
 }

--- a/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCaseTests.swift
+++ b/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCaseTests.swift
@@ -18,58 +18,58 @@ final class ButtonGetContentUseCaseTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_execute_when_alignment_is_leadingIcon_and_image_is_set_and_containsText_is_false() {
+    func test_execute_when_alignment_is_leadingIcon_and_image_is_set_and_containsTitle_is_false() {
         self.testExecute(
             givenAlignment: .leadingIcon,
             givenIconImage: self.imageMock,
-            givenContainsText: false,
+            givenContainsTitle: false,
             expectedContent: .init(
                 shouldShowIconImage: true,
                 isIconImageTrailing: false,
                 iconImage: .left(self.imageMock),
-                shouldShowText: false
+                shouldShowTitle: false
             )
         )
     }
 
-    func test_execute_when_alignment_is_trailingIcon_and_image_is_set_and_containsText_is_false() {
+    func test_execute_when_alignment_is_trailingIcon_and_image_is_set_and_containsTitle_is_false() {
         self.testExecute(
             givenAlignment: .trailingIcon,
             givenIconImage: self.imageMock,
-            givenContainsText: false,
+            givenContainsTitle: false,
             expectedContent: .init(
                 shouldShowIconImage: true,
                 isIconImageTrailing: true,
                 iconImage: .left(self.imageMock),
-                shouldShowText: false
+                shouldShowTitle: false
             )
         )
     }
 
-    func test_execute_when_alignment_is_leadingIcon_and_image_is_set_and_containsText_is_true() {
+    func test_execute_when_alignment_is_leadingIcon_and_image_is_set_and_containsTitle_is_true() {
         self.testExecute(
             givenAlignment: .leadingIcon,
             givenIconImage: self.imageMock,
-            givenContainsText: true,
+            givenContainsTitle: true,
             expectedContent: .init(
                 shouldShowIconImage: true,
                 isIconImageTrailing: false,
                 iconImage: .left(self.imageMock),
-                shouldShowText: true
+                shouldShowTitle: true
             )
         )
     }
 
-    func test_execute_when_alignment_is_leadingIcon_and_containsText_is_true() {
+    func test_execute_when_alignment_is_leadingIcon_and_containsTitle_is_true() {
         self.testExecute(
             givenAlignment: .leadingIcon,
             givenIconImage: nil,
-            givenContainsText: true,
+            givenContainsTitle: true,
             expectedContent: .init(
                 shouldShowIconImage: false,
                 isIconImageTrailing: false,
                 iconImage: nil,
-                shouldShowText: true
+                shouldShowTitle: true
             )
         )
     }
@@ -82,7 +82,7 @@ private extension ButtonGetContentUseCaseTests {
     func testExecute(
         givenAlignment: ButtonAlignment,
         givenIconImage: UIImage?,
-        givenContainsText: Bool,
+        givenContainsTitle: Bool,
         expectedContent: ButtonContent
     ) {
         // GIVEN
@@ -90,7 +90,7 @@ private extension ButtonGetContentUseCaseTests {
         if givenIconImage != nil {
             errorSuffixMessage += " - with icon image"
         }
-        if givenContainsText {
+        if givenContainsTitle {
             errorSuffixMessage += " - with displayed text"
         }
 
@@ -107,7 +107,7 @@ private extension ButtonGetContentUseCaseTests {
         let content = useCase.execute(
             alignment: givenAlignment,
             iconImage: iconImage,
-            containsText: givenContainsText
+            containsTitle: givenContainsTitle
         )
 
         // THEN
@@ -121,8 +121,8 @@ private extension ButtonGetContentUseCaseTests {
                        expectedContent.iconImage?.leftValue,
                        "Wrong iconImage" + errorSuffixMessage)
 
-        XCTAssertEqual(content.shouldShowText,
-                       expectedContent.shouldShowText,
-                       "Wrong shouldShowText" + errorSuffixMessage)
+        XCTAssertEqual(content.shouldShowTitle,
+                       expectedContent.shouldShowTitle,
+                       "Wrong shouldShowTitle" + errorSuffixMessage)
     }
 }

--- a/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCase.swift
@@ -10,7 +10,7 @@
 protocol ButtonGetCurrentColorsUseCaseable {
     func execute(colors: ButtonColors,
                  isPressed: Bool,
-                 displayedTextType: DisplayedTextType) -> ButtonCurrentColors
+                 displayedTitleType: DisplayedTextType) -> ButtonCurrentColors
 }
 
 struct ButtonGetCurrentColorsUseCase: ButtonGetCurrentColorsUseCaseable {
@@ -20,23 +20,23 @@ struct ButtonGetCurrentColorsUseCase: ButtonGetCurrentColorsUseCaseable {
     func execute(
         colors: ButtonColors,
         isPressed: Bool,
-        displayedTextType: DisplayedTextType
+        displayedTitleType: DisplayedTextType
     ) -> ButtonCurrentColors {
-        // Reload text foreground color only if the text is displayed and not the attributedText
-        let isTextColor = (displayedTextType == .text)
-        let textColor = isTextColor ? colors.foregroundColor : nil
+        // Reload title foreground color only if the title is displayed and not the attributedTitle
+        let isTitleColor = (displayedTitleType == .text)
+        let titleColor = isTitleColor ? colors.foregroundColor : nil
 
         if isPressed {
             return .init(
                 iconTintColor: colors.foregroundColor,
-                textColor: textColor,
+                titleColor: titleColor,
                 backgroundColor: colors.pressedBackgroundColor,
                 borderColor: colors.pressedBorderColor
             )
         } else {
             return .init(
                 iconTintColor: colors.foregroundColor,
-                textColor: textColor,
+                titleColor: titleColor,
                 backgroundColor: colors.backgroundColor,
                 borderColor: colors.borderColor
             )

--- a/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCaseTests.swift
+++ b/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCaseTests.swift
@@ -50,26 +50,26 @@ final class ButtonGetCurrentColorsUseCaseTests: XCTestCase {
         )
     }
 
-    // MARK: - DisplayedTextType Tests
+    // MARK: - DisplayedTitleType Tests
 
-    func test_execute_when_displayedTextType_is_none() throws {
+    func test_execute_when_displayedTitleType_is_none() throws {
         try self.testExecute(
-            givenDisplayedTextType: .none,
-            expectedTextColor: nil
+            givenDisplayedTitleType: .none,
+            expectedTitleColor: nil
         )
     }
 
-    func test_execute_when_displayedTextType_is_text() throws {
+    func test_execute_when_displayedTitleType_is_title() throws {
         try self.testExecute(
-            givenDisplayedTextType: .text,
-            expectedTextColor: self.foregroundColorMock
+            givenDisplayedTitleType: .text,
+            expectedTitleColor: self.foregroundColorMock
         )
     }
 
-    func test_execute_when_displayedTextType_is_attributedText() throws {
+    func test_execute_when_displayedTitleType_is_attributedTitle() throws {
         try self.testExecute(
-            givenDisplayedTextType: .attributedText,
-            expectedTextColor: nil
+            givenDisplayedTitleType: .attributedText,
+            expectedTitleColor: nil
         )
     }
 }
@@ -93,15 +93,15 @@ private extension ButtonGetCurrentColorsUseCaseTests {
         let currentColors = useCase.execute(
             colors: self.colorsMock,
             isPressed: givenIsPressed,
-            displayedTextType: .none
+            displayedTitleType: .none
         )
 
         // THEN
         XCTAssertIdentical(currentColors.iconTintColor as? ColorTokenGeneratedMock,
                            expectedIconTintColor,
                            "Wrong iconTintColor" + errorSuffixMessage)
-        XCTAssertNil(currentColors.textColor,
-                     "Wrong textColor" + errorSuffixMessage)
+        XCTAssertNil(currentColors.titleColor,
+                     "Wrong titleColor" + errorSuffixMessage)
         XCTAssertIdentical(currentColors.backgroundColor as? ColorTokenGeneratedMock,
                            expectedBackgroundColor,
                            "Wrong foregroundColor" + errorSuffixMessage)
@@ -111,11 +111,11 @@ private extension ButtonGetCurrentColorsUseCaseTests {
     }
 
     func testExecute(
-        givenDisplayedTextType: DisplayedTextType,
-        expectedTextColor: ColorTokenGeneratedMock?
+        givenDisplayedTitleType: DisplayedTextType,
+        expectedTitleColor: ColorTokenGeneratedMock?
     ) throws {
         // GIVEN
-        let errorSuffixMessage = " for \(givenDisplayedTextType) givenDisplayedTextType"
+        let errorSuffixMessage = " for \(givenDisplayedTitleType) givenDisplayedTitleType"
 
         let useCase = ButtonGetCurrentColorsUseCase()
 
@@ -123,12 +123,12 @@ private extension ButtonGetCurrentColorsUseCaseTests {
         let currentColors = useCase.execute(
             colors: self.colorsMock,
             isPressed: true,
-            displayedTextType: givenDisplayedTextType
+            displayedTitleType: givenDisplayedTitleType
         )
 
         // THEN
-        XCTAssertIdentical(currentColors.textColor as? ColorTokenGeneratedMock,
-                           expectedTextColor,
-                           "Wrong textColor" + errorSuffixMessage)
+        XCTAssertIdentical(currentColors.titleColor as? ColorTokenGeneratedMock,
+                           expectedTitleColor,
+                           "Wrong titleColor" + errorSuffixMessage)
     }
 }

--- a/core/Sources/Components/Button/UseCase/GetIsOnlyIcon/ButtonGetIsOnlyIconUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetIsOnlyIcon/ButtonGetIsOnlyIconUseCase.swift
@@ -9,7 +9,7 @@
 // sourcery: AutoMockable
 protocol ButtonGetIsOnlyIconUseCaseable {
     func execute(iconImage: ImageEither?,
-                 containsText: Bool) -> Bool
+                 containsTitle: Bool) -> Bool
 }
 
 struct ButtonGetIsOnlyIconUseCase: ButtonGetIsOnlyIconUseCaseable {
@@ -18,8 +18,8 @@ struct ButtonGetIsOnlyIconUseCase: ButtonGetIsOnlyIconUseCaseable {
 
     func execute(
         iconImage: ImageEither?,
-        containsText: Bool
+        containsTitle: Bool
     ) -> Bool {
-        return iconImage != nil && !containsText
+        return iconImage != nil && !containsTitle
     }
 }

--- a/core/Sources/Components/Button/UseCase/GetIsOnlyIcon/ButtonGetIsOnlyIconUseCaseTests.swift
+++ b/core/Sources/Components/Button/UseCase/GetIsOnlyIcon/ButtonGetIsOnlyIconUseCaseTests.swift
@@ -18,28 +18,28 @@ final class ButtonGetIsOnlyIconUseCaseTests: XCTestCase {
 
     // MARK: - With IconImage Tests
 
-    func test_execute_when_iconImage_is_set_and_containsText_is_false() {
+    func test_execute_when_iconImage_is_set_and_containsTitle_is_false() {
         // GIVEN
         let useCase = ButtonGetIsOnlyIconUseCase()
 
         // WHEN
         let isIconOnly = useCase.execute(
             iconImage: .left(imageMock),
-            containsText: false
+            containsTitle: false
         )
 
         // THEN
         XCTAssertTrue(isIconOnly)
     }
 
-    func test_execute_when_iconImage_and_containsText_is_true() {
+    func test_execute_when_iconImage_and_containsTitle_is_true() {
         // GIVEN
         let useCase = ButtonGetIsOnlyIconUseCase()
 
         // WHEN
         let isIconOnly = useCase.execute(
             iconImage: .left(imageMock),
-            containsText: true
+            containsTitle: true
         )
 
         // THEN
@@ -48,28 +48,28 @@ final class ButtonGetIsOnlyIconUseCaseTests: XCTestCase {
 
     // MARK: - Without IconImage Tests
 
-    func test_execute_when_image_is_nil_and_containsText_is_true() {
+    func test_execute_when_image_is_nil_and_containsTitle_is_true() {
         // GIVEN
         let useCase = ButtonGetIsOnlyIconUseCase()
 
         // WHEN
         let isIconOnly = useCase.execute(
             iconImage: nil,
-            containsText: true
+            containsTitle: true
         )
 
         // THEN
         XCTAssertFalse(isIconOnly)
     }
 
-    func test_execute_when_image_is_nil_and_containsText_is_false() {
+    func test_execute_when_image_is_nil_and_containsTitle_is_false() {
         // GIVEN
         let useCase = ButtonGetIsOnlyIconUseCase()
 
         // WHEN
         let isIconOnly = useCase.execute(
             iconImage: nil,
-            containsText: false
+            containsTitle: false
         )
 
         // THEN

--- a/core/Sources/Components/Button/View/Common/ButtonSutSnapshotTests.swift
+++ b/core/Sources/Components/Button/View/Common/ButtonSutSnapshotTests.swift
@@ -21,8 +21,8 @@ struct ButtonSutSnapshotTests {
     let shape: ButtonShape
     let alignment: ButtonAlignment
     let iconImage: ImageEither?
-    let text: String?
-    let attributedText: AttributedStringEither?
+    let title: String?
+    let attributedTitle: AttributedStringEither?
     let isEnabled: Bool
     let isPressed: Bool
 
@@ -37,8 +37,8 @@ struct ButtonSutSnapshotTests {
             "\(self.shape)",
             "\(self.alignment)",
             self.iconImage != nil ? "withIcon" : "withoutIcon",
-            self.text != nil ? "withText" : "withoutText",
-            self.attributedText != nil ? "withAttributedText" : "withoutAttributedText",
+            self.title != nil ? "withTitle" : "withoutTitle",
+            self.attributedTitle != nil ? "withAttributedTitle" : "withoutAttributedTitle",
             self.isEnabled ? "isEnabled" : "isDisabled",
             self.isPressed ? "isPressed" : "isUnpressed",
         ].joined(separator: "-")
@@ -63,8 +63,8 @@ struct ButtonSutSnapshotTests {
                                 shape: .rounded,
                                 alignment: .leadingIcon,
                                 iconImage: nil,
-                                text: "My Color Button",
-                                attributedText: nil,
+                                title: "My Color Button",
+                                attributedTitle: nil,
                                 isEnabled: isEnabled,
                                 isPressed: isPressed
                             )
@@ -87,8 +87,8 @@ struct ButtonSutSnapshotTests {
                         shape: shape,
                         alignment: .leadingIcon,
                         iconImage: nil,
-                        text: "My Style Button",
-                        attributedText: nil,
+                        title: "My Style Button",
+                        attributedTitle: nil,
                         isEnabled: true,
                         isPressed: false
                     )
@@ -97,17 +97,17 @@ struct ButtonSutSnapshotTests {
     }
 
     static func allContentCases(isSwiftUIComponent: Bool) -> [Self] {
-        typealias ContentCases = (image: ImageEither?, text: String?, attributedText: AttributedStringEither?)
+        typealias ContentCases = (image: ImageEither?, title: String?, attributedTitle: AttributedStringEither?)
 
         let image: ImageEither = isSwiftUIComponent ? .right(Image.mock) : .left(UIImage.mock)
-        let attributedText: AttributedStringEither = isSwiftUIComponent ? .right(AttributedString("My Attributed Button")) : .left(.init(string: "My Attributed Button"))
+        let attributedTitle: AttributedStringEither = isSwiftUIComponent ? .right(AttributedString("My Attributed Button")) : .left(.init(string: "My Attributed Button"))
 
         let items: [ContentCases] = [
-            (image: image, text: nil, attributedText: nil), // Only icon
-            (image: image, text: "My Full Content Button", attributedText: nil), // Icon + text
-            (image: nil, text: "My Content Button", attributedText: nil), // Only text
-            (image: image, text: nil, attributedText: attributedText), // Icon + attributed text
-            (image: nil, text: nil, attributedText: attributedText) // Only attributed text
+            (image: image, title: nil, attributedTitle: nil), // Only icon
+            (image: image, title: "My Full Content Button", attributedTitle: nil), // Icon + title
+            (image: nil, title: "My Content Button", attributedTitle: nil), // Only title
+            (image: image, title: nil, attributedTitle: attributedTitle), // Icon + attributed title
+            (image: nil, title: nil, attributedTitle: attributedTitle) // Only attributed title
         ]
 
         return items.map { item in
@@ -118,8 +118,8 @@ struct ButtonSutSnapshotTests {
                 shape: .rounded,
                 alignment: .leadingIcon,
                 iconImage: item.image,
-                text: item.text,
-                attributedText: item.attributedText,
+                title: item.title,
+                attributedTitle: item.attributedTitle,
                 isEnabled: true,
                 isPressed: false
             )

--- a/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
@@ -24,7 +24,7 @@ public final class ButtonUIView: UIView {
             arrangedSubviews:
                 [
                     self.iconView,
-                    self.textLabel
+                    self.titleLabel
                 ]
         )
         stackView.axis = .horizontal
@@ -50,7 +50,7 @@ public final class ButtonUIView: UIView {
         return imageView
     }()
 
-    private var textLabel: UILabel = {
+    private var titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 1
         label.lineBreakMode = .byWordWrapping
@@ -169,24 +169,26 @@ public final class ButtonUIView: UIView {
     }
 
     /// The text of the button.
+    @available(*, deprecated, message: "Use setTitle(_:, for:) and title(for:) instead")
     public var text: String? {
         get {
-            return self.textLabel.text
+            return self.titleLabel.text
         }
         set {
-            self.textLabel.text = newValue
-            self.viewModel.set(text: newValue)
+            self.titleLabel.text = newValue
+            self.viewModel.set(title: newValue)
         }
     }
 
     /// The attributed text of the button.
+    @available(*, deprecated, message: "Use setAttributedTitle(_:, for:) and attributedTitle(for:) instead")
     public var attributedText: NSAttributedString? {
         get {
-            return self.textLabel.attributedText
+            return self.titleLabel.attributedText
         }
         set {
-            self.textLabel.attributedText = newValue
-            self.viewModel.set(attributedText: newValue.map { .left($0) })
+            self.titleLabel.attributedText = newValue
+            self.viewModel.set(attributedTitle: newValue.map { .left($0) })
         }
     }
 
@@ -194,10 +196,10 @@ public final class ButtonUIView: UIView {
     /// The default value is **byTruncatingTail**
     public var lineBreakMode: NSLineBreakMode {
         get {
-            return self.textLabel.lineBreakMode
+            return self.titleLabel.lineBreakMode
         }
         set {
-            self.textLabel.lineBreakMode = newValue
+            self.titleLabel.lineBreakMode = newValue
         }
     }
 
@@ -433,8 +435,8 @@ public final class ButtonUIView: UIView {
             shape: shape,
             alignment: alignment,
             iconImage: iconImage.map { .left($0) },
-            text: text,
-            attributedText: attributedText.map { .left($0) },
+            title: text,
+            attributedTitle: attributedText.map { .left($0) },
             isEnabled: isEnabled)
 
         super.init(frame: .zero)
@@ -480,9 +482,9 @@ public final class ButtonUIView: UIView {
         // Label
         // Only one of the text/attributedText can be set in the init
         if let text {
-            self.textLabel.text = text
+            self.titleLabel.text = text
         } else if let attributedText {
-            self.textLabel.attributedText = attributedText
+            self.titleLabel.attributedText = attributedText
         }
     }
 
@@ -644,8 +646,8 @@ public final class ButtonUIView: UIView {
 
             // Foreground Color
             self.iconImageView.tintColor = colors.iconTintColor.uiColor
-            if let textColor = colors.textColor {
-                self.textLabel.textColor = textColor.uiColor
+            if let titleColor = colors.titleColor {
+                self.titleLabel.textColor = titleColor.uiColor
             }
         }
 
@@ -717,8 +719,8 @@ public final class ButtonUIView: UIView {
                     self.iconView.isHidden = !content.shouldShowIconImage
                 }
 
-                if self.textLabel.isHidden == content.shouldShowText {
-                    self.textLabel.isHidden = !content.shouldShowText
+                if self.titleLabel.isHidden == content.shouldShowTitle {
+                    self.titleLabel.isHidden = !content.shouldShowTitle
                 }
                 self.contentStackView.updateConstraintsIfNeeded()
             }
@@ -729,11 +731,11 @@ public final class ButtonUIView: UIView {
         // **
 
         // **
-        // Text Font
-        self.viewModel.$textFontToken.subscribe(in: &self.subscriptions) { [weak self] textFontToken in
-            guard let self, let textFontToken else { return }
+        // Title Font
+        self.viewModel.$titleFontToken.subscribe(in: &self.subscriptions) { [weak self] titleFontToken in
+            guard let self, let titleFontToken else { return }
 
-            self.textLabel.font = textFontToken.uiFont
+            self.titleLabel.font = titleFontToken.uiFont
         }
         // **
     }

--- a/core/Sources/Components/Button/View/UIKit/ButtonUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Button/View/UIKit/ButtonUIViewSnapshotTests.swift
@@ -43,8 +43,8 @@ private extension ButtonUIViewSnapshotTests {
         for sut in suts {
             var view: ButtonUIView!
 
-            // Icon + Text ?
-            if let iconImage = sut.iconImage, let text = sut.text {
+            // Icon + Title ?
+            if let iconImage = sut.iconImage, let title = sut.title {
                 view = ButtonUIView(
                     theme: self.theme,
                     intent: sut.intent,
@@ -53,11 +53,11 @@ private extension ButtonUIViewSnapshotTests {
                     shape: sut.shape,
                     alignment: sut.alignment,
                     iconImage: iconImage.leftValue,
-                    text: text,
+                    text: title,
                     isEnabled: sut.isEnabled
                 )
 
-            } else if let iconImage = sut.iconImage, let attributedText = sut.attributedText { // Icon + Attributed Text
+            } else if let iconImage = sut.iconImage, let attributedTitle = sut.attributedTitle { // Icon + Attributed Title
                 view = ButtonUIView(
                     theme: self.theme,
                     intent: sut.intent,
@@ -66,7 +66,7 @@ private extension ButtonUIViewSnapshotTests {
                     shape: sut.shape,
                     alignment: sut.alignment,
                     iconImage: iconImage.leftValue,
-                    attributedText: attributedText.leftValue,
+                    attributedText: attributedTitle.leftValue,
                     isEnabled: sut.isEnabled
                 )
 
@@ -82,7 +82,7 @@ private extension ButtonUIViewSnapshotTests {
                     isEnabled: sut.isEnabled
                 )
 
-            } else if let text = sut.text { // Only Text
+            } else if let title = sut.title { // Only Title
                 view = ButtonUIView(
                     theme: self.theme,
                     intent: sut.intent,
@@ -90,11 +90,11 @@ private extension ButtonUIViewSnapshotTests {
                     size: sut.size,
                     shape: sut.shape,
                     alignment: sut.alignment,
-                    text: text,
+                    text: title,
                     isEnabled: sut.isEnabled
                 )
 
-            } else if let attributedText = sut.attributedText { // Only Attributed Text
+            } else if let attributedTitle = sut.attributedTitle { // Only Attributed Title
                 view = ButtonUIView(
                     theme: self.theme,
                     intent: sut.intent,
@@ -102,7 +102,7 @@ private extension ButtonUIViewSnapshotTests {
                     size: sut.size,
                     shape: sut.shape,
                     alignment: sut.alignment,
-                    attributedText: attributedText.leftValue,
+                    attributedText: attributedTitle.leftValue,
                     isEnabled: sut.isEnabled
                 )
             } else {

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModel.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModel.swift
@@ -32,7 +32,7 @@ final class ButtonViewModel: ObservableObject {
     @Published private(set) var spacings: ButtonSpacings?
 
     @Published private(set) var content: ButtonContent?
-    @Published private(set) var textFontToken: TypographyFontToken?
+    @Published private(set) var titleFontToken: TypographyFontToken?
 
     // MARK: - Private Properties
 
@@ -41,11 +41,11 @@ final class ButtonViewModel: ObservableObject {
     private var isIconOnly: Bool {
         return self.dependencies.getIsIconOnlyUseCase.execute(
             iconImage: self.iconImage,
-            containsText: self.displayedTextViewModel.containsText
+            containsTitle: self.displayedTitleViewModel.containsText
         )
     }
 
-    private let displayedTextViewModel: DisplayedTextViewModel
+    private let displayedTitleViewModel: DisplayedTextViewModel
 
     private var isPressed: Bool = false
 
@@ -61,8 +61,8 @@ final class ButtonViewModel: ObservableObject {
         shape: ButtonShape,
         alignment: ButtonAlignment,
         iconImage: ImageEither?,
-        text: String? ,
-        attributedText: AttributedStringEither?,
+        title: String? ,
+        attributedTitle: AttributedStringEither?,
         isEnabled: Bool,
         dependencies: any ButtonViewModelDependenciesProtocol = ButtonViewModelDependencies()
     ) {
@@ -73,9 +73,9 @@ final class ButtonViewModel: ObservableObject {
         self.shape = shape
         self.alignment = alignment
         self.iconImage = iconImage
-        self.displayedTextViewModel = dependencies.makeDisplayedTextViewModel(
-            text: text,
-            attributedText: attributedText
+        self.displayedTitleViewModel = dependencies.makeDisplayedTitleViewModel(
+            title: title,
+            attributedTitle: attributedTitle
         )
         self.isEnabled = isEnabled
 
@@ -166,24 +166,24 @@ final class ButtonViewModel: ObservableObject {
         }
     }
 
-    func set(text: String?) {
-        // Displayed text changed ?
-        if self.displayedTextViewModel.textChanged(text) {
+    func set(title: String?) {
+        // Displayed title changed ?
+        if self.displayedTitleViewModel.textChanged(title) {
             self.contentDidUpdate()
             self.sizesDidUpdate()
             self.spacingsDidUpdate()
 
-            // Reload label properties (font and color) if consumer set a new text
-            if text != nil {
-                self.textFontDidUpdate()
+            // Reload label properties (font and color) if consumer set a new title
+            if title != nil {
+                self.titleFontDidUpdate()
                 self.colorsDidUpdate()
             }
         }
     }
 
-    func set(attributedText: AttributedStringEither?) {
-        // Displayed text changed ?
-        if self.displayedTextViewModel.attributedTextChanged(attributedText) {
+    func set(attributedTitle: AttributedStringEither?) {
+        // Displayed title changed ?
+        if self.displayedTitleViewModel.attributedTextChanged(attributedTitle) {
             self.contentDidUpdate()
             self.sizesDidUpdate()
             self.spacingsDidUpdate()
@@ -219,7 +219,7 @@ final class ButtonViewModel: ObservableObject {
         if !themeChanged {
             self.contentDidUpdate() // Not related to theme
         }
-        self.textFontDidUpdate()
+        self.titleFontDidUpdate()
     }
 
     private func stateDidUpdate() {
@@ -247,7 +247,7 @@ final class ButtonViewModel: ObservableObject {
         self.currentColors = self.dependencies.getCurrentColorsUseCase.execute(
             colors: colors,
             isPressed: self.isPressed,
-            displayedTextType: self.displayedTextViewModel.displayedTextType
+            displayedTitleType: self.displayedTitleViewModel.displayedTextType
         )
     }
 
@@ -277,11 +277,11 @@ final class ButtonViewModel: ObservableObject {
         self.content = self.dependencies.getContentUseCase.execute(
             alignment: self.alignment,
             iconImage: self.iconImage,
-            containsText: self.displayedTextViewModel.containsText
+            containsTitle: self.displayedTitleViewModel.containsText
         )
     }
 
-    private func textFontDidUpdate() {
-        self.textFontToken = self.theme.typography.callout
+    private func titleFontDidUpdate() {
+        self.titleFontToken = self.theme.typography.callout
     }
 }

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModelDependencies.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModelDependencies.swift
@@ -19,8 +19,8 @@ protocol ButtonViewModelDependenciesProtocol {
     var getSpacingsUseCase: ButtonGetSpacingsUseCaseable { get }
     var getStateUseCase: ButtonGetStateUseCaseable { get }
 
-    func makeDisplayedTextViewModel(text: String?,
-                                    attributedText: AttributedStringEither?) -> DisplayedTextViewModel
+    func makeDisplayedTitleViewModel(title: String?,
+                                     attributedTitle: AttributedStringEither?) -> DisplayedTextViewModel
 }
 
 struct ButtonViewModelDependencies: ButtonViewModelDependenciesProtocol {
@@ -60,13 +60,13 @@ struct ButtonViewModelDependencies: ButtonViewModelDependenciesProtocol {
 
     // MARK: - Maker
 
-    func makeDisplayedTextViewModel(
-        text: String?,
-        attributedText: AttributedStringEither?
+    func makeDisplayedTitleViewModel(
+        title: String?,
+        attributedTitle: AttributedStringEither?
     ) -> DisplayedTextViewModel {
         return DisplayedTextViewModelDefault(
-            text: text,
-            attributedText: attributedText
+            text: title,
+            attributedText: attributedTitle
         )
     }
 }

--- a/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
+++ b/core/Sources/Components/Button/ViewModel/ButtonViewModelTests.swift
@@ -35,8 +35,8 @@ final class ButtonViewModelTests: XCTestCase {
         let sizeMock: ButtonSize = .large
         let shapeMock: ButtonShape = .pill
         let alignmentMock: ButtonAlignment = .leadingIcon
-        let textMock = "My Button"
-        let attributedTextMock = NSAttributedString(string: "My AT Button")
+        let titleMock = "My Button"
+        let attributedTitleMock = NSAttributedString(string: "My AT Button")
         let isEnabledMock = true
 
         let stub = Stub(
@@ -46,8 +46,8 @@ final class ButtonViewModelTests: XCTestCase {
             shape: shapeMock,
             alignment: alignmentMock,
             isIconImage: true,
-            text: textMock,
-            attributedText: attributedTextMock,
+            title: titleMock,
+            attributedTitle: attributedTitleMock,
             isEnabled: isEnabledMock
         )
 
@@ -108,7 +108,7 @@ final class ButtonViewModelTests: XCTestCase {
             1
         )
         XCTAssertPublisherSinkCountEqual(
-            on: stub.textFontTokenPublisherMock,
+            on: stub.titleFontTokenPublisherMock,
             1
         )
         // **
@@ -162,8 +162,8 @@ final class ButtonViewModelTests: XCTestCase {
         let sizeMock: ButtonSize = .medium
         let shapeMock: ButtonShape = .rounded
         let alignmentMock: ButtonAlignment = .trailingIcon
-        let textMock = "My Button"
-        let attributedTextMock = NSAttributedString(string: "My AT Button")
+        let titleMock = "My Button"
+        let attributedTitleMock = NSAttributedString(string: "My AT Button")
         let isEnabledMock = false
 
         let stub = Stub(
@@ -173,8 +173,8 @@ final class ButtonViewModelTests: XCTestCase {
             shape: shapeMock,
             alignment: alignmentMock,
             isIconImage: true,
-            text: textMock,
-            attributedText: attributedTextMock,
+            title: titleMock,
+            attributedTitle: attributedTitleMock,
             isEnabled: isEnabledMock
         )
 
@@ -194,7 +194,7 @@ final class ButtonViewModelTests: XCTestCase {
         self.testBorder(on: stub)
         self.testSpacings(on: stub)
         self.testContent(on: stub)
-        self.testTextFontToken(on: stub)
+        self.testTitleFontToken(on: stub)
 
         XCTAssertPublisherSinkCountEqual(
             on: stub.statePublisherMock,
@@ -221,7 +221,7 @@ final class ButtonViewModelTests: XCTestCase {
             2
         )
         XCTAssertPublisherSinkCountEqual(
-            on: stub.textFontTokenPublisherMock,
+            on: stub.titleFontTokenPublisherMock,
             2
         )
         // **
@@ -376,8 +376,8 @@ final class ButtonViewModelTests: XCTestCase {
         let sizeMock: ButtonSize = .medium
         let shapeMock: ButtonShape = .rounded
         let alignmentMock: ButtonAlignment = .trailingIcon
-        let textMock = "My Button"
-        let attributedTextMock = NSAttributedString(string: "My AT Button")
+        let titleMock = "My Button"
+        let attributedTitleMock = NSAttributedString(string: "My AT Button")
         let isEnabledMock = false
 
         let stub = Stub(
@@ -387,8 +387,8 @@ final class ButtonViewModelTests: XCTestCase {
             shape: shapeMock,
             alignment: alignmentMock,
             isIconImage: true,
-            text: textMock,
-            attributedText: attributedTextMock,
+            title: titleMock,
+            attributedTitle: attributedTitleMock,
             isEnabled: isEnabledMock
         )
         let viewModel = stub.viewModel
@@ -429,7 +429,7 @@ final class ButtonViewModelTests: XCTestCase {
             1
         )
         XCTAssertPublisherSinkCountEqual(
-            on: stub.textFontTokenPublisherMock,
+            on: stub.titleFontTokenPublisherMock,
             1
         )
         // **
@@ -798,32 +798,32 @@ final class ButtonViewModelTests: XCTestCase {
         // **
     }
 
-    func test_set_text_when_displayedTextViewModel_textChanged_return_true_and_new_value_is_NOT_nil() {
-        self.testSetText(
+    func test_set_title_when_displayedTitleViewModel_titleChanged_return_true_and_new_value_is_NOT_nil() {
+        self.testSetTitle(
             newValueIsNil: false,
             givenIsDifferentNewValue: true
         )
     }
 
-    func test_set_text_when_displayedTextViewModel_textChanged_return_true_and_new_value_is_nil() {
-        self.testSetText(
+    func test_set_title_when_displayedTitleViewModel_titleChanged_return_true_and_new_value_is_nil() {
+        self.testSetTitle(
             newValueIsNil: true,
             givenIsDifferentNewValue: true
         )
     }
 
-    func test_set_text_when_displayedTextViewModel_textChanged_return_false() {
-        self.testSetText(
+    func test_set_title_when_displayedTitleViewModel_titleChanged_return_false() {
+        self.testSetTitle(
             givenIsDifferentNewValue: false
         )
     }
 
-    private func testSetText(
+    private func testSetTitle(
         newValueIsNil: Bool = true,
         givenIsDifferentNewValue: Bool
     ) {
         // GIVEN
-        let newValue: String? = newValueIsNil ? nil : "My New Text"
+        let newValue: String? = newValueIsNil ? nil : "My New Title"
 
         let sizeMock: ButtonSize = .medium
         let alignmentMock: ButtonAlignment = .trailingIcon
@@ -831,7 +831,7 @@ final class ButtonViewModelTests: XCTestCase {
         let stub = Stub(
             size: sizeMock,
             alignment: alignmentMock,
-            text: "Text"
+            title: "Title"
         )
         let viewModel = stub.viewModel
 
@@ -843,8 +843,8 @@ final class ButtonViewModelTests: XCTestCase {
         stub.resetMockedData()
 
         // WHEN
-        stub.displayedTextViewModelMock.textChangedWithTextReturnValue = givenIsDifferentNewValue
-        viewModel.set(text: newValue)
+        stub.displayedTitleViewModelMock.textChangedWithTextReturnValue = givenIsDifferentNewValue
+        viewModel.set(title: newValue)
 
         // THEN
         // **
@@ -866,22 +866,22 @@ final class ButtonViewModelTests: XCTestCase {
             givenIsDifferentNewValue && !newValueIsNil ? 1 : 0
         )
         XCTAssertPublisherSinkCountEqual(
-            on: stub.textFontTokenPublisherMock,
+            on: stub.titleFontTokenPublisherMock,
             givenIsDifferentNewValue && !newValueIsNil ? 1 : 0
         )
         // **
 
         // **
-        // DisplayedText ViewModel
+        // DisplayedTitle ViewModel
         XCTAssertEqual(
-            stub.displayedTextViewModelMock.textChangedWithTextCallsCount,
+            stub.displayedTitleViewModelMock.textChangedWithTextCallsCount,
             1,
-            "Wrong call number on textChanged on displayedTextViewModel"
+            "Wrong call number on textChanged on displayedTitleViewModel"
         )
         XCTAssertEqual(
-            stub.displayedTextViewModelMock.textChangedWithTextReceivedText,
+            stub.displayedTitleViewModelMock.textChangedWithTextReceivedText,
             newValue,
-            "Wrong textChanged parameter on displayedTextViewModel"
+            "Wrong textChanged parameter on displayedTitleViewModel"
         )
         // **
 
@@ -913,19 +913,19 @@ final class ButtonViewModelTests: XCTestCase {
         // **
     }
 
-    func test_set_attributedText_when_displayedTextViewModel_attributedTextChanged_return_true() {
-        self.testSetAttributedText(
+    func test_set_attributedTitle_when_displayedTitleViewModel_attributedTitleChanged_return_true() {
+        self.testSetAttributedTitle(
             givenIsDifferentNewValue: true
         )
     }
 
-    func test_set_attributedText_when_displayedTextViewModel_attributedTextChanged_return_false() {
-        self.testSetAttributedText(
+    func test_set_attributedTitle_when_displayedTitleViewModel_attributedTitleChanged_return_false() {
+        self.testSetAttributedTitle(
             givenIsDifferentNewValue: false
         )
     }
 
-    private func testSetAttributedText(
+    private func testSetAttributedTitle(
         givenIsDifferentNewValue: Bool
     ) {
         // GIVEN
@@ -937,7 +937,7 @@ final class ButtonViewModelTests: XCTestCase {
         let stub = Stub(
             size: sizeMock,
             alignment: alignmentMock,
-            attributedText: .init(string: "My AT Button")
+            attributedTitle: .init(string: "My AT Button")
         )
         let viewModel = stub.viewModel
 
@@ -949,8 +949,8 @@ final class ButtonViewModelTests: XCTestCase {
         stub.resetMockedData()
 
         // WHEN
-        stub.displayedTextViewModelMock.attributedTextChangedWithAttributedTextReturnValue = givenIsDifferentNewValue
-        viewModel.set(attributedText: .left(newValue))
+        stub.displayedTitleViewModelMock.attributedTextChangedWithAttributedTextReturnValue = givenIsDifferentNewValue
+        viewModel.set(attributedTitle: .left(newValue))
 
         // THEN
         // **
@@ -970,14 +970,14 @@ final class ButtonViewModelTests: XCTestCase {
         // **
 
         // **
-        // DisplayedText ViewModel
+        // DisplayedTitle ViewModel
         XCTAssertEqual(
-            stub.displayedTextViewModelMock.attributedTextChangedWithAttributedTextCallsCount,
+            stub.displayedTitleViewModelMock.attributedTextChangedWithAttributedTextCallsCount,
             1,
             "Wrong call number on attributedText on displayedTextViewModel"
         )
         XCTAssertEqual(
-            stub.displayedTextViewModelMock.attributedTextChangedWithAttributedTextReceivedAttributedText?.leftValue,
+            stub.displayedTitleViewModelMock.attributedTextChangedWithAttributedTextReceivedAttributedText?.leftValue,
             newValue,
             "Wrong attributedText parameter on displayedTextViewModel"
         )
@@ -1202,9 +1202,9 @@ private extension ButtonViewModelTests {
         )
     }
 
-    private func testTextFontToken(on stub: Stub) {
+    private func testTitleFontToken(on stub: Stub) {
         XCTAssertPublisherSinkValueIdentical(
-            on: stub.textFontTokenPublisherMock,
+            on: stub.titleFontTokenPublisherMock,
             stub.themeMock.typography.callout as? TypographyFontTokenGeneratedMock
         )
     }
@@ -1270,21 +1270,21 @@ private extension ButtonViewModelTests {
         givenAlignment: ButtonAlignment? = nil,
         givenIconImage: UIImage? = nil
     ) {
-        XCTAssertEqual(stub.getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTextCallsCount,
+        XCTAssertEqual(stub.getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTitleCallsCount,
                        numberOfCalls,
                        "Wrong call number on execute on getContentUseCase")
 
         if numberOfCalls > 0, let givenAlignment {
-            let getContentUseCaseArgs = stub.getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTextReceivedArguments
+            let getContentUseCaseArgs = stub.getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTitleReceivedArguments
             XCTAssertEqual(getContentUseCaseArgs?.alignment,
                            givenAlignment,
                            "Wrong alignment parameter on execute on getContentUseCase")
             XCTAssertEqual(getContentUseCaseArgs?.iconImage?.leftValue,
                            givenIconImage,
                            "Wrong iconImage parameter on execute on getContentUseCase")
-            XCTAssertEqual(getContentUseCaseArgs?.containsText,
-                           stub.displayedTextViewModelMock.containsText,
-                           "Wrong containsText parameter on execute on getContentUseCase")
+            XCTAssertEqual(getContentUseCaseArgs?.containsTitle,
+                           stub.displayedTitleViewModelMock.containsText,
+                           "Wrong containsTitle parameter on execute on getContentUseCase")
         }
     }
 
@@ -1294,12 +1294,12 @@ private extension ButtonViewModelTests {
         givenColors: ButtonColors? = nil,
         givenIsPressed: Bool? = nil
     ) {
-        XCTAssertEqual(stub.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeCallsCount,
+        XCTAssertEqual(stub.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTitleTypeCallsCount,
                        numberOfCalls,
                        "Wrong call number on execute on getCurrentColorsUseCase")
 
         if numberOfCalls > 0, let givenColors, let givenIsPressed {
-            let getCurrentColorsUseCaseArgs = stub.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReceivedArguments
+            let getCurrentColorsUseCaseArgs = stub.getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTitleTypeReceivedArguments
             XCTAssertEqual(try XCTUnwrap(getCurrentColorsUseCaseArgs?.colors),
                            givenColors,
                            "Wrong colors parameter on execute on getCurrentColorsUseCase")
@@ -1314,18 +1314,18 @@ private extension ButtonViewModelTests {
         numberOfCalls: Int,
         givenIconImage: UIImage? = nil
     ) {
-        XCTAssertEqual(stub.getIsIconOnlyUseCaseMock.executeWithIconImageAndContainsTextCallsCount,
+        XCTAssertEqual(stub.getIsIconOnlyUseCaseMock.executeWithIconImageAndContainsTitleCallsCount,
                        numberOfCalls,
                        "Wrong call number on execute on getIsIconOnlyUseCase")
 
         if numberOfCalls > 0 {
-            let getIsIconOnlyUseCaseArgs = stub.getIsIconOnlyUseCaseMock.executeWithIconImageAndContainsTextReceivedArguments
+            let getIsIconOnlyUseCaseArgs = stub.getIsIconOnlyUseCaseMock.executeWithIconImageAndContainsTitleReceivedArguments
             XCTAssertEqual(getIsIconOnlyUseCaseArgs?.iconImage?.leftValue,
                            givenIconImage,
                            "Wrong iconImage parameter on execute on getIsIconOnlyUseCase")
-            XCTAssertEqual(getIsIconOnlyUseCaseArgs?.containsText,
-                           stub.displayedTextViewModelMock.containsText,
-                           "Wrong containsText parameter on execute on getIsIconOnlyUseCase")
+            XCTAssertEqual(getIsIconOnlyUseCaseArgs?.containsTitle,
+                           stub.displayedTitleViewModelMock.containsText,
+                           "Wrong containsTitle parameter on execute on getIsIconOnlyUseCase")
         }
     }
 
@@ -1417,7 +1417,7 @@ private final class Stub {
 
     // MARK: - Dependencies Properties
 
-    let displayedTextViewModelMock: DisplayedTextViewModelGeneratedMock
+    let displayedTitleViewModelMock: DisplayedTextViewModelGeneratedMock
     let getBorderUseCaseMock: ButtonGetBorderUseCaseableGeneratedMock
     let getColorsUseCaseMock: ButtonGetColorsUseCaseableGeneratedMock
     let getContentUseCaseMock: ButtonGetContentUseCaseableGeneratedMock
@@ -1437,7 +1437,7 @@ private final class Stub {
     let borderPublisherMock: PublisherMock<Published<ButtonBorder?>.Publisher>
     let spacingsPublisherMock: PublisherMock<Published<ButtonSpacings?>.Publisher>
     let contentPublisherMock: PublisherMock<Published<ButtonContent?>.Publisher>
-    let textFontTokenPublisherMock: PublisherMock<Published<(any TypographyFontToken)?>.Publisher>
+    let titleFontTokenPublisherMock: PublisherMock<Published<(any TypographyFontToken)?>.Publisher>
 
     // MARK: - Initialization
 
@@ -1448,16 +1448,16 @@ private final class Stub {
         shape: ButtonShape = .rounded,
         alignment: ButtonAlignment = .leadingIcon,
         isIconImage: Bool = false,
-        text: String? = nil,
-        attributedText: NSAttributedString? = nil,
+        title: String? = nil,
+        attributedTitle: NSAttributedString? = nil,
         isEnabled: Bool = true
     ) {
         // **
         // Dependencies
-        let displayedTextViewModelMock = DisplayedTextViewModelGeneratedMock()
-        displayedTextViewModelMock.displayedText = .mocked()
-        displayedTextViewModelMock.underlyingDisplayedTextType = .text
-        self.displayedTextViewModelMock = displayedTextViewModelMock
+        let displayedTitleViewModelMock = DisplayedTextViewModelGeneratedMock()
+        displayedTitleViewModelMock.displayedText = .mocked()
+        displayedTitleViewModelMock.underlyingDisplayedTextType = .text
+        self.displayedTitleViewModelMock = displayedTitleViewModelMock
 
         let getBorderUseCaseMock = ButtonGetBorderUseCaseableGeneratedMock()
         getBorderUseCaseMock.executeWithShapeAndBorderAndVariantReturnValue = self.borderMock
@@ -1468,15 +1468,15 @@ private final class Stub {
         self.getColorsUseCaseMock = getColorsUseCaseMock
 
         let getContentUseCaseMock = ButtonGetContentUseCaseableGeneratedMock()
-        getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTextReturnValue = self.contentMock
+        getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTitleReturnValue = self.contentMock
         self.getContentUseCaseMock = getContentUseCaseMock
 
         let getCurrentColorsUseCaseMock = ButtonGetCurrentColorsUseCaseableGeneratedMock()
-        getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTextTypeReturnValue = self.currentColorsMock
+        getCurrentColorsUseCaseMock.executeWithColorsAndIsPressedAndDisplayedTitleTypeReturnValue = self.currentColorsMock
         self.getCurrentColorsUseCaseMock = getCurrentColorsUseCaseMock
 
         let getIsIconOnlyUseCaseMock = ButtonGetIsOnlyIconUseCaseableGeneratedMock()
-        getIsIconOnlyUseCaseMock.executeWithIconImageAndContainsTextReturnValue = self.isIconOnlyMock
+        getIsIconOnlyUseCaseMock.executeWithIconImageAndContainsTitleReturnValue = self.isIconOnlyMock
         self.getIsIconOnlyUseCaseMock = getIsIconOnlyUseCaseMock
 
         let getSizesUseCaseMock = ButtonGetSizesUseCaseableGeneratedMock()
@@ -1500,7 +1500,7 @@ private final class Stub {
         dependenciesMock.underlyingGetSizesUseCase = getSizesUseCaseMock
         dependenciesMock.underlyingGetSpacingsUseCase = getSpacingsUseCaseMock
         dependenciesMock.underlyingGetStateUseCase = getStateUseCaseMock
-        dependenciesMock.makeDisplayedTextViewModelWithTextAndAttributedTextReturnValue = displayedTextViewModelMock
+        dependenciesMock.makeDisplayedTitleViewModelWithTitleAndAttributedTitleReturnValue = displayedTitleViewModelMock
         self.dependenciesMock = dependenciesMock
         // **
 
@@ -1513,11 +1513,11 @@ private final class Stub {
             iconImageEither = nil
         }
 
-        let attributedTextEither: AttributedStringEither?
-        if let attributedText {
-            attributedTextEither = .left(attributedText)
+        let attributedTitleEither: AttributedStringEither?
+        if let attributedTitle {
+            attributedTitleEither = .left(attributedTitle)
         } else {
-            attributedTextEither = nil
+            attributedTitleEither = nil
         }
 
         let viewModel = ButtonViewModel(
@@ -1528,8 +1528,8 @@ private final class Stub {
             shape: shape,
             alignment: alignment,
             iconImage: iconImageEither,
-            text: text,
-            attributedText: attributedTextEither,
+            title: title,
+            attributedTitle: attributedTitleEither,
             isEnabled: isEnabled,
             dependencies: dependenciesMock
         )
@@ -1544,7 +1544,7 @@ private final class Stub {
         self.borderPublisherMock = .init(publisher: viewModel.$border)
         self.spacingsPublisherMock = .init(publisher: viewModel.$spacings)
         self.contentPublisherMock = .init(publisher: viewModel.$content)
-        self.textFontTokenPublisherMock = .init(publisher: viewModel.$textFontToken)
+        self.titleFontTokenPublisherMock = .init(publisher: viewModel.$titleFontToken)
         //
     }
 
@@ -1557,7 +1557,7 @@ private final class Stub {
         self.borderPublisherMock.loadTesting(on: &subscriptions)
         self.spacingsPublisherMock.loadTesting(on: &subscriptions)
         self.contentPublisherMock.loadTesting(on: &subscriptions)
-        self.textFontTokenPublisherMock.loadTesting(on: &subscriptions)
+        self.titleFontTokenPublisherMock.loadTesting(on: &subscriptions)
     }
 
     func resetMockedData() {
@@ -1581,6 +1581,6 @@ private final class Stub {
         self.borderPublisherMock.reset()
         self.spacingsPublisherMock.reset()
         self.contentPublisherMock.reset()
-        self.textFontTokenPublisherMock.reset()
+        self.titleFontTokenPublisherMock.reset()
     }
 }


### PR DESCRIPTION
Because we want now to have the same syntax as the UIButton, the goal of this PR is just to rename all text to title.
(On the next PR, we will have a get and set title for state and same for the attributedText) 
