### PR TITLE
[Rating#589] Single star view

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spark-ios-snapshots"]
-	path = spark-ios-snapshots
-	url = git@github.com:adevinta/spark-ios-snapshots.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spark-ios-snapshots"]
+	path = spark-ios-snapshots
+	url = git@github.com:adevinta/spark-ios-snapshots.git

--- a/core/Sources/Components/Rating/Cache/CGLayerCache.swift
+++ b/core/Sources/Components/Rating/Cache/CGLayerCache.swift
@@ -1,0 +1,29 @@
+//
+//  CGLayerCache.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+// sourcery: AutoMockable
+protocol CGLayerCaching {
+    func object(forKey: NSString) -> CGLayer?
+    func setObject(_ layer: CGLayer, forKey: NSString)
+}
+
+/// A simple facade for a static NSCache
+final class CGLayerCache: CGLayerCaching {
+    private static var cache = NSCache<NSString, CGLayer>()
+
+    func object(forKey key: NSString) -> CGLayer? {
+        return Self.cache.object(forKey: key)
+    }
+    
+    func setObject(_ layer: CGLayer, forKey key: NSString) {
+        Self.cache.setObject(layer, forKey: key)
+    }
+}

--- a/core/Sources/Components/Rating/Enum/StarFillMode.swift
+++ b/core/Sources/Components/Rating/Enum/StarFillMode.swift
@@ -1,0 +1,42 @@
+//
+//  StarFillMode.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 07.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+public enum StarFillMode {
+    case full
+    case half
+    case fraction(_ :CGFloat)
+    case exact
+
+    public func rating(of givenValue: CGFloat) -> CGFloat {
+        if givenValue > 1 {
+            return 1.0
+        } else if givenValue <= 0 {
+            return 0.0
+        }
+
+        switch self {
+        case .full: return givenValue.rounded()
+        case .half: return givenValue.halfRounded()
+        case let .fraction(value): return givenValue.rounded(by: value)
+        case .exact: return givenValue
+        }
+    }
+}
+
+private extension CGFloat {
+    func rounded(by fraction: CGFloat) -> CGFloat {
+        return (self * fraction).rounded() / fraction
+    }
+    func halfRounded() -> CGFloat {
+        return self.rounded(by: 2.0)
+    }
+}
+
+

--- a/core/Sources/Components/Rating/Enum/StarFillMode.swift
+++ b/core/Sources/Components/Rating/Enum/StarFillMode.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@frozen
 public enum StarFillMode {
     case full
     case half

--- a/core/Sources/Components/Rating/Enum/StarFillMode.swift
+++ b/core/Sources/Components/Rating/Enum/StarFillMode.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+/// The star fill mode determins how the star is to be filled
+/// - full: the rating will be rounded to the next full number 0/1 and can be only empty or filled.
+/// - half: the raing will be rounded to the next half number and can either be empty, half filled and filled.
+/// - fraction: The fill rate will be the rating rounded to the neares fraction, e.g. half is fraction 2.
+/// - exact: The star will be filled with the exact rating value
 @frozen
 public enum StarFillMode {
     case full
@@ -15,6 +20,9 @@ public enum StarFillMode {
     case fraction(_ :CGFloat)
     case exact
 
+    // MARK: - Public functions
+    /// function rating
+    /// Calculate the rounded rating
     public func rating(of givenValue: CGFloat) -> CGFloat {
         if givenValue > 1 {
             return 1.0
@@ -25,12 +33,13 @@ public enum StarFillMode {
         switch self {
         case .full: return givenValue.rounded()
         case .half: return givenValue.halfRounded()
-        case let .fraction(value): return givenValue.rounded(by: value)
+        case let .fraction(fraction): return givenValue.rounded(by: fraction)
         case .exact: return givenValue
         }
     }
 }
 
+// MARK: - Private helpers
 private extension CGFloat {
     func rounded(by fraction: CGFloat) -> CGFloat {
         return (self * fraction).rounded() / fraction
@@ -39,5 +48,3 @@ private extension CGFloat {
         return self.rounded(by: 2.0)
     }
 }
-
-

--- a/core/Sources/Components/Rating/Enum/StarFillModeUnitTests.swift
+++ b/core/Sources/Components/Rating/Enum/StarFillModeUnitTests.swift
@@ -1,0 +1,46 @@
+//
+//  StarFillModeUnitTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+@testable import SparkCore
+
+final class StarFillModeUnitTests: XCTestCase {
+
+    func test_full_with_half_rating() {
+        XCTAssertEqual(StarFillMode.full.rating(of: 0.5), 1.0)
+    }
+
+    func test_full_with_less_than_half_rating() {
+        XCTAssertEqual(StarFillMode.full.rating(of: 0.49), 0.0)
+    }
+
+    func test_half_with_half_rating() {
+        XCTAssertEqual(StarFillMode.half.rating(of: 0.6), 0.5)
+    }
+
+    func test_half_with_big_rating() {
+        XCTAssertEqual(StarFillMode.half.rating(of: 0.75), 1.0)
+    }
+
+    func test_half_with_small_rating() {
+        XCTAssertEqual(StarFillMode.half.rating(of: 0.2), 0.0)
+    }
+
+    func test_exact_rating() {
+        XCTAssertEqual(StarFillMode.exact.rating(of: 0.211), 0.211)
+    }
+
+    func test_fraction_rating_round_down() {
+        XCTAssertEqual(StarFillMode.fraction(10).rating(of: 0.1111), 0.1)
+    }
+
+    func test_fraction_rating_round_up() {
+        XCTAssertEqual(StarFillMode.fraction(10).rating(of: 0.15), 0.2)
+    }
+}

--- a/core/Sources/Components/Rating/Graphics/ShapeLayer.swift
+++ b/core/Sources/Components/Rating/Graphics/ShapeLayer.swift
@@ -1,0 +1,81 @@
+//
+//  ShapeLayer.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class ShapeLayer {
+    private let shape: CGPathShape
+    private let fillColor: CGColor
+    private let strokeColor: CGColor
+    private let fillPercentage: CGFloat
+    private let strokeWidth: CGFloat
+
+    init(shape: CGPathShape, fillColor: CGColor, strokeColor: CGColor, fillPercentage: CGFloat, strokeWidth: CGFloat) {
+        self.shape = shape
+        self.fillColor = fillColor
+        self.strokeColor = strokeColor
+        self.fillPercentage = fillPercentage
+        self.strokeWidth = strokeWidth
+    }
+
+    func layer(graphicsContext: CGContext, size: CGSize) -> CGLayer {
+        guard let starLayer = CGLayer(graphicsContext, size: size, auxiliaryInfo: nil) else {
+            fatalError("Couldn't create layer")
+        }
+
+        guard let context = starLayer.context else {
+            fatalError("Couldn't create layer")
+        }
+
+        self.drawShape(graphicsContext: context, size: size)
+        return starLayer
+    }
+
+    private func drawShape(graphicsContext: CGContext, size: CGSize) {
+        let rect = CGRect(origin: .zero, size: size)
+        let path = self.shape.cgPath(rect: rect)
+
+        graphicsContext.saveGState()
+
+        graphicsContext.clip(to: rect)
+        graphicsContext.addPath(path)
+        graphicsContext.setLineWidth(self.strokeWidth)
+        graphicsContext.setStrokeColor(self.strokeColor)
+        graphicsContext.drawPath(using: .stroke)
+
+        let insets = self.shape.insets.withHorizontalPadding(self.strokeWidth/2.0)
+        let maskWidth = CGFloat((insets.right - insets.left) * fillPercentage)
+
+        let maskHeight = rect.height
+
+        let clipRect = CGRect(
+            x: insets.left,
+            y: 0,
+            width: maskWidth,
+            height: maskHeight
+        )
+        graphicsContext.clip(to: clipRect)
+        graphicsContext.addPath(path)
+        graphicsContext.setFillColor(self.fillColor)
+        graphicsContext.drawPath(using: .fill)
+
+        graphicsContext.addPath(path)
+        graphicsContext.setStrokeColor(self.fillColor)
+        graphicsContext.setLineWidth(self.strokeWidth)
+        graphicsContext.drawPath(using: .stroke)
+
+        graphicsContext.restoreGState()
+    }
+}
+
+private extension UIEdgeInsets {
+    func withHorizontalPadding(_ padding: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: self.top, left: self.left - padding, bottom: self.bottom, right: self.right + padding)
+    }
+}

--- a/core/Sources/Components/Rating/Graphics/ShapeLayer.swift
+++ b/core/Sources/Components/Rating/Graphics/ShapeLayer.swift
@@ -9,14 +9,21 @@
 import Foundation
 import UIKit
 
-class ShapeLayer {
+/// The Shape Layer draws a shape onto a layer and returns the CGLayer.
+final class ShapeLayer {
+    // MARK: - Private variables
     private let shape: CGPathShape
     private let fillColor: CGColor
     private let strokeColor: CGColor
     private let fillPercentage: CGFloat
     private let strokeWidth: CGFloat
 
-    init(shape: CGPathShape, fillColor: CGColor, strokeColor: CGColor, fillPercentage: CGFloat, strokeWidth: CGFloat) {
+    // MARK: - Initializer
+    init(shape: CGPathShape,
+         fillColor: CGColor,
+         strokeColor: CGColor,
+         fillPercentage: CGFloat,
+         strokeWidth: CGFloat) {
         self.shape = shape
         self.fillColor = fillColor
         self.strokeColor = strokeColor
@@ -24,6 +31,7 @@ class ShapeLayer {
         self.strokeWidth = strokeWidth
     }
 
+    /// Create a CGLayer and draw the shape on it.
     func layer(graphicsContext: CGContext, size: CGSize) -> CGLayer {
         guard let starLayer = CGLayer(graphicsContext, size: size, auxiliaryInfo: nil) else {
             fatalError("Couldn't create layer")
@@ -37,6 +45,7 @@ class ShapeLayer {
         return starLayer
     }
 
+    // MARK: - Private
     private func drawShape(graphicsContext: CGContext, size: CGSize) {
         let rect = CGRect(origin: .zero, size: size)
         let path = self.shape.cgPath(rect: rect)
@@ -74,6 +83,7 @@ class ShapeLayer {
     }
 }
 
+// MARK: Private extensions
 private extension UIEdgeInsets {
     func withHorizontalPadding(_ padding: CGFloat) -> UIEdgeInsets {
         return UIEdgeInsets(top: self.top, left: self.left - padding, bottom: self.bottom, right: self.right + padding)

--- a/core/Sources/Components/Rating/Graphics/Star.swift
+++ b/core/Sources/Components/Rating/Graphics/Star.swift
@@ -14,27 +14,34 @@ protocol CGPathShape {
     var insets: UIEdgeInsets { get }
 }
 
-class Star: CGPathShape {
-    private let numberOfPoints: Int
+/// A star shape to calculate the CGPath of a star.
+final class Star: CGPathShape {
+
+    // MARK: - Private variables
+    private let numberOfVertices: Int
     private let vertexSize: CGFloat
     private let cornerRadiusSize: CGFloat
+
+    /// the outermost points of the star.
     var insets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
 
-    init(numberOfPoints: Int,
-         vertexSize: CGFloat = 0.2,
-         cornerRadiusSize: CGFloat = 10.0) {
-        self.numberOfPoints = numberOfPoints
+    // MARK: - Initializer
+    init(numberOfVertices: Int,
+         vertexSize: CGFloat,
+         cornerRadiusSize: CGFloat) {
+        self.numberOfVertices = numberOfVertices
         self.vertexSize = vertexSize
         self.cornerRadiusSize = cornerRadiusSize
     }
 
+    /// Return the CGPath of the star.
     func cgPath(rect: CGRect) -> CGPath {
         let path = CGMutablePath()
 
         self.insets = UIEdgeInsets(top: rect.minY, left: rect.minX, bottom: rect.maxY, right: rect.maxX)
 
         // the size of each angle step
-        let angleStep = ((.pi * 2)  / CGFloat(self.numberOfPoints))
+        let angleStep = ((.pi * 2)  / CGFloat(self.numberOfVertices))
 
         let initialOffset: CGFloat = -.pi/2
 
@@ -47,7 +54,7 @@ class Star: CGPathShape {
         let radius = fullRadius - cornerRadius
 
         // calculate offset to make star look centered vertically
-        let lowestVertex: Int = self.numberOfPoints / 2
+        let lowestVertex: Int = self.numberOfVertices / 2
         let lowestPoint = CGPoint(
             x: centerPoint.x + radius * cos(angleStep * CGFloat(lowestVertex) + initialOffset),
             y: centerPoint.y + radius * sin(angleStep * CGFloat(lowestVertex) + initialOffset)
@@ -72,7 +79,7 @@ class Star: CGPathShape {
         let arcAngle = cornerRadius / radius
 
         // draw the star
-        for i in 1...self.numberOfPoints {
+        for i in 1...self.numberOfVertices {
             let outerPoint1 = CGPoint(
                 x: centerPoint.x + (radius + cornerRadius) * cos(angle - arcAngle/2),
                 y: centerPoint.y + (radius + cornerRadius) * sin(angle - arcAngle/2)
@@ -127,6 +134,7 @@ class Star: CGPathShape {
     }
 }
 
+// MARK: - Private functions
 private func smallest(_ lh: CGFloat, _ rh: CGFloat) -> CGFloat {
     return lh < rh ? lh : rh
 }

--- a/core/Sources/Components/Rating/Graphics/Star.swift
+++ b/core/Sources/Components/Rating/Graphics/Star.swift
@@ -1,0 +1,136 @@
+//
+//  Star.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+protocol CGPathShape {
+    func cgPath(rect: CGRect) -> CGPath
+    var insets: UIEdgeInsets { get }
+}
+
+class Star: CGPathShape {
+    private let numberOfPoints: Int
+    private let vertexSize: CGFloat
+    private let cornerRadiusSize: CGFloat
+    var insets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+
+    init(numberOfPoints: Int,
+         vertexSize: CGFloat = 0.2,
+         cornerRadiusSize: CGFloat = 10.0) {
+        self.numberOfPoints = numberOfPoints
+        self.vertexSize = vertexSize
+        self.cornerRadiusSize = cornerRadiusSize
+    }
+
+    func cgPath(rect: CGRect) -> CGPath {
+        let path = CGMutablePath()
+
+        self.insets = UIEdgeInsets(top: rect.minY, left: rect.minX, bottom: rect.maxY, right: rect.maxX)
+
+        // the size of each angle step
+        let angleStep = ((.pi * 2)  / CGFloat(self.numberOfPoints))
+
+        let initialOffset: CGFloat = -.pi/2
+
+        // the start angle, the first star vertex is to start at the top, therefore the -90° rotation.
+        var angle: CGFloat = angleStep + initialOffset
+
+        var centerPoint = CGPoint(x: rect.midX, y: rect.midY)
+        let fullRadius = (min(rect.width, rect.height)/2)
+        let cornerRadius = self.cornerRadiusSize * fullRadius
+        let radius = fullRadius - cornerRadius
+
+        // calculate offset to make star look centered vertically
+        let lowestVertex: Int = self.numberOfPoints / 2
+        let lowestPoint = CGPoint(
+            x: centerPoint.x + radius * cos(angleStep * CGFloat(lowestVertex) + initialOffset),
+            y: centerPoint.y + radius * sin(angleStep * CGFloat(lowestVertex) + initialOffset)
+        )
+        let highestPoint = CGPoint(
+            x: centerPoint.x + radius * cos(initialOffset),
+            y: centerPoint.y + radius * sin(initialOffset)
+        )
+
+        insets.top = highestPoint.y
+        insets.bottom = lowestPoint.y
+        insets.left = rect.maxX
+        insets.right = rect.minX
+
+        let diff = (rect.maxY - highestPoint.y - lowestPoint.y) / 2
+
+        // modify centerpoint to make star look symmetric
+        centerPoint = CGPoint(
+            x: centerPoint.x,
+            y: centerPoint.y + diff)
+
+        let arcAngle = cornerRadius / radius
+
+        // draw the star
+        for i in 1...self.numberOfPoints {
+            let outerPoint1 = CGPoint(
+                x: centerPoint.x + (radius + cornerRadius) * cos(angle - arcAngle/2),
+                y: centerPoint.y + (radius + cornerRadius) * sin(angle - arcAngle/2)
+            )
+
+            let outerPoint2 = CGPoint(
+                x: centerPoint.x + (radius + cornerRadius) * cos(angle + arcAngle/2),
+                y: centerPoint.y + (radius + cornerRadius) * sin(angle + arcAngle/2)
+            )
+
+            let tangentPoint = CGPoint(
+                x: centerPoint.x + radius * cos(angle - arcAngle),
+                y: centerPoint.y + radius * sin(angle - arcAngle)
+            )
+
+            let nextTangentPoint = CGPoint(
+                x: centerPoint.x + radius * cos(angle + arcAngle),
+                y: centerPoint.y + radius * sin(angle + arcAngle)
+            )
+
+            let innerPoint = CGPoint(
+                x: centerPoint.x + (radius * self.vertexSize) * cos(angle + angleStep/2),
+                y: centerPoint.y + (radius * self.vertexSize) * sin(angle + angleStep/2)
+            )
+
+            if i == 1 {
+                path.move(to: tangentPoint)
+            } else {
+                path.addLine(to: tangentPoint)
+            }
+
+            path.addCurve(to: nextTangentPoint, control1: outerPoint1, control2: outerPoint2)
+
+            self.insets.left = [
+                self.insets.left,
+                nextTangentPoint.x,
+                outerPoint1.x,
+                outerPoint2.x].reduce(rect.maxX, smallest)
+            self.insets.right = [
+                self.insets.right,
+                nextTangentPoint.x,
+                outerPoint1.x,
+                outerPoint2.x].reduce(rect.minX, greatest)
+
+            path.addLine(to: innerPoint)
+
+            angle += angleStep
+        }
+        path.closeSubpath()
+
+        return path
+    }
+}
+
+private func smallest(_ lh: CGFloat, _ rh: CGFloat) -> CGFloat {
+    return lh < rh ? lh : rh
+}
+
+private func greatest(_ lh: CGFloat, _ rh: CGFloat) -> CGFloat {
+    return lh > rh ? lh : rh
+}

--- a/core/Sources/Components/Rating/Model/StarConfiguration.swift
+++ b/core/Sources/Components/Rating/Model/StarConfiguration.swift
@@ -1,0 +1,36 @@
+//
+//  StarConfiguration.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+public struct StarConfiguration: Equatable {
+    public var numberOfVertices: Int
+    public var vertexSize: CGFloat
+    public var cornerRadiusSize: CGFloat
+
+    // MARK: - Default values
+    public enum Defaults {
+        public static let numberOfVertices = 5
+        public static let vertexSize = CGFloat(0.65)
+        public static let cornerRadiusSize = CGFloat(0.15)
+    }
+    
+    public static let `default` = StarConfiguration(
+        numberOfVertices: Defaults.numberOfVertices,
+        vertexSize: Defaults.vertexSize,
+        cornerRadiusSize: Defaults.cornerRadiusSize)
+    
+    public init(numberOfVertices: Int,
+         vertexSize: CGFloat,
+         cornerRadiusSize: CGFloat) {
+        self.numberOfVertices = numberOfVertices
+        self.vertexSize = vertexSize
+        self.cornerRadiusSize = cornerRadiusSize
+    }
+    
+}

--- a/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
@@ -22,12 +22,9 @@ public final class StarUIView: UIView {
 
     // MARK: - Default values
     public enum Defaults {
-        public static let numberOfVertices = 5
         public static let fillMode = StarFillMode.half
         public static let rating = CGFloat(0.0)
         public static let lineWidth = CGFloat(2.0)
-        public static let vertexSize = CGFloat(0.65)
-        public static let cornerRadiusSize = CGFloat(0.15)
         public static let fillColor = UIColor.yellow
         public static let borderColor = UIColor.lightGray
     }
@@ -35,10 +32,36 @@ public final class StarUIView: UIView {
     // MARK: - Public variables
     /// The number of vertices the star has
     public var numberOfVertices: Int {
-        didSet {
-            self.setNeedsDisplay()
+        get {
+            return self.configuration.numberOfVertices
+        }
+        set {
+            self.configuration.numberOfVertices = newValue
         }
     }
+    
+    /// The vertex size determins how deep the inner angle of the star is.
+    /// This value is a percentage of the radius and should be in the range [0...1].
+    public var vertexSize: CGFloat {
+        get {
+            return self.configuration.vertexSize
+        }
+        set {
+            self.configuration.vertexSize = newValue
+        }
+    }
+
+    /// The cornerRadiusSize is a proportional value
+    /// This value is a percentage of the radius and should be in the range [0...1].
+    public var cornerRadiusSize: CGFloat {
+        get {
+            return self.configuration.cornerRadiusSize
+        }
+        set {
+            self.configuration.cornerRadiusSize = newValue
+        }
+    }
+
 
     /// The fill mode.
     /// The fill mode determines how to round the rating value to fill the star.
@@ -64,22 +87,6 @@ public final class StarUIView: UIView {
         }
     }
 
-    /// The vertex size determins how deep the inner angle of the star is.
-    /// This value is a percentage of the radius and should be in the range [0...1].
-    public var vertexSize: CGFloat {
-        didSet {
-            self.setNeedsDisplay()
-        }
-    }
-
-    /// The cornerRadiusSize is a proportional value
-    /// This value is a percentage of the radius and should be in the range [0...1].
-    public var cornerRadiusSize: CGFloat {
-        didSet {
-            self.setNeedsDisplay()
-        }
-    }
-
     /// The borderColor defines the color of the unfilled portion of the star.
     public var borderColor: UIColor {
         didSet {
@@ -90,6 +97,13 @@ public final class StarUIView: UIView {
     /// The fillColor defines the color of the filled portion of the star.
     public var fillColor: UIColor {
         didSet {
+            self.setNeedsDisplay()
+        }
+    }
+    
+    public var configuration: StarConfiguration {
+        didSet {
+            guard self.configuration != oldValue else { return }
             self.setNeedsDisplay()
         }
     }
@@ -123,44 +137,36 @@ public final class StarUIView: UIView {
     /// - borderColor: The color of the border of the unfilled part of the star.
     /// - fillColor: The color of the filled part of the star.
     public convenience init(
-        numberOfVertices: Int = Defaults.numberOfVertices,
         rating: CGFloat = Defaults.rating,
         fillMode: StarFillMode = .half,
         lineWidth: CGFloat = Defaults.lineWidth,
-        vertexSize: CGFloat = Defaults.vertexSize,
-        cornerRadiusSize: CGFloat = Defaults.cornerRadiusSize,
         borderColor: UIColor = Defaults.borderColor,
-        fillColor: UIColor = Defaults.fillColor
+        fillColor: UIColor = Defaults.fillColor,
+        configuration: StarConfiguration = .default
     ) {
         self.init(
-            numberOfVertices: numberOfVertices,
             rating: rating,
             fillMode: fillMode,
             lineWidth: lineWidth,
-            vertexSize: vertexSize,
-            cornerRadiusSize: cornerRadiusSize,
             borderColor: borderColor,
             fillColor: fillColor,
+            configuration: configuration,
             cache: CGLayerCache())
     }
 
     init(
-        numberOfVertices: Int,
         rating: CGFloat,
         fillMode: StarFillMode,
         lineWidth: CGFloat,
-        vertexSize: CGFloat,
-        cornerRadiusSize: CGFloat,
         borderColor: UIColor,
         fillColor: UIColor,
+        configuration: StarConfiguration,
         cache: CGLayerCaching
     ) {
         self.fillMode = fillMode
         self.rating = rating
         self.lineWidth = lineWidth
-        self.numberOfVertices = numberOfVertices
-        self.vertexSize = vertexSize
-        self.cornerRadiusSize = cornerRadiusSize
+        self.configuration = configuration
         self.borderColor = borderColor
         self.fillColor = fillColor
         self.cache = cache

--- a/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
@@ -1,0 +1,188 @@
+//
+//  StarUIView.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 06.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+//: A UIKit based Playground for presenting user interface
+
+import UIKit
+
+public class StarUIView: UIView {
+
+    // MARK: - Default values
+    public enum Defaults {
+        public static let numberOfPoints = 5
+        public static let fillMode = StarFillMode.half
+        public static let rating = CGFloat(0.0)
+        public static let lineWidth = CGFloat(2.0)
+        public static let vertexSize = CGFloat(0.75)
+        public static let cornerRadiusSize = CGFloat(0.125)
+        public static let fillColor = UIColor.yellow
+        public static let borderColor = UIColor.lightGray
+    }
+
+    // MARK: - Public variables
+    public var numberOfPoints: Int {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var fillMode: StarFillMode {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var rating: CGFloat {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var lineWidth: CGFloat {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var vertexSize: CGFloat {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var cornerRadiusSize: CGFloat {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var borderColor: UIColor {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var fillColor: UIColor {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var isCachingEnabled = true
+
+    // MARK: - Private variables
+    private static var cache = NSCache<NSString, CGLayer>()
+    private var normalizedRating: CGFloat {
+        return self.fillMode.rating(of: self.rating)
+    }
+
+    // MARK: - Initializer
+    public init(
+        numberOfPoints: Int = Defaults.numberOfPoints,
+        rating: CGFloat = Defaults.rating,
+        fillMode: StarFillMode = .half,
+        lineWidth: CGFloat = Defaults.lineWidth,
+        vertexSize: CGFloat = Defaults.vertexSize,
+        cornerRadiusSize: CGFloat = Defaults.cornerRadiusSize,
+        borderColor: UIColor = Defaults.borderColor,
+        fillColor: UIColor = Defaults.fillColor
+    ) {
+        self.fillMode = fillMode
+        self.rating = rating
+        self.lineWidth = lineWidth
+        self.numberOfPoints = numberOfPoints
+        self.vertexSize = vertexSize
+        self.cornerRadiusSize = cornerRadiusSize
+        self.borderColor = borderColor
+        self.fillColor = fillColor
+
+        super.init(frame: .zero)
+        self.backgroundColor = .clear
+    }
+
+    override init(frame: CGRect) {
+        self.fillMode = Defaults.fillMode
+        self.rating = Defaults.rating
+        self.lineWidth = Defaults.lineWidth
+        self.numberOfPoints = Defaults.numberOfPoints
+        self.vertexSize = Defaults.vertexSize
+        self.cornerRadiusSize = Defaults.cornerRadiusSize
+        self.borderColor = Defaults.borderColor
+        self.fillColor = Defaults.fillColor
+
+        super.init(frame: frame)
+        self.backgroundColor = .clear
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func draw(_ rect: CGRect) {
+        guard let ctx = UIGraphicsGetCurrentContext() else {
+            super.draw(rect)
+            return
+        }
+        self.drawLayer(context: ctx, rect: rect)
+    }
+
+    // MARK: - Private functions
+    private func drawLayer(context: CGContext, rect: CGRect) {
+
+        let star = Star(
+            numberOfPoints: self.numberOfPoints,
+            vertexSize: self.vertexSize,
+            cornerRadiusSize: self.cornerRadiusSize
+        )
+
+        context.saveGState()
+
+        let cacheKey = self.cacheKey(rect: rect)
+
+        let starLayer: CGLayer
+        if self.isCachingEnabled, let layer = Self.cache.object(forKey: cacheKey) {
+            starLayer = layer
+        } else {
+            let shapeLayer = ShapeLayer(
+                shape: star,
+                fillColor: self.fillColor.cgColor,
+                strokeColor: self.borderColor.cgColor,
+                fillPercentage: self.normalizedRating,
+                strokeWidth: self.lineWidth)
+
+            starLayer = shapeLayer.layer(graphicsContext: context, size: rect.size)
+            if self.isCachingEnabled {
+                Self.cache.setObject(starLayer, forKey: self.cacheKey(rect: rect))
+            }
+        }
+
+        context.draw(starLayer, in: rect)
+        context.restoreGState()
+    }
+
+    internal func cacheKey(rect: CGRect) -> NSString {
+        let key = [Self.self, self.numberOfPoints, self.rating, self.lineWidth, self.vertexSize, self.cornerRadiusSize, self.borderColor.hashValue, self.fillColor.hashValue, rect.width, rect.height
+        ].map{ "\($0)" }
+            .joined(separator: "_")
+        return NSString(string: key)
+    }
+}
+
+
+private extension CGRect {
+    var centerX: CGFloat {
+        return (self.minX + self.maxX)/2
+    }
+
+    var centerY: CGFloat {
+        return (self.minY + self.maxY)/2
+    }
+
+    var center: CGPoint {
+        return CGPoint(x: self.centerX, y: self.centerY)
+    }
+}

--- a/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
@@ -72,6 +72,12 @@ public class StarUIView: UIView {
         }
     }
 
+    public override var bounds: CGRect {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
     public var isCachingEnabled = true
 
     // MARK: - Private variables
@@ -101,20 +107,6 @@ public class StarUIView: UIView {
         self.fillColor = fillColor
 
         super.init(frame: .zero)
-        self.backgroundColor = .clear
-    }
-
-    override init(frame: CGRect) {
-        self.fillMode = Defaults.fillMode
-        self.rating = Defaults.rating
-        self.lineWidth = Defaults.lineWidth
-        self.numberOfPoints = Defaults.numberOfPoints
-        self.vertexSize = Defaults.vertexSize
-        self.cornerRadiusSize = Defaults.cornerRadiusSize
-        self.borderColor = Defaults.borderColor
-        self.fillColor = Defaults.fillColor
-
-        super.init(frame: frame)
         self.backgroundColor = .clear
     }
 
@@ -165,13 +157,20 @@ public class StarUIView: UIView {
     }
 
     internal func cacheKey(rect: CGRect) -> NSString {
-        let key = [Self.self, self.numberOfPoints, self.rating, self.lineWidth, self.vertexSize, self.cornerRadiusSize, self.borderColor.hashValue, self.fillColor.hashValue, rect.width, rect.height
+        let key = [Self.self, 
+                   self.numberOfPoints,
+                   self.normalizedRating,
+                   self.lineWidth,
+                   self.vertexSize,
+                   self.cornerRadiusSize,
+                   self.borderColor.hashValue,
+                   self.fillColor.hashValue,
+                   min(rect.width, rect.height),
         ].map{ "\($0)" }
             .joined(separator: "_")
         return NSString(string: key)
     }
 }
-
 
 private extension CGRect {
     var centerX: CGFloat {

--- a/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
@@ -9,76 +9,101 @@
 
 import UIKit
 
-public class StarUIView: UIView {
+/// StarUIView
+/// Render a star.
+/// The star may be configured by various attributes:
+/// - number of vertices
+/// - corner radius
+/// - vertex size
+/// - border color
+/// - fill color
+///
+public final class StarUIView: UIView {
 
     // MARK: - Default values
     public enum Defaults {
-        public static let numberOfPoints = 5
+        public static let numberOfVertices = 5
         public static let fillMode = StarFillMode.half
         public static let rating = CGFloat(0.0)
         public static let lineWidth = CGFloat(2.0)
-        public static let vertexSize = CGFloat(0.75)
-        public static let cornerRadiusSize = CGFloat(0.125)
+        public static let vertexSize = CGFloat(0.65)
+        public static let cornerRadiusSize = CGFloat(0.15)
         public static let fillColor = UIColor.yellow
         public static let borderColor = UIColor.lightGray
     }
 
     // MARK: - Public variables
-    public var numberOfPoints: Int {
+    /// The number of vertices the star has
+    public var numberOfVertices: Int {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// The fill mode.
+    /// The fill mode determines how to round the rating value to fill the star.
     public var fillMode: StarFillMode {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// The rating.
+    /// The ration should be a value between 0...1. Any number greater than 1 will be taken as a full star. Any number smaller than 0 will be treated as 0.
     public var rating: CGFloat {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// The line width.
+    /// The width of the border of the non filled star.
     public var lineWidth: CGFloat {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+
+    /// The vertex size determins how deep the inner angle of the star is.
+    /// This value is a percentage of the radius and should be in the range [0...1].
     public var vertexSize: CGFloat {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// The cornerRadiusSize is a proportional value
+    /// This value is a percentage of the radius and should be in the range [0...1].
     public var cornerRadiusSize: CGFloat {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// The borderColor defines the color of the unfilled portion of the star.
     public var borderColor: UIColor {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// The fillColor defines the color of the filled portion of the star.
     public var fillColor: UIColor {
         didSet {
             self.setNeedsDisplay()
         }
     }
 
+    /// IsCachingEnabled.
+    /// Calculated stars will be cached for performance reasons. This may be disabled and the star will be calculated everytime when a redraw is required.
+    public var isCachingEnabled = true
+
     public override var bounds: CGRect {
         didSet {
             self.setNeedsDisplay()
         }
     }
-
-    public var isCachingEnabled = true
 
     // MARK: - Private variables
     private static var cache = NSCache<NSString, CGLayer>()
@@ -87,8 +112,18 @@ public class StarUIView: UIView {
     }
 
     // MARK: - Initializer
+    /// Initializer
+    /// Parameters:
+    /// - numberOfVertices: number of vertex elements, the default is 5
+    /// - rating: the value of the rating. This should be a number in the range [0...1]
+    /// - fillMode: the fill mode of the start. The star will be filled according to the rating and the fillMode.
+    /// - lineWidth: the width of the outer border.
+    /// - vertexSize: this is the proportional length of the vertex according to the radius and should be in the range [0..1].
+    /// - cornerRadiusSize: this is a proportional size of the corner radius according to the radius and should be in the range [0...1].
+    /// - borderColor: The color of the border of the unfilled part of the star.
+    /// - fillColor: The color of the filled part of the star.
     public init(
-        numberOfPoints: Int = Defaults.numberOfPoints,
+        numberOfVertices: Int = Defaults.numberOfVertices,
         rating: CGFloat = Defaults.rating,
         fillMode: StarFillMode = .half,
         lineWidth: CGFloat = Defaults.lineWidth,
@@ -100,7 +135,7 @@ public class StarUIView: UIView {
         self.fillMode = fillMode
         self.rating = rating
         self.lineWidth = lineWidth
-        self.numberOfPoints = numberOfPoints
+        self.numberOfVertices = numberOfVertices
         self.vertexSize = vertexSize
         self.cornerRadiusSize = cornerRadiusSize
         self.borderColor = borderColor
@@ -126,7 +161,7 @@ public class StarUIView: UIView {
     private func drawLayer(context: CGContext, rect: CGRect) {
 
         let star = Star(
-            numberOfPoints: self.numberOfPoints,
+            numberOfVertices: self.numberOfVertices,
             vertexSize: self.vertexSize,
             cornerRadiusSize: self.cornerRadiusSize
         )
@@ -158,7 +193,7 @@ public class StarUIView: UIView {
 
     internal func cacheKey(rect: CGRect) -> NSString {
         let key = [Self.self, 
-                   self.numberOfPoints,
+                   self.numberOfVertices,
                    self.normalizedRating,
                    self.lineWidth,
                    self.vertexSize,

--- a/core/Sources/Components/Rating/View/UIKit/StarUIViewTests.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIViewTests.swift
@@ -1,0 +1,39 @@
+//
+//  StarUIViewTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+@testable import SparkCore
+
+final class StarUIViewTests: XCTestCase {
+
+    var cache: CGLayerCachingGeneratedMock!
+    var sut: StarUIView!
+
+    override func setUp() {
+        super.setUp()
+        self.cache = CGLayerCachingGeneratedMock()
+        self.sut = StarUIView(
+            numberOfVertices: 6,
+            rating: 0.4,
+            fillMode: .full,
+            lineWidth: 2,
+            vertexSize: 0.5,
+            cornerRadiusSize: 0.12,
+            borderColor: .red,
+            fillColor: .blue,
+            cache: self.cache)
+    }
+
+    func test_cache_name() throws {
+        // When
+        let key = sut.cacheKey(rect: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+        XCTAssertEqual(key, "StarUIView_6_0.0_2.0_0.5_0.12_144048128_917504_100.0")
+    }
+}

--- a/core/Sources/Components/Rating/View/UIKit/StarUIViewTests.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIViewTests.swift
@@ -19,14 +19,12 @@ final class StarUIViewTests: XCTestCase {
         super.setUp()
         self.cache = CGLayerCachingGeneratedMock()
         self.sut = StarUIView(
-            numberOfVertices: 6,
             rating: 0.4,
             fillMode: .full,
             lineWidth: 2,
-            vertexSize: 0.5,
-            cornerRadiusSize: 0.12,
             borderColor: .red,
             fillColor: .blue,
+            configuration: .init(numberOfVertices: 6, vertexSize: 0.5, cornerRadiusSize: 0.12),
             cache: self.cache)
     }
 

--- a/spark/Demo/Classes/View/Components/ComponentsViewController.swift
+++ b/spark/Demo/Classes/View/Components/ComponentsViewController.swift
@@ -83,7 +83,9 @@ extension ComponentsViewController {
         case .icon:
             viewController = IconComponentUIViewController.build()
         case .radioButton:
-            viewController = RadioButtonComponentUIViewController.build()
+            viewController = RadioButtonUIGroupViewController()
+        case .ratingStar:
+            viewController = StarComponentViewController.build()
         case .spinner:
             viewController = SpinnerComponentUIViewController.build()
         case .switchButton:
@@ -112,6 +114,7 @@ private extension ComponentsViewController {
         case chip
         case icon
         case radioButton
+        case ratingStar
         case spinner
         case switchButton
         case tab

--- a/spark/Demo/Classes/View/Components/ComponentsViewController.swift
+++ b/spark/Demo/Classes/View/Components/ComponentsViewController.swift
@@ -83,7 +83,7 @@ extension ComponentsViewController {
         case .icon:
             viewController = IconComponentUIViewController.build()
         case .radioButton:
-            viewController = RadioButtonUIGroupViewController()
+            viewController = RadioButtonComponentUIViewController.build()
         case .ratingStar:
             viewController = StarComponentViewController.build()
         case .spinner:

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIView.swift
@@ -42,7 +42,7 @@ final class StarComponentUIView: ComponentUIView {
 
     private static func makeStarView(viewModel: StarComponentUIViewModel) -> StarUIView {
         let view = StarUIView(
-            numberOfPoints: viewModel.numberOfPoints,
+            numberOfVertices: viewModel.numberOfVertices,
             rating: viewModel.rating,
             fillMode: viewModel.fillMode,
             lineWidth: CGFloat(viewModel.lineWidth),
@@ -94,8 +94,8 @@ final class StarComponentUIView: ComponentUIView {
             self?.componentView.lineWidth = CGFloat(lineWidth)
         }
 
-        self.viewModel.$numberOfPoints.subscribe(in: &self.cancellables) { [weak self] points in
-            self?.componentView.numberOfPoints = points
+        self.viewModel.$numberOfVertices.subscribe(in: &self.cancellables) { [weak self] points in
+            self?.componentView.numberOfVertices = points
         }
 
         self.viewModel.$cornerRadiusSize.subscribe(in: &self.cancellables) { [weak self] cornerRadius in

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIView.swift
@@ -1,0 +1,105 @@
+//
+//  StarComponentUIView.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import UIKit
+import Combine
+import SparkCore
+import Spark
+
+final class StarComponentUIView: ComponentUIView {
+
+    private var componentView: StarUIView!
+
+    // MARK: - Properties
+    private let viewModel: StarComponentUIViewModel
+    private var cancellables: Set<AnyCancellable> = []
+    private var sizeConstraints = [NSLayoutConstraint]()
+
+    // MARK: - Initializer
+    init(viewModel: StarComponentUIViewModel) {
+        self.viewModel = viewModel
+        self.componentView = Self.makeStarView(viewModel: viewModel)
+
+        super.init(viewModel: viewModel, componentView: componentView)
+
+        self.setupSubscriptions()
+        self.sizeConstraints = [
+            self.componentView.widthAnchor.constraint(equalToConstant: CGFloat(viewModel.frameSize)),
+            self.componentView.heightAnchor.constraint(equalToConstant: CGFloat(viewModel.frameSize))
+        ]
+
+        NSLayoutConstraint.activate(self.sizeConstraints)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private static func makeStarView(viewModel: StarComponentUIViewModel) -> StarUIView {
+        let view = StarUIView(
+            numberOfPoints: viewModel.numberOfPoints,
+            rating: viewModel.rating,
+            fillMode: viewModel.fillMode,
+            lineWidth: CGFloat(viewModel.lineWidth),
+            vertexSize: viewModel.vertexSize,
+            cornerRadiusSize: viewModel.cornerRadiusSize,
+            borderColor: viewModel.strokeColor.uiColor,
+            fillColor: viewModel.fillColor.uiColor)
+
+        return view
+    }
+
+    private func setupSubscriptions() {
+
+        self.viewModel.$frameSize.subscribe(in: &self.cancellables) { [weak self] frameSize in
+            self?.sizeConstraints.forEach{ constraint in
+                constraint.constant = CGFloat(frameSize)
+            }
+        }
+
+        self.viewModel.$cornerRadiusSize.subscribe(in: &self.cancellables) { [weak self] cornerRadiusSize in
+            self?.componentView.cornerRadiusSize = cornerRadiusSize
+        }
+
+        self.viewModel.$vertexSize.subscribe(in: &self.cancellables) { [weak self] vertexSize in
+            self?.componentView.vertexSize = vertexSize
+        }
+
+        self.viewModel.$rating.subscribe(in: &self.cancellables) { [weak self] rating in
+            self?.componentView.rating = rating
+        }
+
+        self.viewModel.$fillColor.subscribe(in: &self.cancellables) { [weak self] fillColor in
+            self?.componentView.fillColor = fillColor.uiColor
+            self?.viewModel.starFillColorConfigurationItemViewModel.buttonTitle = fillColor.name
+        }
+
+        self.viewModel.$strokeColor.subscribe(in: &self.cancellables) { [weak self] strokeColor in
+            self?.componentView.borderColor = strokeColor.uiColor
+            self?.viewModel.starStrokeColorConfigurationItemViewModel.buttonTitle = strokeColor.name
+
+        }
+
+        self.viewModel.$fillMode.subscribe(in: &self.cancellables) { [weak self] starFillMode in
+            self?.componentView.fillMode = starFillMode
+            self?.viewModel.starFillModeConfigurationItemViewModel.buttonTitle = starFillMode.name
+        }
+
+        self.viewModel.$lineWidth.subscribe(in: &self.cancellables) { [weak self] lineWidth in
+            self?.componentView.lineWidth = CGFloat(lineWidth)
+        }
+
+        self.viewModel.$numberOfPoints.subscribe(in: &self.cancellables) { [weak self] points in
+            self?.componentView.numberOfPoints = points
+        }
+
+        self.viewModel.$cornerRadiusSize.subscribe(in: &self.cancellables) { [weak self] cornerRadius in
+            self?.componentView.cornerRadiusSize = cornerRadius
+        }
+    }
+}

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIView.swift
@@ -41,15 +41,19 @@ final class StarComponentUIView: ComponentUIView {
     }
 
     private static func makeStarView(viewModel: StarComponentUIViewModel) -> StarUIView {
-        let view = StarUIView(
+        let configuration = StarConfiguration(
             numberOfVertices: viewModel.numberOfVertices,
+            vertexSize: viewModel.vertexSize,
+            cornerRadiusSize: viewModel.cornerRadiusSize)
+
+        let view = StarUIView(
             rating: viewModel.rating,
             fillMode: viewModel.fillMode,
             lineWidth: CGFloat(viewModel.lineWidth),
-            vertexSize: viewModel.vertexSize,
-            cornerRadiusSize: viewModel.cornerRadiusSize,
             borderColor: viewModel.strokeColor.uiColor,
-            fillColor: viewModel.fillColor.uiColor)
+            fillColor: viewModel.fillColor.uiColor,
+            configuration: configuration
+        )
 
         return view
     }

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIViewModel.swift
@@ -67,19 +67,19 @@ final class StarComponentUIViewModel: ComponentUIViewModel {
         return viewModel
     }()
 
-    lazy var numberOfPointsConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+    lazy var numberOfVerticesConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
-            name: "Number of points",
+            name: "Number of vertices",
             type: .rangeSelector(
-                selected: self.numberOfPoints,
+                selected: self.numberOfVertices,
                 range: 4...10
             ),
-            target: (source: self, action: #selector(self.numberOfPointsChanged)))
+            target: (source: self, action: #selector(self.numberOfVerticesChanged)))
     }()
 
     lazy var frameSizeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
-            name: "Frame Size",
+            name: "Frame size",
             type: .rangeSelectorWithConfig(
                 selected: self.frameSize,
                 range: 10...100,
@@ -147,7 +147,7 @@ final class StarComponentUIViewModel: ComponentUIViewModel {
             starStrokeColorConfigurationItemViewModel,
             starFillColorConfigurationItemViewModel,
             starFillModeConfigurationItemViewModel,
-            numberOfPointsConfigurationItemViewModel,
+            numberOfVerticesConfigurationItemViewModel,
             ratingConfigurationItemViewModel,
             lineWidthConfigurationItemViewModel,
             vertexSizeConfigurationItemViewModel,
@@ -157,7 +157,7 @@ final class StarComponentUIViewModel: ComponentUIViewModel {
     }
 
     // MARK: - Published Properties
-    @Published var numberOfPoints = 5
+    @Published var numberOfVertices = 5
     @Published var fillMode = StarFillMode.half
     @Published var rating = CGFloat(0.5)
     @Published var lineWidth = 2
@@ -189,8 +189,8 @@ extension StarComponentUIViewModel {
         self.showStarFillModeSheetSubject.send(StarFillMode.allCases)
     }
 
-    @objc func numberOfPointsChanged(_ control: NumberSelector) {
-        self.numberOfPoints = control.selectedValue
+    @objc func numberOfVerticesChanged(_ control: NumberSelector) {
+        self.numberOfVertices = control.selectedValue
     }
 
     @objc func frameSizeChanged(_ control: NumberSelector) {

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIViewModel.swift
@@ -1,0 +1,271 @@
+//
+//  StarComponentUIViewModel.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+import Combine
+import Foundation
+import UIKit
+import SparkCore
+
+final class StarComponentUIViewModel: ComponentUIViewModel {
+
+    // MARK: - Published Properties
+    var showStarFillColorSheet: AnyPublisher<[StarColor], Never> {
+        showStarFillColorSheetSubject
+            .eraseToAnyPublisher()
+    }
+
+    var showStarStrokeColorSheet: AnyPublisher<[StarColor], Never> {
+        showStarStrokeColorSheetSubject
+            .eraseToAnyPublisher()
+    }
+
+    var showStarFillModeSheet: AnyPublisher<[StarFillMode], Never> {
+        showStarFillModeSheetSubject
+            .eraseToAnyPublisher()
+    }
+
+    // MARK: - Items Properties
+    private var showStarStrokeColorSheetSubject: PassthroughSubject<[StarColor], Never> = .init()
+    private var showStarFillColorSheetSubject: PassthroughSubject<[StarColor], Never> = .init()
+    private var showStarFillModeSheetSubject: PassthroughSubject<[StarFillMode], Never> = .init()
+
+    lazy var starStrokeColorConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        let viewModel = ComponentsConfigurationItemUIViewModel(
+            name: "Stroke color",
+            type: .button,
+            target: (source: self, action: #selector(self.presentStarStrokeColorSheet))
+        )
+        viewModel.buttonTitle = self.strokeColor.name
+        return viewModel
+    }()
+
+    lazy var starFillColorConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        let viewModel = ComponentsConfigurationItemUIViewModel(
+            name: "Fill color",
+            type: .button,
+            target: (source: self, action: #selector(self.presentStarFillColorSheet))
+        )
+        viewModel.buttonTitle = self.fillColor.name
+        return viewModel
+    }()
+
+    lazy var starFillModeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        let viewModel = ComponentsConfigurationItemUIViewModel(
+            name: "Fill mode",
+            type: .button,
+            target: (source: self, action: #selector(self.presentStarFillModeSheet))
+        )
+
+        viewModel.buttonTitle = self.fillMode.name
+        return viewModel
+    }()
+
+    lazy var numberOfPointsConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Number of points",
+            type: .rangeSelector(
+                selected: self.numberOfPoints,
+                range: 4...10
+            ),
+            target: (source: self, action: #selector(self.numberOfPointsChanged)))
+    }()
+
+    lazy var frameSizeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Frame Size",
+            type: .rangeSelectorWithConfig(
+                selected: self.frameSize,
+                range: 10...100,
+                stepper: 10,
+                numberFormatter: NumberFormatter()
+            ),
+            target: (source: self, action: #selector(self.frameSizeChanged)))
+    }()
+
+    lazy var ratingConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Rating",
+            type: .rangeSelectorWithConfig(
+                selected: Int(self.rating * 20),
+                range: 0...20,
+                stepper: 1,
+                numberFormatter: NumberFormatter()
+                    .multipling(0.05)
+                    .maximizingFractionDigits(2)
+            ),
+            target: (source: self, action: #selector(self.ratingChanged)))
+    }()
+
+    lazy var lineWidthConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Line Width",
+            type: .rangeSelector(
+                selected: self.lineWidth,
+                range: 1...15
+            ),
+            target: (source: self, action: #selector(self.lineWidthChanged)))
+    }()
+
+    lazy var vertexSizeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Vertex size",
+            type: .rangeSelectorWithConfig(
+                selected: Int(self.vertexSize * 20),
+                range: 0...20,
+                stepper: 1,
+                numberFormatter: NumberFormatter()
+                    .multipling(0.05)
+                    .maximizingFractionDigits(2)
+            ),
+            target: (source: self, action: #selector(self.vertexSizeChanged)))
+    }()
+
+    lazy var cornerRadiusSizeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Corner radius size",
+            type: .rangeSelectorWithConfig(
+                selected: Int(self.cornerRadiusSize * 20),
+                range: 0...20,
+                stepper: 1,
+                numberFormatter: NumberFormatter()
+                    .multipling(0.05)
+                    .maximizingFractionDigits(2)
+            ),
+            target: (source: self, action: #selector(self.cornerRadiusSizeChanged)))
+    }()
+
+    // MARK: - Methods
+    override func configurationItemsViewModel() -> [ComponentsConfigurationItemUIViewModel] {
+        return [
+            starStrokeColorConfigurationItemViewModel,
+            starFillColorConfigurationItemViewModel,
+            starFillModeConfigurationItemViewModel,
+            numberOfPointsConfigurationItemViewModel,
+            ratingConfigurationItemViewModel,
+            lineWidthConfigurationItemViewModel,
+            vertexSizeConfigurationItemViewModel,
+            cornerRadiusSizeConfigurationItemViewModel,
+            frameSizeConfigurationItemViewModel
+        ]
+    }
+
+    // MARK: - Published Properties
+    @Published var numberOfPoints = 5
+    @Published var fillMode = StarFillMode.half
+    @Published var rating = CGFloat(0.5)
+    @Published var lineWidth = 2
+    @Published var vertexSize = CGFloat(0.65)
+    @Published var cornerRadiusSize = CGFloat(0.15)
+    @Published var fillColor = StarColor.blue
+    @Published var strokeColor = StarColor.lightGray
+    @Published var frameSize = 100
+
+    // MARK: - Initialization
+    init() {
+        super.init(identifier: "Rating Star")
+    }
+
+}
+
+// MARK: - Navigation
+extension StarComponentUIViewModel {
+
+    @objc func presentStarFillColorSheet() {
+        self.showStarFillColorSheetSubject.send(StarColor.allCases)
+    }
+
+    @objc func presentStarStrokeColorSheet() {
+        self.showStarStrokeColorSheetSubject.send(StarColor.allCases)
+    }
+
+    @objc func presentStarFillModeSheet() {
+        self.showStarFillModeSheetSubject.send(StarFillMode.allCases)
+    }
+
+    @objc func numberOfPointsChanged(_ control: NumberSelector) {
+        self.numberOfPoints = control.selectedValue
+    }
+
+    @objc func frameSizeChanged(_ control: NumberSelector) {
+        self.frameSize = control.selectedValue
+    }
+
+    @objc func lineWidthChanged(_ control: NumberSelector) {
+        self.lineWidth = control.selectedValue
+    }
+
+    @objc func ratingChanged(_ control: NumberSelector) {
+        self.rating = CGFloat(control.selectedValue) / 20.0
+    }
+
+    @objc func vertexSizeChanged(_ control: NumberSelector) {
+        self.vertexSize = CGFloat(control.selectedValue) / 20.0
+    }
+
+    @objc func cornerRadiusSizeChanged(_ control: NumberSelector) {
+        self.cornerRadiusSize = CGFloat(control.selectedValue) / 20.0
+    }
+}
+
+// MARK: - Private helpers
+enum StarColor: CaseIterable {
+    case black
+    case blue
+    case clear
+    case darkGray
+    case gray
+    case green
+    case lightGray
+    case orange
+    case red
+    case yellow
+
+    var uiColor: UIColor {
+        switch self {
+        case .black: return .black
+        case .blue: return .blue
+        case .clear: return .clear
+        case .darkGray: return .darkGray
+        case .gray: return .gray
+        case .green: return .green
+        case .lightGray: return .lightGray
+        case .orange: return .orange
+        case .red: return .red
+        case .yellow: return .yellow
+        }
+    }
+}
+
+extension StarFillMode: CaseIterable {
+    public static var allCases: [SparkCore.StarFillMode] {
+        [.full, .half, .fraction(10), .exact]
+    }
+
+    var name: String {
+        switch self {
+        case .full: return "Full"
+        case .half: return "Half"
+        case let .fraction(fraction): return "Fraction(\(fraction))"
+        case .exact: return "Exact"
+        }
+    }
+}
+
+private extension NumberFormatter {
+    func multipling(_ value: NSNumber) -> Self {
+        self.multiplier = value
+        return self
+    }
+
+    func maximizingFractionDigits(_ value: Int) -> Self {
+        self.maximumFractionDigits = value
+        return self
+    }
+}

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentViewController.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentViewController.swift
@@ -1,0 +1,106 @@
+//
+//  StarComponentViewController.swift
+//  SparkCore
+//
+//  Created by michael.zimmermann on 08.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+import Spark
+import SwiftUI
+import UIKit
+import SparkCore
+
+final class StarComponentViewController: UIViewController {
+
+    // MARK: - Properties
+    let componentView: StarComponentUIView
+    let viewModel: StarComponentUIViewModel
+    private var cancellables: Set<AnyCancellable> = []
+
+    // MARK: - Initializer
+    init(viewModel: StarComponentUIViewModel) {
+        self.viewModel = viewModel
+        self.componentView = StarComponentUIView(viewModel: viewModel)
+        super.init(nibName: nil, bundle: nil)
+
+        self.componentView.viewController = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func loadView() {
+        super.loadView()
+        view = componentView
+    }
+
+    // MARK: - ViewDidLoad
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationItem.title = "Star Rating Configurator"
+        addPublisher()
+    }
+
+    // MARK: - Add Publishers
+    private func addPublisher() {
+
+        self.viewModel.showStarFillColorSheet.subscribe(in: &self.cancellables) { colors in
+            self.presentFillColorActionSheet(colors)
+        }
+
+        self.viewModel.showStarStrokeColorSheet.subscribe(in: &self.cancellables) { colors in
+            self.presentStrokeColorActionSheet(colors)
+        }
+
+        self.viewModel.showStarFillModeSheet.subscribe(in: &self.cancellables) { modes in
+            self.presentFillModeActionSheet(modes)
+        }
+
+    }
+}
+
+// MARK: - Builder
+extension StarComponentViewController {
+
+    static func build() -> StarComponentViewController {
+        let viewModel = StarComponentUIViewModel()
+        let viewController = StarComponentViewController(viewModel: viewModel)
+        return viewController
+    }
+}
+
+// MARK: - Navigation
+extension StarComponentViewController {
+
+    private func presentFillColorActionSheet(_ colors: [StarColor]) {
+        let actionSheet = SparkActionSheet<StarColor>.init(
+            values: colors,
+            texts: colors.map { $0.name }) { color in
+                self.viewModel.fillColor = color
+            }
+        self.present(actionSheet, animated: true)
+    }
+
+    private func presentStrokeColorActionSheet(_ colors: [StarColor]) {
+        let actionSheet = SparkActionSheet<StarColor>.init(
+            values: colors,
+            texts: colors.map { $0.name }) { color in
+                self.viewModel.strokeColor = color
+            }
+        self.present(actionSheet, animated: true)
+    }
+
+    private func presentFillModeActionSheet(_ fillModes: [StarFillMode]) {
+        let actionSheet = SparkActionSheet<StarFillMode>.init(
+            values: fillModes,
+            texts: fillModes.map { $0.name }) { fillMode in
+                self.viewModel.fillMode = fillMode
+            }
+        self.present(actionSheet, animated: true)
+    }
+
+}

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentViewController.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentViewController.swift
@@ -41,7 +41,7 @@ final class StarComponentViewController: UIViewController {
     // MARK: - ViewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.title = "Star Rating Configurator"
+        self.navigationItem.title = "Star Rating"
         addPublisher()
     }
 
@@ -59,7 +59,6 @@ final class StarComponentViewController: UIViewController {
         self.viewModel.showStarFillModeSheet.subscribe(in: &self.cancellables) { modes in
             self.presentFillModeActionSheet(modes)
         }
-
     }
 }
 


### PR DESCRIPTION
As a preparation for the rating view, a single configurable rating star is implemented.
This star wil be used for the RatingView and the RatingInputControl.
The star is configurable. The configuration possibles are added to the demo.



![Simulator Screenshot - iPhone 15 - 2023-11-08 at 16 40 57](https://github.com/adevinta/spark-ios/assets/128726463/0722b54a-f523-47ce-9cff-479d057bd1f4)
