### PR TITLE
[Fix] Tab snapshots tests.

### DIFF
--- a/core/Sources/Components/Tab/View/UIKit/TabUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabUIViewSnapshotTests.swift
@@ -14,7 +14,7 @@ final class TabUIViewSnapshotTests: UIKitComponentSnapshotTestCase {
 
     // MARK: - Properties
     let theme = SparkTheme.shared
-    let names = ["paperplane", "folder", "trash", "pencil", "eraser", "scribble", "lasso"]
+    let names = ["paperplane", "folder", "trash", "pencil", "scribble", "lasso"]
     var badge: BadgeUIView!
     var images: [UIImage]!
 
@@ -22,7 +22,12 @@ final class TabUIViewSnapshotTests: UIKitComponentSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
-        self.images = names.map{ UIImage.init(systemName: $0)! }
+        self.images = names.map{
+            guard let image = UIImage.init(systemName: $0) else {
+                fatalError("No Image for \($0)")
+            }
+            return image
+        }
         self.badge = BadgeUIView(theme: theme, intent: .danger, value: 99, isBorderVisible: false)
     }
 


### PR DESCRIPTION
The system image eraser is no longer available.

The snapshots have been updated under: https://github.com/adevinta/spark-ios-snapshots/pull/69