### PR TITLE
[Button-557] Refactoring: Deprecated current button

### DIFF
--- a/core/Sources/Components/Button/AccessibilityIdentifier/ButtonAccessibilityIdentifier.swift
+++ b/core/Sources/Components/Button/AccessibilityIdentifier/ButtonAccessibilityIdentifier.swift
@@ -12,13 +12,24 @@ public enum ButtonAccessibilityIdentifier {
     // MARK: - Properties
 
     /// The default view accessibility identifier. Can be changed by the consumer
+    @available(*, deprecated, message: "Use button or iconButton key instead")
     public static let view = "spark-button"
+    /// The default view accessibility identifier. Can be changed by the consumer
+    public static let button = "spark-button"
+    /// The default icon button view accessibility identifier. Can be changed by the consumer
+    public static let iconButton = "spark-icon-button"
     /// The default content stackView accessibility identifier.
     static let contentStackView = "spark-button-content-stackView"
     /// The icon view accessibility identifier.
+    @available(*, deprecated, message: "Use imageContentView key instead")
     public static let icon = "spark-button-icon"
+    /// The icon view accessibility identifier.
+    public static let imageContentView = "spark-button-image-contentView"
     /// The icon image accessibility identifier.
+    @available(*, deprecated, message: "Use imageView key instead")
     public static let iconImage = "spark-button-icon-image"
+    /// The icon image accessibility identifier.
+    public static let imageView = "spark-button-image"
     /// The text accessibility identifier.
     public static let text = "spark-button-text"
     /// The default clear button accessibility identifier.

--- a/core/Sources/Components/Button/Enum/Public/Alignment/ButtonAlignmentDeprecated.swift
+++ b/core/Sources/Components/Button/Enum/Public/Alignment/ButtonAlignmentDeprecated.swift
@@ -1,13 +1,14 @@
 //
-//  ButtonAlignment.swift
+//  ButtonAlignmentDeprecated.swift
 //  SparkCore
 //
-//  Created by robin.lemaire on 27/06/2023.
+//  Created by robin.lemaire on 17/11/2023.
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
 /// The alignment of the switch.
-public enum ButtonAlignment: CaseIterable {
+@available(*, deprecated, message: "Use ButtonAlignment instead")
+public enum ButtonAlignmentDeprecated: CaseIterable {
     /// Icon on the leading edge of the button.
     /// Text on the trailing edge of the button.
     /// Not interpreted if button contains only just icon or just text.

--- a/core/Sources/Components/Button/Enum/Public/ButtonEvent.swift
+++ b/core/Sources/Components/Button/Enum/Public/ButtonEvent.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 /// All button touch events supported by this control.
+@available(*, deprecated, message: "Use native **action** or **target** on UIControl or publisher instead")
 public enum ButtonTouchEvent {
     /// Event triggered directly when the view is touched.
     /// - warning: This should not trigger a user action and should only be used for things like tracking.

--- a/core/Sources/Components/Button/Properties/Internal/Content/ButtonContent.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Content/ButtonContent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
+@available(*, deprecated, message: "Must be removed when ButtonUIViewDeprecated is deleted")
 struct ButtonContent: Equatable {
 
     // MARK: - Properties

--- a/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCase.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
+@available(*, deprecated, message: "Must be removed when ButtonViewModelDeprecated is deleted")
 // sourcery: AutoMockable
 protocol ButtonGetContentUseCaseable {
-    func execute(alignment: ButtonAlignment,
+    func execute(alignment: ButtonAlignmentDeprecated,
                  iconImage: ImageEither?,
                  containsTitle: Bool) -> ButtonContent
 }
@@ -18,7 +19,7 @@ struct ButtonGetContentUseCase: ButtonGetContentUseCaseable {
     // MARK: - Methods
 
     func execute(
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         iconImage: ImageEither?,
         containsTitle: Bool
     ) -> ButtonContent {

--- a/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCaseTests.swift
+++ b/core/Sources/Components/Button/UseCase/GetContent/ButtonGetContentUseCaseTests.swift
@@ -21,7 +21,7 @@ final class ButtonGetContentUseCaseTests: XCTestCase {
     func test_execute_when_alignment_is_leadingIcon_and_image_is_set_and_containsTitle_is_false() {
         self.testExecute(
             givenAlignment: .leadingIcon,
-            givenIconImage: self.imageMock,
+            givenImage: self.imageMock,
             givenContainsTitle: false,
             expectedContent: .init(
                 shouldShowIconImage: true,
@@ -35,7 +35,7 @@ final class ButtonGetContentUseCaseTests: XCTestCase {
     func test_execute_when_alignment_is_trailingIcon_and_image_is_set_and_containsTitle_is_false() {
         self.testExecute(
             givenAlignment: .trailingIcon,
-            givenIconImage: self.imageMock,
+            givenImage: self.imageMock,
             givenContainsTitle: false,
             expectedContent: .init(
                 shouldShowIconImage: true,
@@ -49,7 +49,7 @@ final class ButtonGetContentUseCaseTests: XCTestCase {
     func test_execute_when_alignment_is_leadingIcon_and_image_is_set_and_containsTitle_is_true() {
         self.testExecute(
             givenAlignment: .leadingIcon,
-            givenIconImage: self.imageMock,
+            givenImage: self.imageMock,
             givenContainsTitle: true,
             expectedContent: .init(
                 shouldShowIconImage: true,
@@ -63,7 +63,7 @@ final class ButtonGetContentUseCaseTests: XCTestCase {
     func test_execute_when_alignment_is_leadingIcon_and_containsTitle_is_true() {
         self.testExecute(
             givenAlignment: .leadingIcon,
-            givenIconImage: nil,
+            givenImage: nil,
             givenContainsTitle: true,
             expectedContent: .init(
                 shouldShowIconImage: false,
@@ -80,14 +80,14 @@ final class ButtonGetContentUseCaseTests: XCTestCase {
 private extension ButtonGetContentUseCaseTests {
 
     func testExecute(
-        givenAlignment: ButtonAlignment,
-        givenIconImage: UIImage?,
+        givenAlignment: ButtonAlignmentDeprecated,
+        givenImage: UIImage?,
         givenContainsTitle: Bool,
         expectedContent: ButtonContent
     ) {
         // GIVEN
         var errorSuffixMessage = " for \(givenAlignment) alignment case"
-        if givenIconImage != nil {
+        if givenImage != nil {
             errorSuffixMessage += " - with icon image"
         }
         if givenContainsTitle {
@@ -97,8 +97,8 @@ private extension ButtonGetContentUseCaseTests {
         let useCase = ButtonGetContentUseCase()
 
         let iconImage: ImageEither?
-        if let givenIconImage {
-            iconImage = .left(givenIconImage)
+        if let givenImage {
+            iconImage = .left(givenImage)
         } else {
             iconImage = nil
         }

--- a/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetCurrentColors/ButtonGetCurrentColorsUseCase.swift
@@ -8,6 +8,7 @@
 
 // sourcery: AutoMockable
 protocol ButtonGetCurrentColorsUseCaseable {
+    @available(*, deprecated, message: "Use the execute function without the displayedTitleType parameter instead. Must be removed when ButtonViewModelDeprecated is deleted")
     func execute(colors: ButtonColors,
                  isPressed: Bool,
                  displayedTitleType: DisplayedTextType) -> ButtonCurrentColors

--- a/core/Sources/Components/Button/UseCase/GetIsOnlyIcon/ButtonGetIsOnlyIconUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetIsOnlyIcon/ButtonGetIsOnlyIconUseCase.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Adevinta. All rights reserved.
 //
 
+@available(*, deprecated, message: "Must be removed when ButtonViewModelDeprecated is deleted")
 // sourcery: AutoMockable
 protocol ButtonGetIsOnlyIconUseCaseable {
     func execute(iconImage: ImageEither?,

--- a/core/Sources/Components/Button/UseCase/GetSizes/ButtonGetSizesUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetSizes/ButtonGetSizesUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol ButtonGetSizesUseCaseable {
+    @available(*, deprecated, message: "Use the execute function with the type parameter instead. Must be removed when ButtonViewModelDeprecated is deleted")
     func execute(size: ButtonSize,
                  isOnlyIcon: Bool) -> ButtonSizes
 }

--- a/core/Sources/Components/Button/UseCase/GetSpacings/ButtonGetSpacingsUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetSpacings/ButtonGetSpacingsUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol ButtonGetSpacingsUseCaseable {
+    @available(*, deprecated, message: "Use the execute function without isOnlyIcon parameter instead. Must be removed when ButtonViewModelDeprecated is deleted")
     func execute(spacing: LayoutSpacing,
                  isOnlyIcon: Bool) -> ButtonSpacings
 }

--- a/core/Sources/Components/Button/View/Common/ButtonSutSnapshotTests.swift
+++ b/core/Sources/Components/Button/View/Common/ButtonSutSnapshotTests.swift
@@ -19,7 +19,7 @@ struct ButtonSutSnapshotTests {
     let variant: ButtonVariant
     let size: ButtonSize
     let shape: ButtonShape
-    let alignment: ButtonAlignment
+    let alignment: ButtonAlignmentDeprecated
     let iconImage: ImageEither?
     let title: String?
     let attributedTitle: AttributedStringEither?

--- a/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewDelegate.swift
+++ b/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewDelegate.swift
@@ -14,21 +14,21 @@ public protocol ButtonUIViewDelegate: AnyObject {
     /// Optionally implement this method to receive tap events and perform actions.
     /// - Parameter button: the button that was tapped
     /// - note: This is equivalent to receiving `button(button, didReceive: .touchUpInside)`.
-    func buttonWasTapped(_ button: ButtonUIView)
+    func buttonWasTapped(_ button: ButtonUIViewDeprecated)
 
     /// Optionally implement this method to receive touch events.
     /// - Parameters:
     ///   - button: the button receiving the touch event.
     ///   - touchEvent: the control event type.
     /// - note: When receiving touch-event `.touchUpInside`, `buttonWasTapped()` is called as well.
-    func button(_ button: ButtonUIView, didReceive touchEvent: ButtonTouchEvent)
+    func button(_ button: ButtonUIViewDeprecated, didReceive touchEvent: ButtonTouchEvent)
 }
 
 // MARK: - Default implementation
 public extension ButtonUIViewDelegate {
     // Tap handlers are optional.
-    func buttonWasTapped(_ button: ButtonUIView) {}
+    func buttonWasTapped(_ button: ButtonUIViewDeprecated) {}
 
     // Touch events are optional.
-    func button(_ button: ButtonUIView, didReceive touchEvent: ButtonTouchEvent) {}
+    func button(_ button: ButtonUIViewDeprecated, didReceive touchEvent: ButtonTouchEvent) {}
 }

--- a/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewDeprecated+ExtensionSnapshotTests.swift
+++ b/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewDeprecated+ExtensionSnapshotTests.swift
@@ -1,5 +1,5 @@
 //
-//  ButtonUIView+ExtensionSnapshotTests.swift
+//  ButtonUIViewDeprecated+ExtensionSnapshotTests.swift
 //  SparkCoreTests
 //
 //  Created by robin.lemaire on 04/07/2023.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SparkCore
 
-extension ButtonUIView {
+extension ButtonUIViewDeprecated {
 
     func testPressedAction() {
         self.viewModel.pressedAction()

--- a/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewDeprecated.swift
+++ b/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewDeprecated.swift
@@ -1,5 +1,5 @@
 //
-//  ButtonUIView.swift
+//  ButtonUIViewDeprecated.swift
 //  Spark
 //
 //  Created by janniklas.freundt.ext on 02.05.23.
@@ -10,7 +10,8 @@ import Combine
 import UIKit
 
 /// The UIKit version for the button.
-public final class ButtonUIView: UIControl {
+@available(*, deprecated, message: "Use ButtonUIView or IconButtonUIView instead")
+public final class ButtonUIViewDeprecated: UIControl {
 
     // MARK: - Type alias
 
@@ -41,6 +42,7 @@ public final class ButtonUIView: UIControl {
                                                      for: .vertical)
         view.setContentCompressionResistancePriority(.required,
                                                      for: .horizontal)
+        view.backgroundColor = .yellow
         return view
     }()
 
@@ -52,6 +54,7 @@ public final class ButtonUIView: UIControl {
         let imageView = UIControlStateImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityIdentifier = AccessibilityIdentifier.iconImage
+        imageView.backgroundColor = .orange
         return imageView
     }()
 
@@ -148,7 +151,7 @@ public final class ButtonUIView: UIControl {
     }
 
     /// The alignment of the button.
-    public var alignment: ButtonAlignment {
+    public var alignment: ButtonAlignmentDeprecated {
         get {
             return self.viewModel.alignment
         }
@@ -241,7 +244,7 @@ public final class ButtonUIView: UIControl {
 
     // MARK: - Internal Properties
 
-    internal let viewModel: ButtonViewModel
+    internal let viewModel: ButtonViewModelDeprecated
 
     // MARK: - Private Properties
 
@@ -282,7 +285,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         isEnabled: Bool
     ) {
         self.init(
@@ -316,7 +319,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         text: String,
         isEnabled: Bool
     ) {
@@ -351,7 +354,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         attributedText: NSAttributedString,
         isEnabled: Bool
     ) {
@@ -386,7 +389,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         iconImage: UIImage,
         isEnabled: Bool
     ) {
@@ -422,7 +425,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         iconImage: UIImage,
         text: String,
         isEnabled: Bool
@@ -459,7 +462,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         iconImage: UIImage,
         attributedText: NSAttributedString,
         isEnabled: Bool
@@ -484,7 +487,7 @@ public final class ButtonUIView: UIControl {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         iconImage: UIImage?,
         text: String?,
         attributedText: NSAttributedString?,

--- a/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Button/View/UIKit/Deprecated/ButtonUIViewSnapshotTests.swift
@@ -41,11 +41,11 @@ private extension ButtonUIViewSnapshotTests {
 
     func test(suts: [ButtonSutSnapshotTests], function: String = #function) {
         for sut in suts {
-            var view: ButtonUIView!
+            var view: ButtonUIViewDeprecated!
 
             // Icon + Title ?
             if let iconImage = sut.iconImage, let title = sut.title {
-                view = ButtonUIView(
+                view = ButtonUIViewDeprecated(
                     theme: self.theme,
                     intent: sut.intent,
                     variant: sut.variant,
@@ -58,7 +58,7 @@ private extension ButtonUIViewSnapshotTests {
                 )
 
             } else if let iconImage = sut.iconImage, let attributedTitle = sut.attributedTitle { // Icon + Attributed Title
-                view = ButtonUIView(
+                view = ButtonUIViewDeprecated(
                     theme: self.theme,
                     intent: sut.intent,
                     variant: sut.variant,
@@ -71,7 +71,7 @@ private extension ButtonUIViewSnapshotTests {
                 )
 
             } else if let iconImage = sut.iconImage { // Only Icon
-                view = ButtonUIView(
+                view = ButtonUIViewDeprecated(
                     theme: self.theme,
                     intent: sut.intent,
                     variant: sut.variant,
@@ -83,7 +83,7 @@ private extension ButtonUIViewSnapshotTests {
                 )
 
             } else if let title = sut.title { // Only Title
-                view = ButtonUIView(
+                view = ButtonUIViewDeprecated(
                     theme: self.theme,
                     intent: sut.intent,
                     variant: sut.variant,
@@ -95,7 +95,7 @@ private extension ButtonUIViewSnapshotTests {
                 )
 
             } else if let attributedTitle = sut.attributedTitle { // Only Attributed Title
-                view = ButtonUIView(
+                view = ButtonUIViewDeprecated(
                     theme: self.theme,
                     intent: sut.intent,
                     variant: sut.variant,

--- a/core/Sources/Components/Button/ViewModel/Deprecated/ButtonViewModelDeprecated.swift
+++ b/core/Sources/Components/Button/ViewModel/Deprecated/ButtonViewModelDeprecated.swift
@@ -1,5 +1,5 @@
 //
-//  ButtonViewModel.swift
+//  ButtonViewModelDeprecated.swift
 //  Spark
 //
 //  Created by janniklas.freundt.ext on 09.05.23.
@@ -8,7 +8,8 @@
 
 import Foundation
 
-final class ButtonViewModel: ObservableObject {
+@available(*, deprecated, message: "Use ButtonViewModel instead")
+final class ButtonViewModelDeprecated: ObservableObject {
 
     // MARK: - Properties
 
@@ -17,7 +18,7 @@ final class ButtonViewModel: ObservableObject {
     private(set) var variant: ButtonVariant
     private(set) var size: ButtonSize
     private(set) var shape: ButtonShape
-    private(set) var alignment: ButtonAlignment
+    private(set) var alignment: ButtonAlignmentDeprecated
     private(set) var iconImage: ImageEither?
     private(set) var isEnabled: Bool
 
@@ -49,7 +50,7 @@ final class ButtonViewModel: ObservableObject {
 
     private var isPressed: Bool = false
 
-    private let dependencies: any ButtonViewModelDependenciesProtocol
+    private let dependencies: any ButtonViewModelDeprecatedDependenciesProtocol
 
     // MARK: - Initialization
 
@@ -59,12 +60,12 @@ final class ButtonViewModel: ObservableObject {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         iconImage: ImageEither?,
         title: String? ,
         attributedTitle: AttributedStringEither?,
         isEnabled: Bool,
-        dependencies: any ButtonViewModelDependenciesProtocol = ButtonViewModelDependencies()
+        dependencies: any ButtonViewModelDeprecatedDependenciesProtocol = ButtonViewModelDeprecatedDependencies()
     ) {
         self.theme = theme
         self.intent = intent
@@ -158,7 +159,7 @@ final class ButtonViewModel: ObservableObject {
         }
     }
 
-    func set(alignment: ButtonAlignment) {
+    func set(alignment: ButtonAlignmentDeprecated) {
         if self.alignment != alignment {
             self.alignment = alignment
 

--- a/core/Sources/Components/Button/ViewModel/Deprecated/ButtonViewModelDeprecatedDependencies.swift
+++ b/core/Sources/Components/Button/ViewModel/Deprecated/ButtonViewModelDeprecatedDependencies.swift
@@ -1,5 +1,5 @@
 //
-//  ButtonViewModelDependencies.swift
+//  ButtonViewModelDeprecatedDependencies.swift
 //  SparkCore
 //
 //  Created by robin.lemaire on 03/07/2023.
@@ -8,8 +8,9 @@
 
 import Foundation
 
+@available(*, deprecated, message: "Use ButtonViewModelDependenciesProtocol instead")
 // sourcery: AutoMockable
-protocol ButtonViewModelDependenciesProtocol {
+protocol ButtonViewModelDeprecatedDependenciesProtocol {
     var getBorderUseCase: ButtonGetBorderUseCaseable { get }
     var getColorsUseCase: ButtonGetColorsUseCaseable { get }
     var getContentUseCase: ButtonGetContentUseCaseable { get }
@@ -23,7 +24,7 @@ protocol ButtonViewModelDependenciesProtocol {
                                      attributedTitle: AttributedStringEither?) -> DisplayedTextViewModel
 }
 
-struct ButtonViewModelDependencies: ButtonViewModelDependenciesProtocol {
+struct ButtonViewModelDeprecatedDependencies: ButtonViewModelDeprecatedDependenciesProtocol {
 
     // MARK: - Properties
 

--- a/core/Sources/Components/Button/ViewModel/Deprecated/ButtonViewModelDeprecatedTests.swift
+++ b/core/Sources/Components/Button/ViewModel/Deprecated/ButtonViewModelDeprecatedTests.swift
@@ -1,5 +1,5 @@
 //
-//  ButtonViewModelTests.swift
+//  ButtonViewModelDeprecatedTests.swift
 //  Spark
 //
 //  Created by janniklas.freundt.ext on 25.05.23.
@@ -11,7 +11,7 @@ import XCTest
 @testable import SparkCore
 import Combine
 
-final class ButtonViewModelTests: XCTestCase {
+final class ButtonViewModelDeprecatedTests: XCTestCase {
 
     // MARK: - Properties
 
@@ -34,7 +34,7 @@ final class ButtonViewModelTests: XCTestCase {
         let variantMock: ButtonVariant = .filled
         let sizeMock: ButtonSize = .large
         let shapeMock: ButtonShape = .pill
-        let alignmentMock: ButtonAlignment = .leadingIcon
+        let alignmentMock: ButtonAlignmentDeprecated = .leadingIcon
         let titleMock = "My Button"
         let attributedTitleMock = NSAttributedString(string: "My AT Button")
         let isEnabledMock = true
@@ -161,7 +161,7 @@ final class ButtonViewModelTests: XCTestCase {
         let variantMock: ButtonVariant = .outlined
         let sizeMock: ButtonSize = .medium
         let shapeMock: ButtonShape = .rounded
-        let alignmentMock: ButtonAlignment = .trailingIcon
+        let alignmentMock: ButtonAlignmentDeprecated = .trailingIcon
         let titleMock = "My Button"
         let attributedTitleMock = NSAttributedString(string: "My AT Button")
         let isEnabledMock = false
@@ -375,7 +375,7 @@ final class ButtonViewModelTests: XCTestCase {
         let variantMock: ButtonVariant = .outlined
         let sizeMock: ButtonSize = .medium
         let shapeMock: ButtonShape = .rounded
-        let alignmentMock: ButtonAlignment = .trailingIcon
+        let alignmentMock: ButtonAlignmentDeprecated = .trailingIcon
         let titleMock = "My Button"
         let attributedTitleMock = NSAttributedString(string: "My AT Button")
         let isEnabledMock = false
@@ -756,8 +756,8 @@ final class ButtonViewModelTests: XCTestCase {
         givenIsDifferentNewValue: Bool
     ) {
         // GIVEN
-        let defaultValue: ButtonAlignment = .leadingIcon
-        let newValue: ButtonAlignment = givenIsDifferentNewValue ? .trailingIcon : defaultValue
+        let defaultValue: ButtonAlignmentDeprecated = .leadingIcon
+        let newValue: ButtonAlignmentDeprecated = givenIsDifferentNewValue ? .trailingIcon : defaultValue
 
         let sizeMock: ButtonSize = .medium
 
@@ -826,7 +826,7 @@ final class ButtonViewModelTests: XCTestCase {
         let newValue: String? = newValueIsNil ? nil : "My New Title"
 
         let sizeMock: ButtonSize = .medium
-        let alignmentMock: ButtonAlignment = .trailingIcon
+        let alignmentMock: ButtonAlignmentDeprecated = .trailingIcon
 
         let stub = Stub(
             size: sizeMock,
@@ -932,7 +932,7 @@ final class ButtonViewModelTests: XCTestCase {
         let newValue = NSAttributedString(string: "My new AT Button")
 
         let sizeMock: ButtonSize = .medium
-        let alignmentMock: ButtonAlignment = .trailingIcon
+        let alignmentMock: ButtonAlignmentDeprecated = .trailingIcon
 
         let stub = Stub(
             size: sizeMock,
@@ -1029,7 +1029,7 @@ final class ButtonViewModelTests: XCTestCase {
     ) {
         // GIVEN
         let sizeMock: ButtonSize = .medium
-        let alignmentMock: ButtonAlignment = .trailingIcon
+        let alignmentMock: ButtonAlignmentDeprecated = .trailingIcon
 
         let stub = Stub(
             size: sizeMock,
@@ -1158,7 +1158,7 @@ final class ButtonViewModelTests: XCTestCase {
 
 // MARK: - Testing Published Data
 
-private extension ButtonViewModelTests {
+private extension ButtonViewModelDeprecatedTests {
 
     private func testState(on stub: Stub) {
         XCTAssertPublisherSinkValueEqual(
@@ -1212,7 +1212,7 @@ private extension ButtonViewModelTests {
 
 // MARK: - Testing Dependencies
 
-private extension ButtonViewModelTests {
+private extension ButtonViewModelDeprecatedTests {
 
     private func testGetBorderUseCaseMock(
         on stub: Stub,
@@ -1267,7 +1267,7 @@ private extension ButtonViewModelTests {
     private func testGetContentUseCaseMock(
         on stub: Stub,
         numberOfCalls: Int,
-        givenAlignment: ButtonAlignment? = nil,
+        givenAlignment: ButtonAlignmentDeprecated? = nil,
         givenIconImage: UIImage? = nil
     ) {
         XCTAssertEqual(stub.getContentUseCaseMock.executeWithAlignmentAndIconImageAndContainsTitleCallsCount,
@@ -1399,7 +1399,7 @@ private final class Stub {
 
     // MARK: - Properties
 
-    let viewModel: ButtonViewModel
+    let viewModel: ButtonViewModelDeprecated
 
     // MARK: - Data Properties
 
@@ -1427,7 +1427,7 @@ private final class Stub {
     let getSpacingsUseCaseMock: ButtonGetSpacingsUseCaseableGeneratedMock
     let getStateUseCaseMock: ButtonGetStateUseCaseableGeneratedMock
 
-    private let dependenciesMock: ButtonViewModelDependenciesProtocolGeneratedMock
+    private let dependenciesMock: ButtonViewModelDeprecatedDependenciesProtocolGeneratedMock
 
     // MARK: - Publisher Properties
 
@@ -1446,7 +1446,7 @@ private final class Stub {
         variant: ButtonVariant = .tinted,
         size: ButtonSize = .medium,
         shape: ButtonShape = .rounded,
-        alignment: ButtonAlignment = .leadingIcon,
+        alignment: ButtonAlignmentDeprecated = .leadingIcon,
         isIconImage: Bool = false,
         title: String? = nil,
         attributedTitle: NSAttributedString? = nil,
@@ -1491,7 +1491,7 @@ private final class Stub {
         getStateUseCaseMock.executeWithIsEnabledAndDimsReturnValue = self.stateMock
         self.getStateUseCaseMock = getStateUseCaseMock
 
-        let dependenciesMock = ButtonViewModelDependenciesProtocolGeneratedMock()
+        let dependenciesMock = ButtonViewModelDeprecatedDependenciesProtocolGeneratedMock()
         dependenciesMock.underlyingGetBorderUseCase = getBorderUseCaseMock
         dependenciesMock.underlyingGetColorsUseCase = getColorsUseCaseMock
         dependenciesMock.underlyingGetContentUseCase = getContentUseCaseMock
@@ -1520,7 +1520,7 @@ private final class Stub {
             attributedTitleEither = nil
         }
 
-        let viewModel = ButtonViewModel(
+        let viewModel = ButtonViewModelDeprecated(
             theme: self.themeMock,
             intent: intent,
             variant: variant,

--- a/spark/Demo/Classes/View/Components/Button/SwiftUI/ButtonComponentView.swift
+++ b/spark/Demo/Classes/View/Components/Button/SwiftUI/ButtonComponentView.swift
@@ -23,7 +23,7 @@ struct ButtonComponentView: View {
     @State private var variant: ButtonVariant = .filled
     @State private var size: ButtonSize = .medium
     @State private var shape: ButtonShape = .rounded
-    @State private var alignment: ButtonAlignment = .leadingIcon
+    @State private var alignment: ButtonAlignmentDeprecated = .leadingIcon
     @State private var content: ButtonContentDefault = .text
     @State private var isEnabled: CheckboxSelectionState = .selected
     @State private var isSelected: CheckboxSelectionState = .selected
@@ -73,7 +73,7 @@ struct ButtonComponentView: View {
                 EnumSelector(
                     title: "Alignment",
                     dialogTitle: "Select an alignment",
-                    values: ButtonAlignment.allCases,
+                    values: ButtonAlignmentDeprecated.allCases,
                     value: self.$alignment
                 )
 

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentItemsUIView.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentItemsUIView.swift
@@ -26,7 +26,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
     private let variant: ButtonVariant
     private let size: ButtonSize
     private let shape: ButtonShape
-    private let alignment: ButtonAlignment
+    private let alignment: ButtonAlignmentDeprecated
     private let content: ButtonContentDefault
     private let isEnabled: Bool
     private let isSelected: Bool
@@ -42,7 +42,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
         variant: ButtonVariant,
         size: ButtonSize,
         shape: ButtonShape,
-        alignment: ButtonAlignment,
+        alignment: ButtonAlignmentDeprecated,
         content: ButtonContentDefault,
         isEnabled: Bool,
         isSelected: Bool,
@@ -73,11 +73,11 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
     // MARK: - Maker
 
     func makeUIView(context: Context) -> UIStackView {
-        let buttonView: ButtonUIView
+        let buttonView: ButtonUIViewDeprecated
 
         switch self.content {
         case .icon:
-            buttonView = ButtonUIView(
+            buttonView = ButtonUIViewDeprecated(
                 theme: SparkTheme.shared,
                 intent: self.intent,
                 variant: self.variant,
@@ -89,7 +89,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
             )
 
         case .text:
-            buttonView = ButtonUIView(
+            buttonView = ButtonUIViewDeprecated(
                 theme: SparkTheme.shared,
                 intent: self.intent,
                 variant: self.variant,
@@ -101,7 +101,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
             )
 
         case .attributedText:
-            buttonView = ButtonUIView(
+            buttonView = ButtonUIViewDeprecated(
                 theme: SparkTheme.shared,
                 intent: self.intent,
                 variant: self.variant,
@@ -113,7 +113,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
             )
 
         case .iconAndText:
-            buttonView = ButtonUIView(
+            buttonView = ButtonUIViewDeprecated(
                 theme: SparkTheme.shared,
                 intent: self.intent,
                 variant: self.variant,
@@ -126,7 +126,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
             )
 
         case .iconAndAttributedText:
-            buttonView = ButtonUIView(
+            buttonView = ButtonUIViewDeprecated(
                 theme: SparkTheme.shared,
                 intent: self.intent,
                 variant: self.variant,
@@ -139,7 +139,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
             )
 
         default:
-            buttonView = ButtonUIView(
+            buttonView = ButtonUIViewDeprecated(
                 theme: SparkTheme.shared,
                 intent: self.intent,
                 variant: self.variant,
@@ -164,7 +164,7 @@ struct ButtonComponentItemsUIView: UIViewRepresentable {
     }
 
     func updateUIView(_ stackView: UIStackView, context: Context) {
-        guard let buttonView = stackView.arrangedSubviews.compactMap({ $0 as? ButtonUIView }).first else {
+        guard let buttonView = stackView.arrangedSubviews.compactMap({ $0 as? ButtonUIViewDeprecated }).first else {
             return
         }
 

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIView.swift
@@ -15,9 +15,9 @@ final class ButtonComponentUIView: ComponentUIView {
 
     // MARK: - Components
 
-    private let buttonView: ButtonUIView
+    private let buttonView: ButtonUIViewDeprecated
 
-    private static func makeButtonView(_ viewModel: ButtonComponentUIViewModel) -> ButtonUIView {
+    private static func makeButtonView(_ viewModel: ButtonComponentUIViewModel) -> ButtonUIViewDeprecated {
         return .init(
             theme: viewModel.theme,
             intent: viewModel.intent,
@@ -281,11 +281,11 @@ final class ButtonComponentUIView: ComponentUIView {
     }
 }
 
-// MARK: - ButtonUIViewDelegate
+// MARK: - ButtonUIViewDeprecatedDelegate
 
 extension ButtonComponentUIView: ButtonUIViewDelegate {
 
-    func buttonWasTapped(_ button: ButtonUIView) {
+    func buttonWasTapped(_ button: ButtonUIViewDeprecated) {
         self.showAlert(for: .delegate)
     }
 }

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentUIViewModel.swift
@@ -40,7 +40,7 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
             .eraseToAnyPublisher()
     }
 
-    var showAlignmentSheet: AnyPublisher<[ButtonAlignment], Never> {
+    var showAlignmentSheet: AnyPublisher<[ButtonAlignmentDeprecated], Never> {
         showAlignmentSheetSubject
             .eraseToAnyPublisher()
     }
@@ -77,7 +77,7 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
     @Published var variant: ButtonVariant
     @Published var size: ButtonSize
     @Published var shape: ButtonShape
-    @Published var alignment: ButtonAlignment
+    @Published var alignment: ButtonAlignmentDeprecated
     @Published var contentNormal: ButtonContentDefault
     @Published var contentHighlighted: ButtonContentDefault
     @Published var contentDisabled: ButtonContentDefault
@@ -235,7 +235,7 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
     private var showVariantSheetSubject: PassthroughSubject<[ButtonVariant], Never> = .init()
     private var showSizeSheetSubject: PassthroughSubject<[ButtonSize], Never> = .init()
     private var showShapeSheetSubject: PassthroughSubject<[ButtonShape], Never> = .init()
-    private var showAlignmentSheetSubject: PassthroughSubject<[ButtonAlignment], Never> = .init()
+    private var showAlignmentSheetSubject: PassthroughSubject<[ButtonAlignmentDeprecated], Never> = .init()
     private var showContentNormalSheetSubject: PassthroughSubject<[ButtonContentDefault], Never> = .init()
     private var showContentHighlightedSheetSubject: PassthroughSubject<[ButtonContentDefault], Never> = .init()
     private var showContentDisabledSheetSubject: PassthroughSubject<[ButtonContentDefault], Never> = .init()
@@ -252,7 +252,7 @@ final class ButtonComponentUIViewModel: ComponentUIViewModel {
         variant: ButtonVariant = .filled,
         size: ButtonSize = .medium,
         shape: ButtonShape = .rounded,
-        alignment: ButtonAlignment = .leadingIcon,
+        alignment: ButtonAlignmentDeprecated = .leadingIcon,
         contentNormal: ButtonContentDefault = .text,
         contentHighlighted: ButtonContentDefault = .text,
         contentDisabled: ButtonContentDefault = .text,
@@ -315,7 +315,7 @@ extension ButtonComponentUIViewModel {
     }
 
     @objc func presentAlignmentSheet() {
-        self.showAlignmentSheetSubject.send(ButtonAlignment.allCases)
+        self.showAlignmentSheetSubject.send(ButtonAlignmentDeprecated.allCases)
     }
 
     @objc func presentContentNormalSheet() {

--- a/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentViewController.swift
+++ b/spark/Demo/Classes/View/Components/Button/UIKit/ButtonComponentViewController.swift
@@ -164,8 +164,8 @@ extension ButtonComponentViewController {
         self.present(actionSheet, animated: true)
     }
 
-    private func presentAlignmentActionSheet(_ alignments: [ButtonAlignment]) {
-        let actionSheet = SparkActionSheet<ButtonAlignment>.init(
+    private func presentAlignmentActionSheet(_ alignments: [ButtonAlignmentDeprecated]) {
+        let actionSheet = SparkActionSheet<ButtonAlignmentDeprecated>.init(
             values: alignments,
             texts: alignments.map { $0.name }) { alignment in
                 self.viewModel.alignment = alignment


### PR DESCRIPTION
Deprecate all classes (UIView, Enum, UseCases, ...) which will no longer be used in the new button (next PR)