### PR TITLE
[Rating#591] Rating display UI View and View-Model

### DIFF
--- a/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
+++ b/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
@@ -216,12 +216,13 @@ public final class ChipUIView: UIControl {
     //MARK: - Initializers
 
     /// Initializer of a chip containing only an icon.
-    ///
-    /// Parameters:
-    /// - theme: The theme.
-    /// - intent: The intent of the chip, e.g. main, support
-    /// - variant: The chip variant, e.g. outlined, filled
-    /// - iconImage: An icon
+    /// 
+    /// - Parameters:
+    ///   - theme: The theme.
+    ///   - intent: The intent of the chip, e.g. main, support
+    ///   - variant: The chip variant, e.g. outlined, filled
+    ///   - alignment: Leading or Trailing Icon
+    ///   - iconImage: An icon
     public convenience init(theme: Theme,
                             intent: ChipIntent,
                             variant: ChipVariant,

--- a/core/Sources/Components/Rating/AccessibilityIdentifier/RatingDisplayAccessibilityIdentifier.swift
+++ b/core/Sources/Components/Rating/AccessibilityIdentifier/RatingDisplayAccessibilityIdentifier.swift
@@ -1,0 +1,18 @@
+//
+//  RatingDisplayAccessibilityIdentifier.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 21.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+/// The accessibility identifiers of the rating display.
+public enum RatingDisplayAccessibilityIdentifier {
+
+    // MARK: - Properties
+
+    /// The accessibility identifier.
+    public static let identifier = "spark-rating-display"
+}

--- a/core/Sources/Components/Rating/Enum/RatingDisplaySize.swift
+++ b/core/Sources/Components/Rating/Enum/RatingDisplaySize.swift
@@ -1,0 +1,15 @@
+//
+//  RatingDisplaySize.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+public enum RatingDisplaySize: Int, CaseIterable {
+    case small = 12
+    case medium = 16
+    case input = 40
+}

--- a/core/Sources/Components/Rating/Enum/RatingIntent.swift
+++ b/core/Sources/Components/Rating/Enum/RatingIntent.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public enum RatingIntent {
+public enum RatingIntent: CaseIterable {
     case main
 }

--- a/core/Sources/Components/Rating/Enum/RatingStarsCount.swift
+++ b/core/Sources/Components/Rating/Enum/RatingStarsCount.swift
@@ -1,0 +1,14 @@
+//
+//  RatingStarsCount.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+public enum RatingStarsCount: Int {
+    case one = 1
+    case five = 5
+}

--- a/core/Sources/Components/Rating/Enum/RatingStarsCount.swift
+++ b/core/Sources/Components/Rating/Enum/RatingStarsCount.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum RatingStarsCount: Int {
+public enum RatingStarsCount: Int, CaseIterable {
     case one = 1
     case five = 5
 }

--- a/core/Sources/Components/Rating/Model/RatingSizeAttributes.swift
+++ b/core/Sources/Components/Rating/Model/RatingSizeAttributes.swift
@@ -11,4 +11,5 @@ import Foundation
 struct RatingSizeAttributes {
     let borderWidth: CGFloat
     let height: CGFloat
+    let spacing: CGFloat
 }

--- a/core/Sources/Components/Rating/Model/RatingSizeAttributes.swift
+++ b/core/Sources/Components/Rating/Model/RatingSizeAttributes.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct RatingSizeAttributes {
+struct RatingSizeAttributes: Equatable {
     let borderWidth: CGFloat
     let height: CGFloat
     let spacing: CGFloat

--- a/core/Sources/Components/Rating/Model/RatingSizeAttributes.swift
+++ b/core/Sources/Components/Rating/Model/RatingSizeAttributes.swift
@@ -1,0 +1,14 @@
+//
+//  RatingSizeAttributes.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+struct RatingSizeAttributes {
+    let borderWidth: CGFloat
+    let height: CGFloat
+}

--- a/core/Sources/Components/Rating/TestHelpers/RatingDisplayConfigurationSnapshotTests.swift
+++ b/core/Sources/Components/Rating/TestHelpers/RatingDisplayConfigurationSnapshotTests.swift
@@ -1,0 +1,39 @@
+//
+//  RatingDisplayConfigurationSnapshotTests.swift
+//  SparkCoreSnapshotTests
+//
+//  Created by Michael Zimmermann on 20.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+import UIKit
+@testable import SparkCore
+
+struct RatingDisplayConfigurationSnapshotTests {
+
+    // MARK: - Properties
+
+    let scenario: RatingDisplayScenarioSnapshotTests
+
+    let rating: CGFloat
+    let size: RatingDisplaySize
+    let count: RatingStarsCount
+    let intent = RatingIntent.main
+
+    let modes: [ComponentSnapshotTestMode]
+    let sizes: [UIContentSizeCategory]
+    
+    // MARK: - Getter
+
+    func testName() -> String {
+        return [
+            "\(self.scenario.rawValue)",
+            "\(self.intent)",
+            "\(self.size)",
+            "\(self.count)",
+            "\(self.rating)"
+        ].joined(separator: "-")
+    }
+}

--- a/core/Sources/Components/Rating/TestHelpers/RatingDisplayScenarioSnapshotTests.swift
+++ b/core/Sources/Components/Rating/TestHelpers/RatingDisplayScenarioSnapshotTests.swift
@@ -1,0 +1,70 @@
+//
+//  RatingDisplayScenarioSnapshotTests.swift
+//  SparkCoreSnapshotTests
+//
+//  Created by Michael Zimmermann on 20.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+@testable import SparkCore
+import UIKit
+import SwiftUI
+
+enum RatingDisplayScenarioSnapshotTests: String, CaseIterable {
+    case test1
+//    case test2
+//    case test3
+//    case test4
+//    case test5
+
+    // MARK: - Type Alias
+
+    typealias Constants = ComponentSnapshotTestConstants
+
+    // MARK: - Configurations
+
+    func configuration(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
+        switch self {
+        case .test1:
+            return self.test1(isSwiftUIComponent: isSwiftUIComponent)
+//        case .test2:
+//            return self.test2(isSwiftUIComponent: isSwiftUIComponent)
+//        case .test3:
+//            return self.test3(isSwiftUIComponent: isSwiftUIComponent)
+//        case .test4:
+//            return self.test4(isSwiftUIComponent: isSwiftUIComponent)
+//        case .test5:
+//            return self.test5(isSwiftUIComponent: isSwiftUIComponent)
+        }
+    }
+
+    // MARK: - Scenarios
+
+    /// Test 1
+    ///
+    /// Description: To test all intents
+    ///
+    /// Content:
+    ///  - intents: all
+    ///  - variant: outlined
+    ///  - content: icon + text
+    ///  - state: default
+    ///  - mode: all
+    ///  - size: default
+    private func test1(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
+        let ratings: [CGFloat] = [0.0, 1.0, 2.5, 5.5]
+
+        return ratings.map { rating in
+            return .init(
+                scenario: self,
+                rating: rating,
+                size: .medium,
+                count: .five,
+                modes: Constants.Modes.all,
+                sizes: Constants.Sizes.default
+            )
+        }
+    }
+}

--- a/core/Sources/Components/Rating/TestHelpers/RatingDisplayScenarioSnapshotTests.swift
+++ b/core/Sources/Components/Rating/TestHelpers/RatingDisplayScenarioSnapshotTests.swift
@@ -14,10 +14,8 @@ import SwiftUI
 
 enum RatingDisplayScenarioSnapshotTests: String, CaseIterable {
     case test1
-//    case test2
-//    case test3
-//    case test4
-//    case test5
+    case test2
+    case test3
 
     // MARK: - Type Alias
 
@@ -29,14 +27,10 @@ enum RatingDisplayScenarioSnapshotTests: String, CaseIterable {
         switch self {
         case .test1:
             return self.test1(isSwiftUIComponent: isSwiftUIComponent)
-//        case .test2:
-//            return self.test2(isSwiftUIComponent: isSwiftUIComponent)
-//        case .test3:
-//            return self.test3(isSwiftUIComponent: isSwiftUIComponent)
-//        case .test4:
-//            return self.test4(isSwiftUIComponent: isSwiftUIComponent)
-//        case .test5:
-//            return self.test5(isSwiftUIComponent: isSwiftUIComponent)
+        case .test2:
+            return self.test2(isSwiftUIComponent: isSwiftUIComponent)
+        case .test3:
+            return self.test3(isSwiftUIComponent: isSwiftUIComponent)
         }
     }
 
@@ -44,17 +38,16 @@ enum RatingDisplayScenarioSnapshotTests: String, CaseIterable {
 
     /// Test 1
     ///
-    /// Description: To test all intents
+    /// Description: To various rating values
     ///
     /// Content:
-    ///  - intents: all
-    ///  - variant: outlined
-    ///  - content: icon + text
-    ///  - state: default
-    ///  - mode: all
-    ///  - size: default
+    ///  - ratings: [0.0, 1.0, 2.5, 5.5]
+    ///  - size: medium
+    ///  - count: five (number of stars)
+    ///  - modes: all
+    ///  - accessibility sizes: default
     private func test1(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
-        let ratings: [CGFloat] = [0.0, 1.0, 2.5, 5.5]
+        let ratings: [CGFloat] = [1.0, 2.5, 5.5]
 
         return ratings.map { rating in
             return .init(
@@ -63,6 +56,52 @@ enum RatingDisplayScenarioSnapshotTests: String, CaseIterable {
                 size: .medium,
                 count: .five,
                 modes: Constants.Modes.all,
+                sizes: Constants.Sizes.default
+            )
+        }
+    }
+
+    /// Test 2
+    ///
+    ///
+    /// Description: To various accessibility sizes
+    ///
+    /// Content:
+    ///  - ratings: [ 2.5]
+    ///  - size: small
+    ///  - count: five (number of stars)
+    ///  - modes: default
+    ///  - sizes: all
+    private func test2(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
+            return [.init(
+                scenario: self,
+                rating: 2.5,
+                size: .small,
+                count: .five,
+                modes: Constants.Modes.default,
+                sizes: Constants.Sizes.all
+            )]
+    }
+
+    /// Test 3
+    ///
+    /// Description: To various rating sizes
+    ///
+    /// Content:
+    ///  - ratings: [2.5]
+    ///  - size: [small, medium, input]
+    ///  - count: one (number of stars)
+    ///  - modes: default
+    ///  - accessibility sizes: default
+    private func test3(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
+
+        return RatingDisplaySize.allCases.map { size in
+            return .init(
+                scenario: self,
+                rating: 2.5,
+                size: size,
+                count: .five,
+                modes: Constants.Modes.default,
                 sizes: Constants.Sizes.default
             )
         }

--- a/core/Sources/Components/Rating/UseCases/RatingGetColorsUseCase.swift
+++ b/core/Sources/Components/Rating/UseCases/RatingGetColorsUseCase.swift
@@ -16,6 +16,14 @@ protocol RatingGetColorsUseCaseable {
     ) -> RatingColors
 }
 
+extension RatingGetColorsUseCaseable {
+    func execute(theme: Theme,
+                 intent: RatingIntent
+    ) -> RatingColors {
+        return self.execute(theme: theme, intent: intent, state: .standard)
+    }
+}
+
 /// Get the colors of the rating
 struct RatingGetColorsUseCase: RatingGetColorsUseCaseable {
 
@@ -27,7 +35,7 @@ struct RatingGetColorsUseCase: RatingGetColorsUseCaseable {
     ///   - state: the current state
     func execute(theme: Theme,
                  intent: RatingIntent,
-                 state: RatingState = .standard
+                 state: RatingState
     ) -> RatingColors {
         
         var colors: RatingColors

--- a/core/Sources/Components/Rating/UseCases/RatingGetColorsUseCase.swift
+++ b/core/Sources/Components/Rating/UseCases/RatingGetColorsUseCase.swift
@@ -27,7 +27,7 @@ struct RatingGetColorsUseCase: RatingGetColorsUseCaseable {
     ///   - state: the current state
     func execute(theme: Theme,
                  intent: RatingIntent,
-                 state: RatingState
+                 state: RatingState = .standard
     ) -> RatingColors {
         
         var colors: RatingColors

--- a/core/Sources/Components/Rating/UseCases/RatingSizeAttributesUseCase.swift
+++ b/core/Sources/Components/Rating/UseCases/RatingSizeAttributesUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  RatingSizeAttributesUseCase.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 20.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+// sourcery: AutoMockable
+protocol RatingSizeAttributesUseCaseable {
+    func execute(spacing: LayoutSpacing, size: RatingDisplaySize) -> RatingSizeAttributes
+}
+
+struct RatingSizeAttributesUseCase: RatingSizeAttributesUseCaseable {
+    func execute(spacing: LayoutSpacing, size: RatingDisplaySize) -> RatingSizeAttributes {
+        switch size {
+        case .small: return size.sizeAttributes(spacing: spacing.small)
+        case .medium: return size.sizeAttributes(spacing: spacing.small)
+        case .input: return size.sizeAttributes(spacing: spacing.medium)
+        }
+    }
+}
+
+private extension RatingDisplaySize {
+    func sizeAttributes(spacing: CGFloat) -> RatingSizeAttributes {
+        switch self {
+        case .small: return .init(borderWidth: 1.0, height: self.height, spacing: spacing)
+        case .medium: return .init(borderWidth: 1.33, height: self.height, spacing: spacing)
+        case .input: return .init(borderWidth: 3.33, height: self.height, spacing: spacing)
+        }
+    }
+
+    var height: CGFloat {
+        return CGFloat(self.rawValue)
+    }
+}

--- a/core/Sources/Components/Rating/UseCases/RatingSizeAttributesUseCase.swift
+++ b/core/Sources/Components/Rating/UseCases/RatingSizeAttributesUseCase.swift
@@ -13,7 +13,14 @@ protocol RatingSizeAttributesUseCaseable {
     func execute(spacing: LayoutSpacing, size: RatingDisplaySize) -> RatingSizeAttributes
 }
 
+/// Calculates size attributes of the rating display according to the spacing and the size.
 struct RatingSizeAttributesUseCase: RatingSizeAttributesUseCaseable {
+
+    /// Returns: rating size attributes
+    ///
+    /// - Parameters:
+    ///   - spacing: the spacing defined by the theme
+    ///   - size: the size of the rating display
     func execute(spacing: LayoutSpacing, size: RatingDisplaySize) -> RatingSizeAttributes {
         switch size {
         case .small: return size.sizeAttributes(spacing: spacing.small)
@@ -23,6 +30,7 @@ struct RatingSizeAttributesUseCase: RatingSizeAttributesUseCaseable {
     }
 }
 
+// MARK: - Private helpers
 private extension RatingDisplaySize {
     func sizeAttributes(spacing: CGFloat) -> RatingSizeAttributes {
         switch self {

--- a/core/Sources/Components/Rating/UseCases/RatingSizeAttributesUseCaseTests.swift
+++ b/core/Sources/Components/Rating/UseCases/RatingSizeAttributesUseCaseTests.swift
@@ -1,0 +1,49 @@
+//
+//  RatingSizeAttributesUseCaseTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 20.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+@testable import SparkCore
+
+final class RatingSizeAttributesUseCaseTests: XCTestCase {
+
+    var spacing: LayoutSpacingGeneratedMock!
+    var sut: RatingSizeAttributesUseCase!
+
+    // MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.spacing = LayoutSpacingGeneratedMock.mocked()
+        self.sut = RatingSizeAttributesUseCase()
+    }
+
+    // MARK: - Tests
+    func test_small() {
+        // When
+        let sizes = sut.execute(spacing: self.spacing, size: .small)
+
+        // Then
+        XCTAssertEqual(sizes, .init(borderWidth: 1.0, height: 12.0, spacing: 3.0))
+    }
+
+    func test_medium() {
+        // When
+        let sizes = sut.execute(spacing: self.spacing, size: .medium)
+
+        // Then
+        XCTAssertEqual(sizes, .init(borderWidth: 1.33, height: 16.0, spacing: 3.0))
+    }
+
+    func test_input() {
+        // When
+        let sizes = sut.execute(spacing: self.spacing, size: .input)
+
+        // Then
+        XCTAssertEqual(sizes, .init(borderWidth: 3.33, height: 40.0, spacing: 5.0))
+    }
+}

--- a/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
@@ -6,10 +6,13 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
+import Combine
 import Foundation
 
+/// A view model for the rating display.
 final class RatingDisplayViewModel: ObservableObject {
     
+    /// The current theme of which colors and sizes are dependent.
     var theme: Theme {
         didSet {
             self.colors = self.colorsUseCase.execute(theme: self.theme, intent: self.intent)
@@ -17,6 +20,7 @@ final class RatingDisplayViewModel: ObservableObject {
         }
     }
 
+    /// The current intent which describes colors.
     var intent: RatingIntent {
         didSet {
             guard self.intent != oldValue else { return }
@@ -24,6 +28,7 @@ final class RatingDisplayViewModel: ObservableObject {
         }
     }
 
+    /// The display size of the rating
     var size: RatingDisplaySize {
         didSet {
             guard self.size != oldValue else { return }
@@ -31,6 +36,7 @@ final class RatingDisplayViewModel: ObservableObject {
         }
     }
 
+    /// The number of stars in the rating display
     var count: RatingStarsCount {
         didSet {
             guard self.count != oldValue else { return }
@@ -38,6 +44,7 @@ final class RatingDisplayViewModel: ObservableObject {
         }
     }
 
+    /// The current rating value
     var rating: CGFloat {
         didSet {
             guard self.rating != oldValue else { return }
@@ -45,14 +52,20 @@ final class RatingDisplayViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Published variables
+    /// The current defined colors
     @Published var colors: RatingColors
+    /// Current size attributes
     @Published var ratingSize: RatingSizeAttributes
+    /// The normalized rating value
     @Published var ratingValue: CGFloat
 
+    // MARK: - Private variables
     private let colorsUseCase: RatingGetColorsUseCaseable
     private let sizeUseCase: RatingSizeAttributesUseCaseable
 
-    init(theme: Theme, 
+    // MARK: Initializer
+    init(theme: Theme,
          intent: RatingIntent,
          size: RatingDisplaySize,
          count: RatingStarsCount,
@@ -72,11 +85,13 @@ final class RatingDisplayViewModel: ObservableObject {
         self.count = count
     }
 
+    // MARK: - Private functions
     private func updateRatingValue() {
         self.ratingValue = self.count.ratingValue(self.rating)
     }
 }
 
+// MARK: - Private helpers
 private extension RatingStarsCount {
     func ratingValue(_ rating: CGFloat) -> CGFloat {
         switch self {

--- a/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
@@ -1,0 +1,66 @@
+//
+//  RatingDisplayViewModel.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+final class RatingDisplayViewModel: ObservableObject {
+    
+    var theme: Theme {
+        didSet {
+            self.colors = self.colorsUseCase.execute(theme: self.theme, intent: self.intent)
+        }
+    }
+
+    var intent: RatingIntent {
+        didSet {
+            guard self.intent != oldValue else { return }
+            self.colors = self.colorsUseCase.execute(theme: self.theme, intent: self.intent)
+        }
+    }
+
+    var size: RatingDisplaySize {
+        didSet {
+            guard self.size != oldValue else { return }
+            self.ratingSize = self.size.sizeAttributes
+        }
+    }
+
+    @Published var colors: RatingColors
+    @Published var spacing: CGFloat
+    @Published var ratingSize: RatingSizeAttributes
+
+    private let colorsUseCase: RatingGetColorsUseCase
+
+    init(theme: Theme, 
+         intent: RatingIntent,
+         size: RatingDisplaySize,
+         colorsUseCase: RatingGetColorsUseCase = RatingGetColorsUseCase()
+    ) {
+        self.theme = theme
+        self.intent = intent
+        self.size = size
+        self.colorsUseCase = colorsUseCase
+        self.colors = colorsUseCase.execute(theme: theme, intent: intent)
+        self.spacing = theme.layout.spacing.small
+        self.ratingSize = size.sizeAttributes
+    }
+}
+
+private extension RatingDisplaySize {
+    var sizeAttributes: RatingSizeAttributes {
+        switch self {
+        case .small: return .init(borderWidth: 1.0, height: self.height)
+        case .medium: return .init(borderWidth: 1.33, height: self.height)
+        case .input: return .init(borderWidth: 3.33, height: self.height)
+        }
+    }
+
+    var height: CGFloat {
+        return CGFloat(self.rawValue)
+    }
+}

--- a/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
@@ -13,7 +13,7 @@ final class RatingDisplayViewModel: ObservableObject {
     var theme: Theme {
         didSet {
             self.colors = self.colorsUseCase.execute(theme: self.theme, intent: self.intent)
-            self.ratingSize = self.spacingUseCase.execute(spacing: theme.layout.spacing, size: size)
+            self.ratingSize = self.sizeUseCase.execute(spacing: theme.layout.spacing, size: size)
         }
     }
 
@@ -27,7 +27,7 @@ final class RatingDisplayViewModel: ObservableObject {
     var size: RatingDisplaySize {
         didSet {
             guard self.size != oldValue else { return }
-            self.ratingSize = self.spacingUseCase.execute(spacing: theme.layout.spacing, size: size)
+            self.ratingSize = self.sizeUseCase.execute(spacing: theme.layout.spacing, size: size)
         }
     }
 
@@ -50,7 +50,7 @@ final class RatingDisplayViewModel: ObservableObject {
     @Published var ratingValue: CGFloat
 
     private let colorsUseCase: RatingGetColorsUseCaseable
-    private let spacingUseCase: RatingSizeAttributesUseCaseable
+    private let sizeUseCase: RatingSizeAttributesUseCaseable
 
     init(theme: Theme, 
          intent: RatingIntent,
@@ -58,15 +58,15 @@ final class RatingDisplayViewModel: ObservableObject {
          count: RatingStarsCount,
          rating: CGFloat,
          colorsUseCase: RatingGetColorsUseCaseable = RatingGetColorsUseCase(),
-         spacingUseCase: RatingSizeAttributesUseCaseable = RatingSizeAttributesUseCase()
+         sizeUseCase: RatingSizeAttributesUseCaseable = RatingSizeAttributesUseCase()
     ) {
         self.theme = theme
         self.intent = intent
         self.size = size
         self.colorsUseCase = colorsUseCase
         self.colors = colorsUseCase.execute(theme: theme, intent: intent, state: .standard)
-        self.spacingUseCase = spacingUseCase
-        self.ratingSize = spacingUseCase.execute(spacing: theme.layout.spacing, size: size)
+        self.sizeUseCase = sizeUseCase
+        self.ratingSize = sizeUseCase.execute(spacing: theme.layout.spacing, size: size)
         self.ratingValue = count.ratingValue(rating)
         self.rating = rating
         self.count = count

--- a/core/Sources/Components/Rating/View/RatingDisplayViewModelTests.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModelTests.swift
@@ -1,0 +1,147 @@
+//
+//  RatingDisplayViewModelTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 20.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+import Combine
+import XCTest
+
+@testable import SparkCore
+
+final class RatingDisplayViewModelTests: XCTestCase {
+
+    // MARK: - Properties
+    var theme: ThemeGeneratedMock!
+    var colorsUseCase: RatingGetColorsUseCaseableGeneratedMock!
+    var sizeUseCase: RatingSizeAttributesUseCaseableGeneratedMock!
+    var sut: RatingDisplayViewModel!
+    var subscriptions: Set<AnyCancellable>!
+
+    // MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.colorsUseCase = RatingGetColorsUseCaseableGeneratedMock()
+        self.sizeUseCase = RatingSizeAttributesUseCaseableGeneratedMock()
+        self.theme = ThemeGeneratedMock.mocked()
+        self.subscriptions = .init()
+
+        self.colorsUseCase.executeWithThemeAndIntentAndStateReturnValue = RatingColors(
+            fillColor: self.theme.colors.main.onMain,
+            strokeColor: self.theme.colors.base.background,
+            opacity: 1.0)
+
+        self.sizeUseCase.executeWithSpacingAndSizeReturnValue = RatingSizeAttributes(borderWidth: 2.0, height: 20, spacing: 8)
+
+
+        self.sut = RatingDisplayViewModel(
+            theme: self.theme,
+            intent: .main,
+            size: .small,
+            count: .five,
+            rating: 1.0,
+            colorsUseCase: self.colorsUseCase,
+            sizeUseCase: self.sizeUseCase
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.subscriptions.removeAll()
+    }
+
+    // MARK: - Tests
+    func test_setup() {
+        // Then
+        XCTAssertEqual(self.sut.colors.opacity, 1.0, "Expected opacity to 0.0")
+        XCTAssertEqual(self.sut.colors.fillColor.uiColor, self.theme.colors.main.onMain.uiColor, "Expected fill color to be onMain")
+        XCTAssertEqual(self.sut.colors.strokeColor.uiColor, self.theme.colors.base.background.uiColor, "Expected background color to be set")
+        XCTAssertEqual(self.sut.ratingValue, 1.0)
+    }
+
+    func test_single_star() {
+        // Given
+        self.sut.rating = 2
+        self.sut.count = .one
+
+        XCTAssertEqual(self.sut.ratingValue, 0.4)
+    }
+
+    func test_theme_updated() {
+
+        // Given
+        let colorsPublisherMock: PublisherMock<Published< RatingColors>.Publisher> = .init(publisher: self.sut.$colors)
+        let ratingSizePublisherMock: PublisherMock<Published<RatingSizeAttributes>.Publisher> = .init(publisher: self.sut.$ratingSize)
+
+        colorsPublisherMock.loadTesting(on: &subscriptions)
+        ratingSizePublisherMock.loadTesting(on: &subscriptions)
+
+        // When
+        self.sut.theme = self.theme
+
+        // Then
+        XCTAssertPublisherSinkCountEqual(
+            on: colorsPublisherMock,
+            2
+        )
+
+        XCTAssertPublisherSinkCountEqual(
+            on: ratingSizePublisherMock,
+            2
+        )
+    }
+
+    func test_rating_size_did_update() {
+        // Given
+        let ratingSizePublisherMock: PublisherMock<Published<RatingSizeAttributes>.Publisher> = .init(publisher: self.sut.$ratingSize)
+
+        ratingSizePublisherMock.loadTesting(on: &subscriptions)
+
+        // When
+        self.sut.size = .input
+
+        // Then
+        XCTAssertPublisherSinkCountEqual(
+            on: ratingSizePublisherMock,
+            2
+        )
+    }
+
+    func test_rating_count_did_update() {
+        // Given
+        let ratingValuePublisherMock: PublisherMock<Published<CGFloat>.Publisher> = .init(publisher: self.sut.$ratingValue)
+
+        ratingValuePublisherMock.loadTesting(on: &subscriptions)
+
+        // When
+        self.sut.count = .one
+
+        // Then
+        XCTAssertPublisherSinkCountEqual(
+            on: ratingValuePublisherMock,
+            2
+        )
+
+        XCTAssertEqual(self.sut.ratingValue, self.sut.rating / 5.0)
+    }
+
+    func test_rating_did_update() {
+        // Given
+        let ratingValuePublisherMock: PublisherMock<Published<CGFloat>.Publisher> = .init(publisher: self.sut.$ratingValue)
+
+        ratingValuePublisherMock.loadTesting(on: &subscriptions)
+
+        // When
+        self.sut.count = .one
+        self.sut.rating = 4
+
+        // Then
+        XCTAssertPublisherSinkCountEqual(
+            on: ratingValuePublisherMock,
+            3
+        )
+
+        XCTAssertEqual(self.sut.ratingValue, self.sut.rating / 5.0)
+    }
+}

--- a/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
@@ -152,8 +152,9 @@ public class RatingDisplayUIView: UIView {
 
     // MARK: - Private functions
     private func setupView() {
+        self.accessibilityIdentifier = RatingDisplayAccessibilityIdentifier.identifier
         var currentRating = self.viewModel.ratingValue
-        for _ in 0..<count.rawValue {
+        for i in 0..<count.rawValue {
             let star = StarUIView(
                 rating: currentRating,
                 fillMode: self.fillMode,
@@ -162,6 +163,8 @@ public class RatingDisplayUIView: UIView {
                 fillColor: self.viewModel.colors.fillColor.uiColor
             )
             currentRating -= 1
+
+            star.accessibilityIdentifier = "\(RatingDisplayAccessibilityIdentifier.identifier)-\(i+1)"
 
             self.sizeConstraints.append(star.widthAnchor.constraint(equalToConstant: self.ratingSize))
             self.sizeConstraints.append(star.heightAnchor.constraint(equalToConstant: self.ratingSize))
@@ -186,16 +189,13 @@ public class RatingDisplayUIView: UIView {
         }
 
         self.viewModel.$ratingSize.subscribe(in: &self.cancellable) { [weak self] size in
-            self?.didUpdate(borderWidth: size.borderWidth)
-            self?.didUpdate(size: size.height)
-            self?.didUpdate(spacing: size.spacing)
+            self?.didUpdate(size: size)
         }
 
         self.viewModel.$ratingValue.subscribe(in: &self.cancellable) {
             [weak self] ratingValue in
             self?.didUpdate(rating: ratingValue)
         }
-
     }
 
     private func didUpdate(rating: CGFloat) {
@@ -213,10 +213,15 @@ public class RatingDisplayUIView: UIView {
         }
     }
 
+    private func didUpdate(size: RatingSizeAttributes) {
+        self.didUpdate(borderWidth: size.borderWidth)
+        self.didUpdate(size: size.height)
+        self.didUpdate(spacing: size.spacing)
+    }
     private func didUpdate(borderWidth: CGFloat) {
         self.borderWidth = borderWidth
         for view in self.ratingStarViews {
-            view.lineWidth = borderWidth
+            view.lineWidth = self.borderWidth
         }
     }
 
@@ -229,7 +234,7 @@ public class RatingDisplayUIView: UIView {
         self.ratingSize = size
 
         self.sizeConstraints.forEach { constraint in
-            constraint.constant = size
+            constraint.constant = self.ratingSize
         }
     }
 }

--- a/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
@@ -1,0 +1,199 @@
+//
+//  RatingDisplayUIView.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+public class RatingDisplayUIView: UIView {
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = self.spacing
+        return stackView
+    }()
+    
+    private let viewModel: RatingDisplayViewModel
+    private let count: RatingStarsCount
+    private let fillMode: StarFillMode
+    private var sizeConstraints = [NSLayoutConstraint]()
+    private var cancellable = Set<AnyCancellable>()
+
+    public var theme: Theme {
+        get {
+            return self.viewModel.theme
+        }
+        set {
+            self.viewModel.theme = newValue
+        }
+    }
+    
+    public var intent: RatingIntent {
+        get {
+            return self.viewModel.intent
+        }
+        set {
+            self.viewModel.intent = newValue
+        }
+    }
+    
+    public var size: RatingDisplaySize {
+        get {
+            return self.viewModel.size
+        }
+        set {
+            self.viewModel.size = newValue
+        }
+    }
+    
+    public var rating: CGFloat {
+        didSet {
+            self.didUpdate(rating: self.rating)
+        }
+    }
+    
+    public var lineWidth: CGFloat {
+        get {
+            return self.borderWidth
+        }
+        set {
+            self.borderWidth = newValue
+            self.didUpdate(borderWidth: self.borderWidth)
+        }
+    }
+    
+    @ScaledUIMetric private var borderWidth: CGFloat
+    @ScaledUIMetric private var ratingSize: CGFloat
+    @ScaledUIMetric private var spacing: CGFloat
+
+    public init(
+        theme: Theme,
+        intent: RatingIntent,
+        count: RatingStarsCount = .five,
+        size: RatingDisplaySize = .medium,
+        rating: CGFloat = 0.0,
+        fillMode: StarFillMode = .half,
+        configuration: StarConfiguration = .default
+    ) {
+        self.count = count
+        self.rating = rating
+        self.fillMode = fillMode
+        self.viewModel = RatingDisplayViewModel(
+            theme: theme,
+            intent: intent,
+            size: size)
+        self.spacing = self.viewModel.spacing
+        self.ratingSize = self.viewModel.ratingSize.height
+        self.borderWidth = self.viewModel.ratingSize.borderWidth
+
+        super.init(frame: .zero)
+        self.setupView()
+        self.setupSubscriptions()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        self._spacing.update(traitCollection: traitCollection)
+        self._borderWidth.update(traitCollection: traitCollection)
+        self._ratingSize.update(traitCollection: traitCollection)
+
+        self.didUpdate(borderWidth: self.borderWidth)
+
+        self.sizeConstraints.forEach { constraint in
+            constraint.constant = self.ratingSize
+        }
+    }
+
+    private func setupView() {
+        var currentRating = self.rating
+        for _ in 0..<count.rawValue {
+            let star = StarUIView(
+                rating: currentRating,
+                fillMode: self.fillMode,
+                lineWidth: self.borderWidth,
+                borderColor: self.viewModel.colors.strokeColor.uiColor,
+                fillColor: self.viewModel.colors.fillColor.uiColor
+            )
+            currentRating -= 1
+
+            self.sizeConstraints.append(star.widthAnchor.constraint(equalToConstant: self.ratingSize))
+            self.sizeConstraints.append(star.heightAnchor.constraint(equalToConstant: self.ratingSize))
+            self.stackView.addArrangedSubview(star)
+        }
+
+        self.addSubviewSizedEqually(self.stackView)
+
+        NSLayoutConstraint.activate(self.sizeConstraints)
+    }
+
+    private func setupSubscriptions() {
+        self.viewModel.$colors.subscribe(in: &self.cancellable) { [weak self] colors in
+            self?.didUpdate(colors: colors)
+        }
+
+        self.viewModel.$spacing.subscribe(in: &self.cancellable) { [weak self] spacing in
+            self?.didUpdate(spacing: spacing)
+        }
+
+        self.viewModel.$ratingSize.subscribe(in: &self.cancellable) { [weak self] size in
+            self?.didUpdate(borderWidth: size.borderWidth)
+            self?.didUpdate(size: size.height)
+        }
+
+    }
+
+    private func didUpdate(rating: CGFloat) {
+        let ratingStarViews = self.stackView.arrangedSubviews.compactMap { view in
+            return view as? StarUIView
+        }
+
+        var currentRating = rating
+        for view in ratingStarViews {
+            view.rating = currentRating
+            currentRating -= 1
+        }
+    }
+
+    private func didUpdate(colors: RatingColors) {
+        let ratingStarViews = self.stackView.arrangedSubviews.compactMap { view in
+            return view as? StarUIView
+        }
+
+        for view in ratingStarViews {
+            view.borderColor = colors.strokeColor.uiColor
+            view.fillColor = colors.fillColor.uiColor
+        }
+    }
+
+    private func didUpdate(borderWidth: CGFloat) {
+        let ratingStarViews = self.stackView.arrangedSubviews.compactMap { view in
+            return view as? StarUIView
+        }
+
+        for view in ratingStarViews {
+            view.lineWidth = borderWidth
+        }
+    }
+
+    private func didUpdate(spacing: CGFloat) {
+        self.spacing = spacing
+        self.stackView.spacing = self.spacing
+    }
+
+    private func didUpdate(size: CGFloat) {
+        self.ratingSize = size
+
+        self.sizeConstraints.forEach { constraint in
+            constraint.constant = size
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
@@ -122,6 +122,7 @@ public class RatingDisplayUIView: UIView {
         self._ratingSize.update(traitCollection: traitCollection)
 
         self.didUpdate(borderWidth: self.borderWidth)
+        self.stackView.spacing = self.spacing
 
         self.sizeConstraints.forEach { constraint in
             constraint.constant = self.ratingSize

--- a/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIView.swift
@@ -9,7 +9,12 @@
 import Combine
 import UIKit
 
+/// RatingDisplayUIView is a view with which a 5 star rating can be shown.
+/// The rating value is expected to be within the range [0...5]. Values outside of this range will be ignored. Anything less than zero will be shown as zero. Anything greater than 5 will be shown as five.
+/// The rating display may be shown with 5 stars (the standard version) or just one star for a shortened version. For the shortened version, the expected value range is still [0...5]
 public class RatingDisplayUIView: UIView {
+
+    // MARK: - Private variables
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -27,6 +32,9 @@ public class RatingDisplayUIView: UIView {
         }
     }
 
+    // MARK: - Public accessors
+    /// Count: the number of stars to show in the rating.
+    /// Only values five and one are allowed, five is the default.
     public var count: RatingStarsCount {
         get {
             return self.viewModel.count
@@ -38,6 +46,8 @@ public class RatingDisplayUIView: UIView {
         }
     }
 
+    /// The current rating. This should be a value in the range [0...5].
+    /// Anything small than 0 will be treated as a 0, and anything greater than 5 will be treated as a five.
     public var rating: CGFloat {
         get {
             return self.viewModel.rating
@@ -47,6 +57,7 @@ public class RatingDisplayUIView: UIView {
         }
     }
 
+    /// The current theme.
     public var theme: Theme {
         get {
             return self.viewModel.theme
@@ -56,6 +67,7 @@ public class RatingDisplayUIView: UIView {
         }
     }
     
+    /// The intent for defining the color.
     public var intent: RatingIntent {
         get {
             return self.viewModel.intent
@@ -65,6 +77,8 @@ public class RatingDisplayUIView: UIView {
         }
     }
     
+    /// The size of the rating stars.
+    /// Possible sizes `small`, `medium` and `input`.
     public var size: RatingDisplaySize {
         get {
             return self.viewModel.size
@@ -74,20 +88,23 @@ public class RatingDisplayUIView: UIView {
         }
     }
     
-    public var lineWidth: CGFloat {
-        get {
-            return self.borderWidth
-        }
-        set {
-            self.borderWidth = newValue
-            self.didUpdate(borderWidth: self.borderWidth)
-        }
-    }
-    
+    // MARK: - Scaled metrics
     @ScaledUIMetric private var borderWidth: CGFloat
     @ScaledUIMetric private var ratingSize: CGFloat
     @ScaledUIMetric private var spacing: CGFloat
 
+    // MARK: - Initialization
+
+
+    /// Create a rating display view with the following parameters
+    /// - Parameters:
+    ///   - theme: The current theme
+    ///   - intent: The intent to define the colors
+    ///   - count: The number of stars in the rating view. The default is `five`.
+    ///   - size: The size of the rating view. The default is `medium`
+    ///   - rating: The rating value. This should be a value within the range 0...5
+    ///   - fillMode: Define incomplete stars are to be filled. The default is `.half`
+    ///   - configuration: A configuration of the star. A default value is defined.
     public init(
         theme: Theme,
         intent: RatingIntent,
@@ -114,6 +131,10 @@ public class RatingDisplayUIView: UIView {
         self.setupSubscriptions()
     }
 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -129,6 +150,7 @@ public class RatingDisplayUIView: UIView {
         }
     }
 
+    // MARK: - Private functions
     private func setupView() {
         var currentRating = self.viewModel.ratingValue
         for _ in 0..<count.rawValue {
@@ -209,9 +231,5 @@ public class RatingDisplayUIView: UIView {
         self.sizeConstraints.forEach { constraint in
             constraint.constant = size
         }
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIViewSnapshotTests.swift
@@ -1,0 +1,44 @@
+//
+//  RatingDisplayUIViewSnapshotTests.swift
+//  Spark
+//
+//  Created by Michael Zimmermann on 20.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+@testable import SparkCore
+
+final class RatingDisplayUIViewSnapshotTests: UIKitComponentSnapshotTestCase {
+
+    // MARK: - Properties
+
+    private let theme: Theme = SparkTheme.shared
+
+    // MARK: - Tests
+
+    func test() {
+        let scenarios = RatingDisplayScenarioSnapshotTests.allCases
+
+        for scenario in scenarios {
+            let configurations = scenario.configuration(isSwiftUIComponent: false)
+            for configuration in configurations {
+                let view = RatingDisplayUIView(
+                    theme: self.theme,
+                    intent: .main,
+                    count: configuration.count,
+                    size: configuration.size,
+                    rating: configuration.rating
+                )
+
+                self.assertSnapshot(
+                    matching: view,
+                    modes: configuration.modes,
+                    sizes: configuration.sizes,
+                    testName: configuration.testName()
+                )
+            }
+        }
+    }
+}

--- a/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingDisplayUIViewSnapshotTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 @testable import SparkCore
 
@@ -31,6 +31,8 @@ final class RatingDisplayUIViewSnapshotTests: UIKitComponentSnapshotTestCase {
                     size: configuration.size,
                     rating: configuration.rating
                 )
+
+                view.backgroundColor = UIColor.lightGray
 
                 self.assertSnapshot(
                     matching: view,

--- a/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
@@ -229,8 +229,8 @@ public final class StarUIView: UIView {
                    self.lineWidth,
                    self.vertexSize,
                    self.cornerRadiusSize,
-                   self.borderColor.hashValue,
-                   self.fillColor.hashValue,
+                   self.borderColor.rgb,
+                   self.fillColor.rgb,
                    min(rect.width, rect.height),
         ].map{ "\($0)" }
             .joined(separator: "_")
@@ -239,6 +239,17 @@ public final class StarUIView: UIView {
 }
 
 // MARK: Private extension
+private extension UIColor {
+    var rgb: String {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return "\(red)-\(green)-\(blue)-\(alpha)"
+    }
+}
+
 private extension CGRect {
     var centerX: CGFloat {
         return (self.minX + self.maxX)/2

--- a/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIView.swift
@@ -126,8 +126,9 @@ public final class StarUIView: UIView {
     }
 
     // MARK: - Initializer
-    /// Initializer
-    /// Parameters:
+    /// Create a StarUIView with the following parameters
+    /// 
+    /// - Parameters:
     /// - numberOfVertices: number of vertex elements, the default is 5
     /// - rating: the value of the rating. This should be a number in the range [0...1]
     /// - fillMode: the fill mode of the start. The star will be filled according to the rating and the fillMode.

--- a/core/Sources/Components/Rating/View/UIKit/StarUIViewTests.swift
+++ b/core/Sources/Components/Rating/View/UIKit/StarUIViewTests.swift
@@ -32,6 +32,6 @@ final class StarUIViewTests: XCTestCase {
         // When
         let key = sut.cacheKey(rect: CGRect(x: 0, y: 0, width: 100, height: 100))
 
-        XCTAssertEqual(key, "StarUIView_6_0.0_2.0_0.5_0.12_144048128_917504_100.0")
+        XCTAssertEqual(key, "StarUIView_6_0.0_2.0_0.5_0.12_1.0-0.0-0.0-1.0_0.0-0.0-1.0-1.0_100.0")
     }
 }

--- a/spark/Demo/Classes/Extension/NumberFormatter.swift
+++ b/spark/Demo/Classes/Extension/NumberFormatter.swift
@@ -1,0 +1,21 @@
+//
+//  NumberFormatter.swift
+//  SparkDemo
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+extension NumberFormatter {
+    func multipling(_ value: NSNumber) -> Self {
+        self.multiplier = value
+        return self
+    }
+
+    func maximizingFractionDigits(_ value: Int) -> Self {
+        self.maximumFractionDigits = value
+        return self
+    }
+}

--- a/spark/Demo/Classes/View/Components/ComponentsViewController.swift
+++ b/spark/Demo/Classes/View/Components/ComponentsViewController.swift
@@ -86,6 +86,8 @@ extension ComponentsViewController {
             viewController = RadioButtonComponentUIViewController.build()
         case .ratingStar:
             viewController = StarComponentViewController.build()
+        case .ratingDisplay:
+            viewController = RatingDisplayComponentViewController.build()
         case .spinner:
             viewController = SpinnerComponentUIViewController.build()
         case .switchButton:
@@ -115,6 +117,7 @@ private extension ComponentsViewController {
         case icon
         case radioButton
         case ratingStar
+        case ratingDisplay
         case spinner
         case switchButton
         case tab

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIView.swift
@@ -30,7 +30,6 @@ final class RatingDisplayComponentUIView: ComponentUIView {
         super.init(viewModel: viewModel, componentView: componentView)
 
         self.setupSubscriptions()
-
     }
 
     required init?(coder: NSCoder) {
@@ -39,12 +38,11 @@ final class RatingDisplayComponentUIView: ComponentUIView {
 
     private static func makeRatingDisplayView(viewModel: RatingDisplayComponentUIViewModel) -> RatingDisplayUIView {
         let view = RatingDisplayUIView(
-            theme: viewModel.theme, 
+            theme: viewModel.theme,
             intent: viewModel.intent,
             count: viewModel.count,
             size: viewModel.size
         )
-
         return view
     }
 
@@ -53,13 +51,13 @@ final class RatingDisplayComponentUIView: ComponentUIView {
             guard let self = self else { return }
             let themes = self.viewModel.themes
             let themeTitle: String? = theme is SparkTheme ? themes.first?.title : themes.last?.title
-            
+
             self.viewModel.themeConfigurationItemViewModel.buttonTitle = themeTitle
             self.viewModel.configurationViewModel.update(theme: theme)
-            
+
             self.componentView.theme = theme
         }
-        
+
         self.viewModel.$size.subscribe(in: &self.cancellables) { [weak self] size in
             guard let self = self else { return }
             self.viewModel.sizeConfigurationItemViewModel.buttonTitle = size.name
@@ -77,11 +75,10 @@ final class RatingDisplayComponentUIView: ComponentUIView {
             self.viewModel.intentConfigurationItemViewModel.buttonTitle = intent.name
             self.componentView.intent = intent
         }
-        
+
         self.viewModel.$rating.subscribe(in: &self.cancellables) { [weak self] rating in
             guard let self = self else { return }
             self.componentView.rating = rating
         }
-
     }
 }

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIView.swift
@@ -41,6 +41,7 @@ final class RatingDisplayComponentUIView: ComponentUIView {
         let view = RatingDisplayUIView(
             theme: viewModel.theme, 
             intent: viewModel.intent,
+            count: viewModel.count,
             size: viewModel.size
         )
 
@@ -59,13 +60,18 @@ final class RatingDisplayComponentUIView: ComponentUIView {
             self.componentView.theme = theme
         }
         
-        
         self.viewModel.$size.subscribe(in: &self.cancellables) { [weak self] size in
             guard let self = self else { return }
             self.viewModel.sizeConfigurationItemViewModel.buttonTitle = size.name
             self.componentView.size = size
         }
-        
+
+        self.viewModel.$count.subscribe(in: &self.cancellables) { [weak self] count in
+            guard let self = self else { return }
+            self.viewModel.countConfigurationItemViewModel.buttonTitle = count.name
+            self.componentView.count = count
+        }
+
         self.viewModel.$intent.subscribe(in: &self.cancellables) { [weak self] intent in
             guard let self = self else { return }
             self.viewModel.intentConfigurationItemViewModel.buttonTitle = intent.name

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIView.swift
@@ -1,0 +1,81 @@
+//
+//  RatingDisplayUIView.swift
+//  SparkDemo
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+import UIKit
+import Combine
+import SparkCore
+import Spark
+
+final class RatingDisplayComponentUIView: ComponentUIView {
+
+    private var componentView: RatingDisplayUIView!
+
+    // MARK: - Properties
+    private let viewModel: RatingDisplayComponentUIViewModel
+    private var cancellables: Set<AnyCancellable> = []
+    private var sizeConstraints = [NSLayoutConstraint]()
+
+    // MARK: - Initializer
+    init(viewModel: RatingDisplayComponentUIViewModel) {
+        self.viewModel = viewModel
+        self.componentView = Self.makeRatingDisplayView(viewModel: viewModel)
+
+        super.init(viewModel: viewModel, componentView: componentView)
+
+        self.setupSubscriptions()
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private static func makeRatingDisplayView(viewModel: RatingDisplayComponentUIViewModel) -> RatingDisplayUIView {
+        let view = RatingDisplayUIView(
+            theme: viewModel.theme, 
+            intent: viewModel.intent,
+            size: viewModel.size
+        )
+
+        return view
+    }
+
+    private func setupSubscriptions() {
+        self.viewModel.$theme.subscribe(in: &self.cancellables) { [weak self] theme in
+            guard let self = self else { return }
+            let themes = self.viewModel.themes
+            let themeTitle: String? = theme is SparkTheme ? themes.first?.title : themes.last?.title
+            
+            self.viewModel.themeConfigurationItemViewModel.buttonTitle = themeTitle
+            self.viewModel.configurationViewModel.update(theme: theme)
+            
+            self.componentView.theme = theme
+        }
+        
+        
+        self.viewModel.$size.subscribe(in: &self.cancellables) { [weak self] size in
+            guard let self = self else { return }
+            self.viewModel.sizeConfigurationItemViewModel.buttonTitle = size.name
+            self.componentView.size = size
+        }
+        
+        self.viewModel.$intent.subscribe(in: &self.cancellables) { [weak self] intent in
+            guard let self = self else { return }
+            self.viewModel.intentConfigurationItemViewModel.buttonTitle = intent.name
+            self.componentView.intent = intent
+        }
+        
+        self.viewModel.$rating.subscribe(in: &self.cancellables) { [weak self] rating in
+            guard let self = self else { return }
+            self.componentView.rating = rating
+        }
+
+    }
+}

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
@@ -17,7 +17,7 @@ final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
     private var showThemeSheetSubject: PassthroughSubject<[ThemeCellModel], Never> = .init()
     private var showIntentSheetSubject: PassthroughSubject<[RatingIntent], Never> = .init()
     private var showSizeSheetSubject: PassthroughSubject<[RatingDisplaySize], Never> = .init()
-    
+    private var showCountSheetSubject: PassthroughSubject<[RatingStarsCount], Never> = .init()
     var themes = ThemeCellModel.themes
     
     // MARK: - Items Properties
@@ -44,7 +44,15 @@ final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
             target: (source: self, action: #selector(self.presentSizeSheet))
         )
     }()
-    
+
+    lazy var countConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Count",
+            type: .button,
+            target: (source: self, action: #selector(self.presentCountSheet))
+        )
+    }()
+
     lazy var ratingConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
             name: "Rating",
@@ -74,17 +82,23 @@ final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
             .eraseToAnyPublisher()
     }
 
+    var showCountSheet: AnyPublisher<[RatingStarsCount], Never> {
+        showCountSheetSubject
+            .eraseToAnyPublisher()
+    }
     // MARK: - Published Properties
     @Published var theme: Theme
     @Published var intent: RatingIntent
     @Published var size: RatingDisplaySize
     @Published var rating: CGFloat = 0.0
+    @Published var count: RatingStarsCount = .five
 
     override func configurationItemsViewModel() -> [ComponentsConfigurationItemUIViewModel] {
         return [
             self.themeConfigurationItemViewModel,
             self.intentConfigurationItemViewModel,
             self.sizeConfigurationItemViewModel,
+            self.countConfigurationItemViewModel,
             self.ratingConfigurationItemViewModel
         ]
     }
@@ -117,7 +131,11 @@ extension RatingDisplayComponentUIViewModel {
     @objc func presentSizeSheet() {
         self.showSizeSheetSubject.send(RatingDisplaySize.allCases)
     }
-    
+
+    @objc func presentCountSheet() {
+        self.showCountSheetSubject.send(RatingStarsCount.allCases)
+    }
+
     @objc func ratingChanged(_ control: NumberSelector) {
         self.rating = CGFloat(control.selectedValue) / 2.0
     }

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
@@ -58,7 +58,7 @@ final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
             name: "Rating",
             type: .rangeSelectorWithConfig(
                 selected: Int(self.rating),
-                range: 0...10,
+                range: 2...10,
                 stepper: 1,
                 numberFormatter: NumberFormatter()
                     .multipling(0.5)
@@ -90,7 +90,7 @@ final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
     @Published var theme: Theme
     @Published var intent: RatingIntent
     @Published var size: RatingDisplaySize
-    @Published var rating: CGFloat = 0.0
+    @Published var rating: CGFloat = 1.0
     @Published var count: RatingStarsCount = .five
 
     override func configurationItemsViewModel() -> [ComponentsConfigurationItemUIViewModel] {

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
@@ -1,0 +1,124 @@
+//
+//  RatingDisplayComponentUIViewModel.swift
+//  SparkDemo
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+import Spark
+import SparkCore
+import UIKit
+
+final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
+    
+    // MARK: - Private Properties
+    private var showThemeSheetSubject: PassthroughSubject<[ThemeCellModel], Never> = .init()
+    private var showIntentSheetSubject: PassthroughSubject<[RatingIntent], Never> = .init()
+    private var showSizeSheetSubject: PassthroughSubject<[RatingDisplaySize], Never> = .init()
+    
+    var themes = ThemeCellModel.themes
+    
+    // MARK: - Items Properties
+    lazy var themeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Theme",
+            type: .button,
+            target: (source: self, action: #selector(self.presentThemeSheet))
+        )
+    }()
+
+    lazy var intentConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Intent",
+            type: .button,
+            target: (source: self, action: #selector(self.presentIntentSheet))
+        )
+    }()
+
+    lazy var sizeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Size",
+            type: .button,
+            target: (source: self, action: #selector(self.presentSizeSheet))
+        )
+    }()
+    
+    lazy var ratingConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Rating",
+            type: .rangeSelectorWithConfig(
+                selected: Int(self.rating),
+                range: 0...10,
+                stepper: 1,
+                numberFormatter: NumberFormatter()
+                    .multipling(0.5)
+                    .maximizingFractionDigits(2)
+            ),
+            target: (source: self, action: #selector(self.ratingChanged)))
+    }()
+
+    var showThemeSheet: AnyPublisher<[ThemeCellModel], Never> {
+        showThemeSheetSubject
+            .eraseToAnyPublisher()
+    }
+
+    var showIntentSheet: AnyPublisher<[RatingIntent], Never> {
+        showIntentSheetSubject
+            .eraseToAnyPublisher()
+    }
+
+    var showSizeSheet: AnyPublisher<[RatingDisplaySize], Never> {
+        showSizeSheetSubject
+            .eraseToAnyPublisher()
+    }
+
+    // MARK: - Published Properties
+    @Published var theme: Theme
+    @Published var intent: RatingIntent
+    @Published var size: RatingDisplaySize
+    @Published var rating: CGFloat = 0.0
+
+    override func configurationItemsViewModel() -> [ComponentsConfigurationItemUIViewModel] {
+        return [
+            self.themeConfigurationItemViewModel,
+            self.intentConfigurationItemViewModel,
+            self.sizeConfigurationItemViewModel,
+            self.ratingConfigurationItemViewModel
+        ]
+    }
+
+    // MARK: Initializer
+    init(
+        theme: Theme,
+        intent: RatingIntent = .main,
+        size: RatingDisplaySize = .medium
+    ) {
+        self.theme = theme
+        self.intent = intent
+        self.size = size
+
+        super.init(identifier: "Rating Display")
+    }
+}
+
+// MARK: - Navigation
+extension RatingDisplayComponentUIViewModel {
+    
+    @objc func presentThemeSheet() {
+        self.showThemeSheetSubject.send(themes)
+    }
+    
+    @objc func presentIntentSheet() {
+        self.showIntentSheetSubject.send(RatingIntent.allCases)
+    }
+    
+    @objc func presentSizeSheet() {
+        self.showSizeSheetSubject.send(RatingDisplaySize.allCases)
+    }
+    
+    @objc func ratingChanged(_ control: NumberSelector) {
+        self.rating = CGFloat(control.selectedValue) / 2.0
+    }
+}

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentUIViewModel.swift
@@ -12,14 +12,14 @@ import SparkCore
 import UIKit
 
 final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
-    
+
     // MARK: - Private Properties
     private var showThemeSheetSubject: PassthroughSubject<[ThemeCellModel], Never> = .init()
     private var showIntentSheetSubject: PassthroughSubject<[RatingIntent], Never> = .init()
     private var showSizeSheetSubject: PassthroughSubject<[RatingDisplaySize], Never> = .init()
     private var showCountSheetSubject: PassthroughSubject<[RatingStarsCount], Never> = .init()
     var themes = ThemeCellModel.themes
-    
+
     // MARK: - Items Properties
     lazy var themeConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
@@ -119,15 +119,15 @@ final class RatingDisplayComponentUIViewModel: ComponentUIViewModel {
 
 // MARK: - Navigation
 extension RatingDisplayComponentUIViewModel {
-    
+
     @objc func presentThemeSheet() {
         self.showThemeSheetSubject.send(themes)
     }
-    
+
     @objc func presentIntentSheet() {
         self.showIntentSheetSubject.send(RatingIntent.allCases)
     }
-    
+
     @objc func presentSizeSheet() {
         self.showSizeSheetSubject.send(RatingDisplaySize.allCases)
     }

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentViewController.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentViewController.swift
@@ -71,6 +71,10 @@ final class RatingDisplayComponentViewController: UIViewController {
         self.viewModel.showSizeSheet.subscribe(in: &self.cancellables) { sizes in
             self.presentSizeActionSheet(sizes)
         }
+
+        self.viewModel.showCountSheet.subscribe(in: &self.cancellables) { counts in
+            self.presentCountActionSheet(counts)
+        }
     }
 }
 
@@ -110,6 +114,15 @@ extension RatingDisplayComponentViewController {
             values: sizes,
             texts: sizes.map{ $0.name }) { size in
                 self.viewModel.size = size
+            }
+            self.present(actionSheet, animated: true)
+    }
+
+    private func presentCountActionSheet(_ counts: [RatingStarsCount]) {
+        let actionSheet = SparkActionSheet<RatingStarsCount>.init(
+            values: counts,
+            texts: counts.map{ $0.name }) { count in
+                self.viewModel.count = count
             }
             self.present(actionSheet, animated: true)
     }

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentViewController.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/RatingDisplayComponentViewController.swift
@@ -1,0 +1,116 @@
+//
+//  RatingDisplayComponentViewController.swift
+//  SparkDemo
+//
+//  Created by Michael Zimmermann on 17.11.23.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import Combine
+import Spark
+import SwiftUI
+import UIKit
+import SparkCore
+
+final class RatingDisplayComponentViewController: UIViewController {
+
+    // MARK: - Published Properties
+    @ObservedObject private var themePublisher = SparkThemePublisher.shared
+
+    // MARK: - Properties
+    let componentView: RatingDisplayComponentUIView
+    let viewModel: RatingDisplayComponentUIViewModel
+    private var cancellables: Set<AnyCancellable> = []
+
+    // MARK: - Initializer
+    init(viewModel: RatingDisplayComponentUIViewModel) {
+        self.viewModel = viewModel
+        self.componentView = RatingDisplayComponentUIView(viewModel: viewModel)
+        super.init(nibName: nil, bundle: nil)
+
+        self.componentView.viewController = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func loadView() {
+        super.loadView()
+        view = componentView
+    }
+
+    // MARK: - ViewDidLoad
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationItem.title = "Rating Display"
+        addPublisher()
+    }
+
+    // MARK: - Add Publishers
+    private func addPublisher() {
+
+        self.themePublisher
+            .$theme
+            .sink { [weak self] theme in
+                guard let self = self else { return }
+                self.viewModel.theme = theme
+                self.navigationController?.navigationBar.tintColor = theme.colors.main.main.uiColor
+            }
+            .store(in: &self.cancellables)
+
+        self.viewModel.showThemeSheet.subscribe(in: &self.cancellables) { intents in
+            self.presentThemeActionSheet(intents)
+        }
+
+        self.viewModel.showIntentSheet.subscribe(in: &self.cancellables) { intents in
+            self.presentIntentActionSheet(intents)
+        }
+
+        self.viewModel.showSizeSheet.subscribe(in: &self.cancellables) { sizes in
+            self.presentSizeActionSheet(sizes)
+        }
+    }
+}
+
+// MARK: - Builder
+extension RatingDisplayComponentViewController {
+
+    static func build() -> RatingDisplayComponentViewController {
+        let viewModel = RatingDisplayComponentUIViewModel(theme: SparkThemePublisher.shared.theme)
+        let viewController = RatingDisplayComponentViewController(viewModel: viewModel)
+        return viewController
+    }
+}
+
+// MARK: - Navigation
+extension RatingDisplayComponentViewController {
+
+    private func presentThemeActionSheet(_ themes: [ThemeCellModel]) {
+        let actionSheet = SparkActionSheet<Theme>.init(
+            values: themes.map { $0.theme },
+            texts: themes.map { $0.title }) { theme in
+                self.themePublisher.theme = theme
+            }
+        self.present(actionSheet, animated: true)
+    }
+
+    private func presentIntentActionSheet(_ intents: [RatingIntent]) {
+        let actionSheet = SparkActionSheet<RatingIntent>.init(
+            values: intents,
+            texts: intents.map { $0.name }) { intent in
+                self.viewModel.intent = intent
+            }
+        self.present(actionSheet, animated: true)
+    }
+
+    private func presentSizeActionSheet(_ sizes: [RatingDisplaySize]) {
+        let actionSheet = SparkActionSheet<RatingDisplaySize>.init(
+            values: sizes,
+            texts: sizes.map{ $0.name }) { size in
+                self.viewModel.size = size
+            }
+            self.present(actionSheet, animated: true)
+    }
+}

--- a/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Rating/UIKit/StarComponentUIViewModel.swift
@@ -257,15 +257,3 @@ extension StarFillMode: CaseIterable {
         }
     }
 }
-
-private extension NumberFormatter {
-    func multipling(_ value: NSNumber) -> Self {
-        self.multiplier = value
-        return self
-    }
-
-    func maximizingFractionDigits(_ value: Int) -> Self {
-        self.maximumFractionDigits = value
-        return self
-    }
-}


### PR DESCRIPTION
### Pull requests template

# The rating display
This is the uIKit version of the rating display.
There is only one intent, but nonetheless an enum was created in accordance with all other components.
The API is a little more flexible than the specs define. In the specs, the rating display with five stars can have two sizes, small and medium. A rating display with one star should have the size of the rating input. 
A user can configure this, but the API doesn't block the user of configuring a five star rating with size `input`.

Snapshots are available: please see the PR https://github.com/adevinta/spark-ios-snapshots/pull/73.

This pull request has:
- [/] Code documentation on publics
- [/] Accessibility
	- [/] Dynamic sizes
	- [/] Identifiers
- [/] Tests
- [/] Demo update
- [ ] Wiki
