### PR TITLE
[RadioButton#629] Move single radio button support from Polaris to Spark

### DIFF
--- a/spark/Demo/Classes/View/Components/RadioButton/UIKit/RadioButtonComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/RadioButton/UIKit/RadioButtonComponentUIView.swift
@@ -14,21 +14,33 @@ import UIKit
 final class RadioButtonComponentUIView: ComponentUIView {
     // MARK: - Components
     private let componentView: RadioButtonUIGroupView<Int>
+    private let singleComponentView: RadioButtonUIView<Int>
+    private let stackView: UIStackView
 
     // MARK: - Properties
 
     private let viewModel: RadioButtonComponentUIViewModel
     private var cancellables = Set<AnyCancellable>()
+    private var singleRadioButtonValuePublished = false
 
     // MARK: - Initializer
     init(viewModel: RadioButtonComponentUIViewModel) {
         self.viewModel = viewModel
         let componentView = Self.makeRadioButtonView(viewModel)
         self.componentView = componentView
+        let singleComponentView = Self.makeSingleRadioButtonView(viewModel)
+        self.singleComponentView = singleComponentView
+
+        let stackView = UIStackView(arrangedSubviews: [componentView, singleComponentView])
+        stackView.axis = NSLayoutConstraint.Axis.vertical
+        stackView.spacing = 20
+
+        self.stackView = stackView
+
 
         super.init(
             viewModel: viewModel,
-            componentView: componentView
+            componentView: stackView
         )
 
         self.setupSubscriptions()
@@ -50,18 +62,21 @@ final class RadioButtonComponentUIView: ComponentUIView {
             self.viewModel.configurationViewModel.update(theme: theme)
 
             self.componentView.theme = theme
+            self.singleComponentView.theme = theme
         }
 
         self.viewModel.$intent.subscribe(in: &self.cancellables) { [weak self] intent in
             guard let self = self else { return }
             self.viewModel.intentConfigurationItemViewModel.buttonTitle = intent.name
             self.componentView.intent = intent
+            self.singleComponentView.intent = intent
         }
 
         self.viewModel.$labelAlignment.subscribe(in: &self.cancellables) { [weak self] alignment in
             guard let self = self else { return }
             self.viewModel.alignmentConfigurationItemViewModel.buttonTitle = alignment.name
             self.componentView.labelAlignment = alignment
+            self.singleComponentView.labelAlignment = alignment
         }
 
         self.viewModel.$axis.subscribe(in: &self.cancellables) { [weak self] axis in
@@ -105,6 +120,12 @@ final class RadioButtonComponentUIView: ComponentUIView {
 
         self.viewModel.$isDisabled.subscribe(in: &self.cancellables) { [weak self] disabled in
             self?.componentView.isEnabled = !disabled
+
+            self?.singleComponentView.isEnabled = !disabled
+        }
+
+        self.viewModel.$isSelected.subscribe(in: &self.cancellables) { [weak self] selected in
+            self?.singleComponentView.isSelected = selected
         }
 
         self.viewModel.$numberOfRadioButtons.subscribe(in: &self.cancellables) { [weak self] numberOfRadioButtons in
@@ -120,10 +141,32 @@ final class RadioButtonComponentUIView: ComponentUIView {
                 self.componentView.addRadioButton(content)
             }
         }
+
+        self.componentView.radioButtonViews[0].publisher.subscribe(in: &self.cancellables) { selected in
+            print("GROUP VALUE PUBLISHED \(selected)")
+        }
+        self.singleComponentView.publisher
+            .subscribe(in: &self.cancellables) {
+                [weak self] selected in
+                guard let self = self else { return }
+                print("VALUE PUBLISHED \(selected)")
+                self.singleRadioButtonValuePublished = selected
+            }
+
+        let action = UIAction { [weak self] action in
+            guard let self = self else { return }
+            print("ACTION HANDLE")
+            if !self.singleRadioButtonValuePublished {
+                self.singleComponentView.isSelected = false
+            }
+            self.singleRadioButtonValuePublished = false
+        }
+        self.singleComponentView.addAction(action, for: .touchUpInside)
     }
 
     // MARK: - Private construction helper
     static private func makeRadioButtonView(_ viewModel: RadioButtonComponentUIViewModel) -> RadioButtonUIGroupView<Int> {
+
         let component = RadioButtonUIGroupView(
             theme: viewModel.theme,
             intent: viewModel.intent,
@@ -135,7 +178,15 @@ final class RadioButtonComponentUIView: ComponentUIView {
 
         component.title = "Radio Button Group (UIKit)"
         component.supplementaryText = "Radio Button Group Supplementary Text"
-
         return component
+    }
+
+    static private func makeSingleRadioButtonView(_ viewModel: RadioButtonComponentUIViewModel) -> RadioButtonUIView<Int> {
+        return RadioButtonUIView(
+            theme: viewModel.theme,
+            intent: viewModel.intent,
+            id: 99,
+            label: NSAttributedString(string: "Sample of toggle on radio button"),
+            isSelected: false)
     }
 }

--- a/spark/Demo/Classes/View/Components/RadioButton/UIKit/RadioButtonComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/RadioButton/UIKit/RadioButtonComponentUIViewModel.swift
@@ -83,6 +83,13 @@ final class RadioButtonComponentUIViewModel: ComponentUIViewModel {
             target: (source: self, action: #selector(self.disableChanged(_:))))
     }()
 
+    lazy var selectedConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Selected (for single radio button)",
+            type: .checkbox(title: "", isOn: self.isSelected),
+            target: (source: self, action: #selector(self.selectedChanged(_:))))
+    }()
+
     lazy var numberOfRadioButtonsConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
             name: "Number of Items",
@@ -110,7 +117,8 @@ final class RadioButtonComponentUIViewModel: ComponentUIViewModel {
             self.longLabelConfigurationItemViewModel,
             self.attributedLabelConfigurationItemViewModel,
             self.disableConfigurationItemViewModel,
-            self.numberOfRadioButtonsConfigurationItemViewModel
+            self.numberOfRadioButtonsConfigurationItemViewModel,
+            self.selectedConfigurationItemViewModel
         ]
     }
 
@@ -127,6 +135,7 @@ final class RadioButtonComponentUIViewModel: ComponentUIViewModel {
     @Published var showIcon = true
     @Published var showBadge = false
     @Published var isDisabled = false
+    @Published var isSelected = false // only for single radio button
     @Published var numberOfRadioButtons = 3
     @Published var selectedRadioButton = 0
     @Published var axis: RadioButtonGroupLayout = .vertical
@@ -208,6 +217,10 @@ extension RadioButtonComponentUIViewModel {
 
     @objc func disableChanged(_ selected: Any?) {
         self.isDisabled = isTrue(selected)
+    }
+
+    @objc func selectedChanged(_ selected: Any?) {
+        self.isSelected = isTrue(selected)
     }
 
     @objc func axisChanged(_ selected: Any?) {


### PR DESCRIPTION
To avoid having to use the binding in the single radio button, the adaptation which was used in Polaris has been moved to Spark

