### PR TITLE
[Fix] performance improvement by removing layoutIfNeeded

### DIFF
--- a/core/Sources/Components/Icon/View/UIKit/IconUIView.swift
+++ b/core/Sources/Components/Icon/View/UIKit/IconUIView.swift
@@ -54,7 +54,7 @@ public final class IconUIView: UIView {
     }
 
     public override var intrinsicContentSize: CGSize {
-        CGSize(width: size.value, height: size.value)
+        return CGSize(width: self.width, height: self.height)
     }
 
     // MARK: - Private properties
@@ -152,12 +152,12 @@ public final class IconUIView: UIView {
     private func updateIconSize() {
         if self.heightConstraint?.constant != self.height {
             self.heightConstraint?.constant = self.height
-            self.layoutIfNeeded()
+            self.updateConstraintsIfNeeded()
         }
 
         if self.widthConstraint?.constant != self.width {
             self.widthConstraint?.constant = self.width
-            self.layoutIfNeeded()
+            self.updateConstraintsIfNeeded()
         }
     }
 

--- a/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
+++ b/core/Sources/Components/Switch/View/UIKit/SwitchUIView.swift
@@ -483,7 +483,7 @@ public final class SwitchUIView: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
 
-        self.layoutIfNeeded()
+        self.toggleView.layoutIfNeeded()
         self.toggleView.setCornerRadius(self.theme.border.radius.full)
         self.toggleDotView.setCornerRadius(self.theme.border.radius.full)
     }
@@ -659,7 +659,7 @@ public final class SwitchUIView: UIView {
             self.toggleContentTrailingConstraint?.constant = -self.toggleSpacing
             self.toggleContentBottomConstraint?.constant = -self.toggleSpacing
 
-            self.toggleContentStackView.layoutIfNeeded()
+            self.toggleContentStackView.updateConstraintsIfNeeded()
             self.invalidateIntrinsicContentSize()
         }
     }
@@ -680,7 +680,7 @@ public final class SwitchUIView: UIView {
             valueChanged = true
         }
         if valueChanged {
-            self.toggleView.layoutIfNeeded()
+            self.toggleView.updateConstraints()
             self.invalidateIntrinsicContentSize()
         }
     }
@@ -693,7 +693,7 @@ public final class SwitchUIView: UIView {
             self.toggleDotTrailingConstraint?.constant = -self.toggleDotSpacing
             self.toggleDotBottomConstraint?.constant = -self.toggleDotSpacing
 
-            self.toggleDotImageView.layoutIfNeeded()
+            self.toggleDotImageView.updateConstraintsIfNeeded()
             self.invalidateIntrinsicContentSize()
         }
     }

--- a/core/Sources/Components/Tag/View/UIKit/TagUIView.swift
+++ b/core/Sources/Components/Tag/View/UIKit/TagUIView.swift
@@ -290,7 +290,7 @@ public final class TagUIView: UIView {
         // Reload height only if value changed
         if self.height != self.heightConstraint?.constant {
             self.heightConstraint?.constant = self.height
-            self.layoutIfNeeded()
+            self.updateConstraintsIfNeeded()
         }
     }
 
@@ -319,7 +319,7 @@ public final class TagUIView: UIView {
         if contentHorizontalSpacing != self.contentStackViewLeadingConstraint?.constant {
             self.contentStackViewLeadingConstraint?.constant = contentHorizontalSpacing
             self.contentStackViewTrailingConstraint?.constant = -contentHorizontalSpacing
-            self.contentStackView.layoutIfNeeded()
+            self.contentStackView.updateConstraintsIfNeeded()
         }
     }
 


### PR DESCRIPTION
- Replace layoutIfNeeded to updateConstraintsIfNeeded when the updated value is a constraints
- Move the layoutIfNeeded to the mandatory child view and not the parent