### PR TITLE
[Fix-580] Components: remove some animations

### DIFF
--- a/core/Sources/Common/UIKit/Extension/Animation/UIView+ExecuteExtension.swift
+++ b/core/Sources/Common/UIKit/Extension/Animation/UIView+ExecuteExtension.swift
@@ -1,0 +1,52 @@
+//
+//  UIView+ExecuteExtension.swift
+//  SparkCore
+//
+//  Created by robin.lemaire on 26/10/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    /// Execute a code with or without animation.
+    static func execute(
+        isAnimated: Bool,
+        withDuration duration: TimeInterval,
+        context: @escaping () -> Void,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        if isAnimated {
+            UIView.animate(
+                withDuration: duration,
+                animations: context,
+                completion: completion)
+        } else {
+            context()
+            completion?(true)
+        }
+    }
+
+    /// Execute a code with or without transition animation.
+    static func execute(
+        with view: UIView,
+        isTransitionAnimated: Bool,
+        withDuration duration: TimeInterval,
+        options: UIView.AnimationOptions = [],
+        context: @escaping () -> Void,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        if isTransitionAnimated {
+            UIView.transition(
+                with: view,
+                duration: duration,
+                options: options,
+                animations: context,
+                completion: completion)
+        } else {
+            context()
+            completion?(true)
+        }
+    }
+}

--- a/core/Sources/Common/UIKit/Extension/Animation/UIView+ExecuteExtension.swift
+++ b/core/Sources/Common/UIKit/Extension/Animation/UIView+ExecuteExtension.swift
@@ -8,45 +8,52 @@
 
 import UIKit
 
+enum UIExecuteAnimationType {
+    case unanimated
+    case animated(duration: TimeInterval)
+}
+
 extension UIView {
 
     /// Execute a code with or without animation.
     static func execute(
-        isAnimated: Bool,
-        withDuration duration: TimeInterval,
-        context: @escaping () -> Void,
+        animationType: UIExecuteAnimationType,
+        instructions: @escaping () -> Void,
         completion: ((Bool) -> Void)? = nil
     ) {
-        if isAnimated {
+        switch animationType {
+        case .unanimated:
+            instructions()
+            completion?(true)
+
+        case .animated(let duration):
             UIView.animate(
                 withDuration: duration,
-                animations: context,
+                animations: instructions,
                 completion: completion)
-        } else {
-            context()
-            completion?(true)
         }
     }
 
     /// Execute a code with or without transition animation.
     static func execute(
         with view: UIView,
-        isTransitionAnimated: Bool,
-        withDuration duration: TimeInterval,
+        animationType: UIExecuteAnimationType,
         options: UIView.AnimationOptions = [],
-        context: @escaping () -> Void,
+        instructions: @escaping () -> Void,
         completion: ((Bool) -> Void)? = nil
     ) {
-        if isTransitionAnimated {
+        switch animationType {
+        case .unanimated:
+            instructions()
+            completion?(true)
+
+        case .animated(let duration):
             UIView.transition(
                 with: view,
                 duration: duration,
                 options: options,
-                animations: context,
+                animations: instructions,
                 completion: completion)
-        } else {
-            context()
-            completion?(true)
         }
     }
 }

--- a/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
@@ -15,7 +15,7 @@ public final class ButtonUIView: UIView {
     // MARK: - Type alias
 
     private typealias AccessibilityIdentifier = ButtonAccessibilityIdentifier
-    private typealias Constants = ButtonConstants
+    private typealias Animation = ButtonConstants.Animation
 
     // MARK: - Components
 
@@ -578,10 +578,11 @@ public final class ButtonUIView: UIView {
         if verticalSpacing != self.contentStackViewTopConstraint?.constant ||
             horizontalSpacing != self.contentStackViewLeadingConstraint?.constant ||
             horizontalPadding != self.contentStackView.spacing {
-            UIView.execute(
-                isAnimated: self.isAnimated && !self.firstContentStackViewAnimation,
-                withDuration: Constants.Animation.slowDuration
-            ) { [weak self] in
+
+            let isAnimated = self.isAnimated && !self.firstContentStackViewAnimation
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Animation.slowDuration) : .unanimated
+
+            UIView.execute(animationType: animationType) { [weak self] in
                 guard let self else { return }
 
                 self.firstContentStackViewAnimation = false
@@ -622,11 +623,12 @@ public final class ButtonUIView: UIView {
 
             // Animate only if new alpha is different from current alpha
             let alpha = state.opacity
-            UIView.execute(
-                isAnimated: self.isAnimated && self.alpha != alpha,
-                withDuration: Constants.Animation.slowDuration
-            ) { [weak self] in
-                    self?.alpha = alpha
+
+            let isAnimated = self.isAnimated && self.alpha != alpha
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Animation.slowDuration) : .unanimated
+
+            UIView.execute(animationType: animationType) { [weak self] in
+                self?.alpha = alpha
             }
         }
         // **
@@ -637,10 +639,10 @@ public final class ButtonUIView: UIView {
             guard let self, let colors else { return }
 
             // Background Color
-            UIView.execute(
-                isAnimated: self.isAnimated && self.backgroundColor != colors.backgroundColor.uiColor,
-                withDuration: Constants.Animation.fastDuration
-            ) { [weak self] in
+            let isAnimated = self.isAnimated && self.backgroundColor != colors.backgroundColor.uiColor
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Animation.fastDuration) : .unanimated
+            
+            UIView.execute(animationType: animationType) { [weak self] in
                 self?.backgroundColor = colors.backgroundColor.uiColor
             }
 
@@ -712,10 +714,10 @@ public final class ButtonUIView: UIView {
             self.iconImageView.image = content.iconImage?.leftValue
 
             // Subviews positions and visibilities
-            UIView.execute(
-                isAnimated: self.isAnimated && !self.firstContentStackViewSubviewAnimation,
-                withDuration: Constants.Animation.slowDuration
-            ) { [weak self] in
+            let isAnimated = self.isAnimated && !self.firstContentStackViewSubviewAnimation
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Animation.slowDuration) : .unanimated
+
+            UIView.execute(animationType: animationType) { [weak self] in
                 guard let self else { return }
 
                 self.firstContentStackViewSubviewAnimation = false
@@ -770,7 +772,7 @@ public final class ButtonUIView: UIView {
     }
 
     private func unpressedAction() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.Animation.fastDuration, execute: { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Animation.fastDuration, execute: { [weak self] in
             self?.viewModel.unpressedAction()
         })
     }

--- a/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/ButtonUIView.swift
@@ -213,6 +213,9 @@ public final class ButtonUIView: UIView {
         }
     }
 
+    /// Button modifications should be animated or not. **True** by default.
+    public var isAnimated: Bool = true
+
     // MARK: - Internal Properties
 
     internal let viewModel: ButtonViewModel
@@ -572,11 +575,13 @@ public final class ButtonUIView: UIView {
         let horizontalSpacing = self._horizontalSpacing.wrappedValue
         let horizontalPadding = self._horizontalPadding.wrappedValue
 
-        let animationDuration = self.firstContentStackViewAnimation ? 0 : Constants.Animation.slowDuration
         if verticalSpacing != self.contentStackViewTopConstraint?.constant ||
             horizontalSpacing != self.contentStackViewLeadingConstraint?.constant ||
             horizontalPadding != self.contentStackView.spacing {
-            UIView.animate(withDuration: animationDuration) { [weak self] in
+            UIView.execute(
+                isAnimated: self.isAnimated && !self.firstContentStackViewAnimation,
+                withDuration: Constants.Animation.slowDuration
+            ) { [weak self] in
                 guard let self else { return }
 
                 self.firstContentStackViewAnimation = false
@@ -617,12 +622,11 @@ public final class ButtonUIView: UIView {
 
             // Animate only if new alpha is different from current alpha
             let alpha = state.opacity
-            if self.alpha != alpha {
-                UIView.animate(withDuration: Constants.Animation.slowDuration) { [weak self] in
+            UIView.execute(
+                isAnimated: self.isAnimated && self.alpha != alpha,
+                withDuration: Constants.Animation.slowDuration
+            ) { [weak self] in
                     self?.alpha = alpha
-                }
-            } else {
-                self.alpha = alpha
             }
         }
         // **
@@ -633,12 +637,11 @@ public final class ButtonUIView: UIView {
             guard let self, let colors else { return }
 
             // Background Color
-            if self.backgroundColor != colors.backgroundColor.uiColor {
-                UIView.animate(withDuration: Constants.Animation.fastDuration) { [weak self] in
-                    self?.backgroundColor = colors.backgroundColor.uiColor
-                }
-            } else {
-                self.backgroundColor = colors.backgroundColor.uiColor
+            UIView.execute(
+                isAnimated: self.isAnimated && self.backgroundColor != colors.backgroundColor.uiColor,
+                withDuration: Constants.Animation.fastDuration
+            ) { [weak self] in
+                self?.backgroundColor = colors.backgroundColor.uiColor
             }
 
             // Border Color
@@ -709,8 +712,10 @@ public final class ButtonUIView: UIView {
             self.iconImageView.image = content.iconImage?.leftValue
 
             // Subviews positions and visibilities
-            let animationDuration = self.firstContentStackViewSubviewAnimation ? 0 : Constants.Animation.slowDuration
-            UIView.animate(withDuration: animationDuration) { [weak self] in
+            UIView.execute(
+                isAnimated: self.isAnimated && !self.firstContentStackViewSubviewAnimation,
+                withDuration: Constants.Animation.slowDuration
+            ) { [weak self] in
                 guard let self else { return }
 
                 self.firstContentStackViewSubviewAnimation = false

--- a/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
+++ b/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
@@ -129,12 +129,13 @@ public final class SwitchUIView: UIView {
         }
     }
 
-    /// The value of the switch.
+    /// The value of the switch (retrieve and set without animation).
     public var isOn: Bool {
         get {
             return self.viewModel.isOn
         }
         set {
+            self.isOnAnimated = false
             self.viewModel.set(isOn: newValue)
         }
     }
@@ -159,12 +160,13 @@ public final class SwitchUIView: UIView {
         }
     }
 
-    /// The state of the switch: enabled or not.
+    /// The state of the switch: enabled or not (retrieve and set without animation). .
     public var isEnabled: Bool {
         get {
             return self.viewModel.isEnabled
         }
         set {
+            self.isEnabledAnimated = false
             self.viewModel.set(isEnabled: newValue)
         }
     }
@@ -249,6 +251,9 @@ public final class SwitchUIView: UIView {
     @ScaledUIMetric private var toggleWidth: CGFloat = Constants.ToggleSizes.width
     @ScaledUIMetric private var toggleSpacing: CGFloat = Constants.ToggleSizes.padding
     @ScaledUIMetric private var toggleDotSpacing: CGFloat = Constants.toggleDotImagePadding
+
+    private var isEnabledAnimated: Bool = false
+    private var isOnAnimated: Bool = false
 
     private var subscriptions = Set<AnyCancellable>()
 
@@ -605,6 +610,20 @@ public final class SwitchUIView: UIView {
         self.textLabel.heightAnchor.constraint(greaterThanOrEqualTo: self.toggleView.heightAnchor).isActive = true
     }
 
+    // MARK: - Setter
+
+    /// Sets the state of the switch to the on or off position, optionally animating the transition.
+    public func setOn(_ isOn: Bool, animated: Bool) {
+        self.isOnAnimated = animated
+        self.viewModel.set(isOn: isOn)
+    }
+
+    /// Sets the enable status of the switch, optionally animating the color.
+    public func setEnabled(_ isEnabled: Bool, animated: Bool) {
+        self.isEnabledAnimated = animated
+        self.viewModel.set(isEnabled: isEnabled)
+    }
+
     // MARK: - Actions
 
     @objc private func toggleTapGestureAction(_ sender: UITapGestureRecognizer) {
@@ -702,14 +721,11 @@ public final class SwitchUIView: UIView {
             guard let self, let toggleOpacity else { return }
 
             // Animate only if new alpha is different from current alpha
-            let animated = self.toggleView.alpha != toggleOpacity
-
-            if animated {
-                UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
-                    self?.toggleView.alpha = toggleOpacity
-                }
-            } else {
-                self.toggleView.alpha = toggleOpacity
+            UIView.execute(
+                isAnimated: self.isEnabledAnimated && self.toggleView.alpha != toggleOpacity,
+                withDuration: Constants.animationDuration
+            ) { [weak self] in
+                self?.toggleView.alpha = toggleOpacity
             }
         }
         // **
@@ -722,12 +738,11 @@ public final class SwitchUIView: UIView {
             // Animate only if there is currently an color on View and if new color is different from current color
             let animated = self.toggleView.backgroundColor != nil && self.toggleView.backgroundColor != colorToken.uiColor
 
-            if animated {
-                UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
-                    self?.toggleView.backgroundColor = colorToken.uiColor
-                }
-            } else {
-                self.toggleView.backgroundColor = colorToken.uiColor
+            UIView.execute(
+                isAnimated: self.isOnAnimated && animated,
+                withDuration: Constants.animationDuration
+            ) { [weak self] in
+                self?.toggleView.backgroundColor = colorToken.uiColor
             }
         }
         self.viewModel.$toggleDotBackgroundColorToken.subscribe(in: &self.subscriptions) { [weak self] colorToken in
@@ -741,12 +756,11 @@ public final class SwitchUIView: UIView {
             // Animate only if there is currently an color on View and if new color is different from current color
             let animated = self.toggleDotImageView.tintColor != nil && self.toggleDotImageView.tintColor != colorToken.uiColor
 
-            if animated {
-                UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
-                    self?.toggleDotImageView.tintColor = colorToken.uiColor
-                }
-            } else {
-                self.toggleDotImageView.tintColor = colorToken.uiColor
+            UIView.execute(
+                isAnimated: self.isOnAnimated && animated,
+                withDuration: Constants.animationDuration
+            ) { [weak self] in
+                self?.toggleDotImageView.tintColor = colorToken.uiColor
             }
         }
         self.viewModel.$textForegroundColorToken.subscribe(in: &self.subscriptions) { [weak self] colorToken in
@@ -786,7 +800,10 @@ public final class SwitchUIView: UIView {
             let currentUserInteraction = self.viewModel.isToggleInteractionEnabled ?? true
             self.toggleView.isUserInteractionEnabled = false
 
-            UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
+            UIView.execute(
+                isAnimated: self.isOnAnimated,
+                withDuration: Constants.animationDuration
+            ) { [weak self] in
                 self?.toggleLeftSpaceView.isHidden = !showLeftSpace
                 self?.toggleRightSpaceView.isHidden = showLeftSpace
             } completion: { [weak self] _ in
@@ -803,21 +820,16 @@ public final class SwitchUIView: UIView {
             let image = toggleDotImagesState?.currentImage.leftValue
 
             // Animate only if there is currently an image on ImageView and new image is exists
-            let animated = self.toggleDotImageView.image != nil && image != nil
-
-            if animated {
-                UIView.transition(
-                    with: self.toggleDotImageView,
-                    duration: Constants.animationDuration,
-                    options: .transitionCrossDissolve,
-                    animations: {
-                        self.toggleDotImageView.image = image
-                    },
-                    completion: nil
-                )
-            } else {
-                self.toggleDotImageView.image = image
-            }
+            UIView.execute(
+                with: self.toggleDotImageView,
+                isTransitionAnimated: self.isOnAnimated && self.toggleDotImageView.image != nil && image != nil,
+                withDuration: Constants.animationDuration,
+                options: .transitionCrossDissolve,
+                context: {
+                    self.toggleDotImageView.image = image
+                },
+                completion: nil
+            )
         }
 
         // Displayed Text

--- a/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
+++ b/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
@@ -721,10 +721,11 @@ public final class SwitchUIView: UIView {
             guard let self, let toggleOpacity else { return }
 
             // Animate only if new alpha is different from current alpha
-            UIView.execute(
-                isAnimated: self.isEnabledAnimated && self.toggleView.alpha != toggleOpacity,
-                withDuration: Constants.animationDuration
-            ) { [weak self] in
+
+            let isAnimated = self.isEnabledAnimated && self.toggleView.alpha != toggleOpacity
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Constants.animationDuration) : .unanimated
+
+            UIView.execute(animationType: animationType) { [weak self] in
                 self?.toggleView.alpha = toggleOpacity
             }
         }
@@ -736,12 +737,10 @@ public final class SwitchUIView: UIView {
             guard let self, let colorToken else { return }
 
             // Animate only if there is currently an color on View and if new color is different from current color
-            let animated = self.toggleView.backgroundColor != nil && self.toggleView.backgroundColor != colorToken.uiColor
+            let isAnimated = self.isOnAnimated && self.toggleView.backgroundColor != nil && self.toggleView.backgroundColor != colorToken.uiColor
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Constants.animationDuration) : .unanimated
 
-            UIView.execute(
-                isAnimated: self.isOnAnimated && animated,
-                withDuration: Constants.animationDuration
-            ) { [weak self] in
+            UIView.execute(animationType: animationType) { [weak self] in
                 self?.toggleView.backgroundColor = colorToken.uiColor
             }
         }
@@ -754,12 +753,10 @@ public final class SwitchUIView: UIView {
             guard let self, let colorToken else { return }
 
             // Animate only if there is currently an color on View and if new color is different from current color
-            let animated = self.toggleDotImageView.tintColor != nil && self.toggleDotImageView.tintColor != colorToken.uiColor
+            let isAnimated = self.isOnAnimated && self.toggleDotImageView.tintColor != nil && self.toggleDotImageView.tintColor != colorToken.uiColor
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Constants.animationDuration) : .unanimated
 
-            UIView.execute(
-                isAnimated: self.isOnAnimated && animated,
-                withDuration: Constants.animationDuration
-            ) { [weak self] in
+            UIView.execute(animationType: animationType) { [weak self] in
                 self?.toggleDotImageView.tintColor = colorToken.uiColor
             }
         }
@@ -800,10 +797,9 @@ public final class SwitchUIView: UIView {
             let currentUserInteraction = self.viewModel.isToggleInteractionEnabled ?? true
             self.toggleView.isUserInteractionEnabled = false
 
-            UIView.execute(
-                isAnimated: self.isOnAnimated,
-                withDuration: Constants.animationDuration
-            ) { [weak self] in
+            let animationType: UIExecuteAnimationType = self.isOnAnimated ? .animated(duration: Constants.animationDuration) : .unanimated
+
+            UIView.execute(animationType: animationType) { [weak self] in
                 self?.toggleLeftSpaceView.isHidden = !showLeftSpace
                 self?.toggleRightSpaceView.isHidden = showLeftSpace
             } completion: { [weak self] _ in
@@ -820,13 +816,15 @@ public final class SwitchUIView: UIView {
             let image = toggleDotImagesState?.currentImage.leftValue
 
             // Animate only if there is currently an image on ImageView and new image is exists
+            let isAnimated = self.isOnAnimated && self.toggleDotImageView.image != nil && image != nil
+            let animationType: UIExecuteAnimationType = isAnimated ? .animated(duration: Constants.animationDuration) : .unanimated
+
             UIView.execute(
                 with: self.toggleDotImageView,
-                isTransitionAnimated: self.isOnAnimated && self.toggleDotImageView.image != nil && image != nil,
-                withDuration: Constants.animationDuration,
+                animationType: animationType,
                 options: .transitionCrossDissolve,
-                context: {
-                    self.toggleDotImageView.image = image
+                instructions: { [weak self] in
+                    self?.toggleDotImageView.image = image
                 },
                 completion: nil
             )

--- a/spark/Demo/Classes/View/Components/Button/SwiftUI/ButtonComponentView.swift
+++ b/spark/Demo/Classes/View/Components/Button/SwiftUI/ButtonComponentView.swift
@@ -26,6 +26,7 @@ struct ButtonComponentView: View {
     @State private var alignment: ButtonAlignment = .leadingIcon
     @State private var content: ButtonContentDefault = .text
     @State private var isEnabled: CheckboxSelectionState = .selected
+    @State private var isAnimated: CheckboxSelectionState = .selected
 
     @State private var shouldShowReverseBackgroundColor: Bool = false
 
@@ -102,7 +103,8 @@ struct ButtonComponentView: View {
                         shape: self.$shape.wrappedValue,
                         alignment: self.$alignment.wrappedValue,
                         content: self.$content.wrappedValue,
-                        isEnabled: self.$isEnabled.wrappedValue == .selected
+                        isEnabled: self.$isEnabled.wrappedValue == .selected,
+                        isAnimated: self.$isAnimated.wrappedValue == .selected
                     )
                     .frame(width: geometry.size.width, height: self.uiKitViewHeight, alignment: .center)
                     .padding(.horizontal, self.shouldShowReverseBackgroundColor ? 4 : 0)

--- a/spark/Demo/Classes/View/Components/Button/SwiftUI/ButtonComponentView.swift
+++ b/spark/Demo/Classes/View/Components/Button/SwiftUI/ButtonComponentView.swift
@@ -90,6 +90,14 @@ struct ButtonComponentView: View {
                     state: .enabled,
                     selectionState: self.$isEnabled
                 )
+
+                CheckboxView(
+                    text: "Is animated",
+                    checkedImage: DemoIconography.shared.checkmark,
+                    theme: self.theme,
+                    state: .enabled,
+                    selectionState: self.$isAnimated
+                )
             },
             integration: {
                 GeometryReader { geometry in

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentItemsUIView.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentItemsUIView.swift
@@ -29,6 +29,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
     private let alignment: ButtonAlignment
     private let content: ButtonContentDefault
     private let isEnabled: Bool
+    private let isAnimated: Bool
 
     // MARK: - Initialization
 
@@ -42,7 +43,8 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
         shape: ButtonShape,
         alignment: ButtonAlignment,
         content: ButtonContentDefault,
-        isEnabled: Bool
+        isEnabled: Bool,
+        isAnimated: Bool
     ) {
         self.viewModel = viewModel
         self.iconImage = .init(named: viewModel.imageNamed) ?? UIImage()
@@ -62,6 +64,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
         self.alignment = alignment
         self.content = content
         self.isEnabled = isEnabled
+        self.isAnimated = isAnimated
     }
 
     // MARK: - Maker
@@ -196,6 +199,10 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
 
         if buttonView.isEnabled != self.isEnabled {
             buttonView.isEnabled = self.isEnabled
+        }
+
+        if buttonView.isAnimated != self.isAnimated {
+            buttonView.isAnimated = self.isAnimated
         }
 
         DispatchQueue.main.async {

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIView.swift
@@ -185,5 +185,10 @@ final class ButtonComponentUIView: ComponentUIView {
             guard let self = self else { return }
             self.buttonView.isEnabled = isEnabled
         }
+
+        self.viewModel.$isAnimated.subscribe(in: &self.cancellables) { [weak self] isAnimated in
+            guard let self = self else { return }
+            self.buttonView.isAnimated = isAnimated
+        }
     }
 }

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIViewModel.swift
@@ -60,6 +60,7 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
     @Published var alignment: ButtonAlignment
     @Published var content: ButtonContentDefault
     @Published var isEnabled: Bool
+    @Published var isAnimated: Bool
 
     // MARK: - Items Properties
 
@@ -127,6 +128,14 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
         )
     }()
 
+    lazy var isAnimatedConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Is Animated",
+            type: .toggle(isOn: self.isAnimated),
+            target: (source: self, action: #selector(self.isAnimatedChanged))
+        )
+    }()
+
     // MARK: - Properties
 
     let text: String
@@ -144,7 +153,8 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
             self.shapeConfigurationItemViewModel,
             self.alignmentConfigurationItemViewModel,
             self.contentConfigurationItemViewModel,
-            self.isEnabledConfigurationItemViewModel
+            self.isEnabledConfigurationItemViewModel,
+            self.isAnimatedConfigurationItemViewModel
         ]
     }
 
@@ -170,7 +180,8 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
         shape: ButtonShape = .rounded,
         alignment: ButtonAlignment = .leadingIcon,
         content: ButtonContentDefault = .text,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        isAnimated: Bool = true
     ) {
         self.text = text
         self.iconImage = .init(named: iconImageNamed) ?? UIImage()
@@ -189,6 +200,7 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
         self.alignment = alignment
         self.content = content
         self.isEnabled = isEnabled
+        self.isAnimated = isAnimated
 
         super.init(identifier: "Button")
     }
@@ -228,5 +240,9 @@ extension ButtonComponentUIViewModel {
 
     @objc func isEnabledChanged() {
         self.isEnabled.toggle()
+    }
+
+    @objc func isAnimatedChanged() {
+        self.isAnimated.toggle()
     }
 }

--- a/spark/Demo/Classes/View/Components/Switch/UIKit/SwitchComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Switch/UIKit/SwitchComponentUIView.swift
@@ -32,6 +32,9 @@ final class SwitchComponentUIView: ComponentUIView {
 
         // Setup
         self.setupSubscriptions()
+
+        // Delegate
+        self.componentView.delegate = self
     }
 
     required init?(coder: NSCoder) {
@@ -86,12 +89,22 @@ final class SwitchComponentUIView: ComponentUIView {
 
         self.viewModel.$isOn.subscribe(in: &self.cancellables) { [weak self] isOn in
             guard let self = self else { return }
-            self.componentView.isOn = isOn
+
+            if self.viewModel.isOnAnimated {
+                self.componentView.setOn(isOn, animated: true)
+            } else {
+                self.componentView.isOn = isOn
+            }
         }
 
         self.viewModel.$isEnabled.subscribe(in: &self.cancellables) { [weak self] isEnabled in
             guard let self = self else { return }
-            self.componentView.isEnabled = isEnabled
+
+            if self.viewModel.isEnabledAnimated {
+                self.componentView.setEnabled(isEnabled, animated: true)
+            } else {
+                self.componentView.isEnabled = isEnabled
+            }
         }
 
         self.viewModel.$hasImages.subscribe(in: &self.cancellables) { [weak self] hasImages in
@@ -172,5 +185,12 @@ private extension SwitchComponentUIView {
             )
         }
         return switchView
+    }
+}
+
+extension SwitchComponentUIView: SwitchUIViewDelegate {
+
+    func switchDidChange(_ switchView: SparkCore.SwitchUIView, isOn: Bool) {
+        self.viewModel.isOn = isOn
     }
 }

--- a/spark/Demo/Classes/View/Components/Switch/UIKit/SwitchComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Switch/UIKit/SwitchComponentUIViewModel.swift
@@ -86,11 +86,27 @@ final class SwitchComponentUIViewModel: ComponentUIViewModel {
         )
     }()
 
+    lazy var isOnAnimatedConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Is On Animated",
+            type: .toggle(isOn: self.isOnAnimated),
+            target: (source: self, action: #selector(self.isOnAnimatedChanged))
+        )
+    }()
+
     lazy var isEnabledConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
             name: "Is Enabled",
             type: .toggle(isOn: self.isEnabled),
             target: (source: self, action: #selector(self.isEnabledChanged))
+        )
+    }()
+
+    lazy var isEnabledAnimatedConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Is Enabled Animated",
+            type: .toggle(isOn: self.isEnabledAnimated),
+            target: (source: self, action: #selector(self.isEnabledAnimatedChanged))
         )
     }()
 
@@ -111,8 +127,10 @@ final class SwitchComponentUIViewModel: ComponentUIViewModel {
             self.alignmentConfigurationItemViewModel,
             self.contentConfigurationItemViewModel,
             self.isOnConfigurationItemViewModel,
+            self.isOnAnimatedConfigurationItemViewModel,
             self.isEnabledConfigurationItemViewModel,
-            self.hasImagesConfigurationItemViewModel
+            self.isEnabledAnimatedConfigurationItemViewModel,
+            self.hasImagesConfigurationItemViewModel,
         ]
     }
 
@@ -137,7 +155,9 @@ final class SwitchComponentUIViewModel: ComponentUIViewModel {
     @Published var alignment: SwitchAlignment
     @Published var textContent: SwitchTextContentDefault
     @Published var isOn: Bool
+    @Published var isOnAnimated: Bool
     @Published var isEnabled: Bool
+    @Published var isEnabledAnimated: Bool
     @Published var hasImages: Bool
 
     init(
@@ -146,15 +166,20 @@ final class SwitchComponentUIViewModel: ComponentUIViewModel {
         alignment: SwitchAlignment = .left,
         textContent: SwitchTextContentDefault = .text,
         isOn: Bool = true,
+        isOnAnimated: Bool = true,
         isEnabled: Bool = true,
-        hasImages: Bool = false
+        isEnabledAnimated: Bool = true,
+        hasImages: Bool = false,
+        isAnimated: Bool = true
     ) {
         self.theme = theme
         self.intent = intent
         self.alignment = alignment
         self.textContent = textContent
         self.isOn = isOn
+        self.isOnAnimated = isOnAnimated
         self.isEnabled = isEnabled
+        self.isEnabledAnimated = isEnabledAnimated
         self.hasImages = hasImages
         self.attributedText = .init(
             string: self.text,
@@ -188,8 +213,16 @@ extension SwitchComponentUIViewModel {
         self.isOn.toggle()
     }
 
+    @objc func isOnAnimatedChanged() {
+        self.isOnAnimated.toggle()
+    }
+
     @objc func isEnabledChanged() {
         self.isEnabled.toggle()
+    }
+
+    @objc func isEnabledAnimatedChanged() {
+        self.isEnabledAnimated.toggle()
     }
 
     @objc func hasImagesChanged() {


### PR DESCRIPTION
- Create an extension for UIView to manage code with and without animation (same for transition animation)
- Add public property on Button to manage animation.
- Add setOn et setEnabled on the Switch to manage the. The associated variables (isOn and isEnabled) change update the UI without animation (like apple does on UIKit)
- Update demo app to manage this animation (or not) 