### PR TITLE
[Button-557] Add Control for SwiftUI

### DIFF
--- a/core/Sources/Common/Control/SwiftUI/Control.swift
+++ b/core/Sources/Common/Control/SwiftUI/Control.swift
@@ -1,0 +1,16 @@
+//
+//  Control.swift
+//  SparkCore
+//
+//  Created by robin.lemaire on 24/11/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+struct Control: Equatable {
+
+    // MARK: - Properties
+
+    var isDisabled: Bool = false
+    var isSelected: Bool = false
+    var isPressed: Bool = false
+}

--- a/core/Sources/Common/Control/SwiftUI/ControlStateImage.swift
+++ b/core/Sources/Common/Control/SwiftUI/ControlStateImage.swift
@@ -1,0 +1,50 @@
+//
+//  ControlStateImage.swift
+//  SparkCore
+//
+//  Created by robin.lemaire on 24/11/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import SwiftUI
+
+final class ControlStateImage: ObservableObject {
+
+    // MARK: - Public Published Properties
+
+    @Published var image: Image?
+
+    // MARK: - Private Properties
+
+    private let imageStates = ControlPropertyStates<Image>()
+
+    // MARK: - Setter
+
+    /// Set the image for a state.
+    /// - parameter image: new image
+    /// - parameter state: state of the image
+    /// - parameter control: the parent control
+    func setImage(
+        _ image: Image?,
+        for state: ControlState,
+        on control: Control
+    ) {
+        self.imageStates.setValue(image, for: state)
+        self.updateContent(from: control)
+    }
+
+    // MARK: - Update UI
+
+    /// Update the label (image or attributed) for a parent control state.
+    /// - parameter control: the parent control
+    func updateContent(from control: Control) {
+        // Create the status from the control
+        let status = ControlStatus(
+            isHighlighted: control.isPressed,
+            isEnabled: !control.isDisabled,
+            isSelected: control.isSelected
+        )
+
+        self.image = self.imageStates.value(for: status)
+    }
+}

--- a/core/Sources/Common/Control/SwiftUI/ControlStateImageTests.swift
+++ b/core/Sources/Common/Control/SwiftUI/ControlStateImageTests.swift
@@ -1,0 +1,81 @@
+//
+//  ControlStateImageTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by robin.lemaire on 24/11/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+
+@testable import SparkCore
+
+final class ControlStateImageTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_default_image() {
+        // GIVEN / WHEN
+        let controlStateImage = ControlStateImage()
+
+        // THEN
+        XCTAssertNil(controlStateImage.image)
+    }
+
+    func test_setImage() {
+        // GIVEN
+        let givenImage = Image("arrow")
+
+        let controlStateImage = ControlStateImage()
+
+        let statesMock = ControlPropertyStates<Image>()
+        statesMock.setValue(
+            givenImage,
+            for: .normal
+        )
+
+        // WHEN
+        controlStateImage.setImage(
+            givenImage,
+            for: .normal,
+            on: .init()
+        )
+
+        // THEN
+        XCTAssertEqual(
+            controlStateImage.image,
+            statesMock.value(for: .normal)
+        )
+    }
+
+    func test_updateContent() {
+        // GIVEN
+        let givenDisabledImage = Image("switchOff")
+
+        let control = Control(isDisabled: true)
+
+        let controlStateImage = ControlStateImage()
+
+        let statesMock = ControlPropertyStates<Image>()
+
+        controlStateImage.setImage(
+            givenDisabledImage,
+            for: .disabled,
+            on: .init()
+        )
+        statesMock.setValue(
+            givenDisabledImage,
+            for: .disabled
+        )
+
+        // WHEN
+        controlStateImage.updateContent(from: control)
+
+        // THEN
+        XCTAssertEqual(
+            controlStateImage.image,
+            statesMock.value(for: .disabled)
+        )
+    }
+}

--- a/core/Sources/Common/Control/SwiftUI/ControlStateText.swift
+++ b/core/Sources/Common/Control/SwiftUI/ControlStateText.swift
@@ -1,0 +1,91 @@
+//
+//  ControlStateText.swift
+//  SparkCore
+//
+//  Created by robin.lemaire on 24/11/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import SwiftUI
+
+final class ControlStateText: ObservableObject {
+
+    // MARK: - Public Published Properties
+
+    @Published var text: String?
+    @Published var attributedText: AttributedString?
+
+    // MARK: - Private Properties
+
+    private let textStates = ControlPropertyStates<String>()
+    private let attributedTextStates = ControlPropertyStates<AttributedString>()
+    private let textTypesStates = ControlPropertyStates<DisplayedTextType>()
+
+    // MARK: - Setter
+
+    /// Set the text for a state.
+    /// - parameter text: new text
+    /// - parameter state: state of the text
+    /// - parameter control: the parent control
+    func setText(
+        _ text: String?,
+        for state: ControlState,
+        on control: Control
+    ) {
+        self.textStates.setValue(text, for: state)
+        self.textTypesStates.setValue(
+            text != nil ? .text : DisplayedTextType.none,
+            for: state
+        )
+        self.updateContent(from: control)
+    }
+
+    /// Set the attributed text for a state.
+    /// - parameter text: new attributed text
+    /// - parameter state: state of the attributed text
+    /// - parameter control: the parent control
+    func setAttributedText(
+        _ attributedText: AttributedString?,
+        for state: ControlState,
+        on control: Control
+    ) {
+        self.attributedTextStates.setValue(attributedText, for: state)
+        self.textTypesStates.setValue(
+            attributedText != nil ? .attributedText : DisplayedTextType.none,
+            for: state
+        )
+        self.updateContent(from: control)
+    }
+
+    // MARK: - Update UI
+
+    /// Update the label (text or attributed) for a parent control state.
+    /// - parameter control: the parent control
+    func updateContent(from control: Control) {
+        // Create the status from the control
+        let status = ControlStatus(
+            isHighlighted: control.isPressed,
+            isEnabled: !control.isDisabled,
+            isSelected: control.isSelected
+        )
+
+        // Get the current textType from status
+        let textType = self.textTypesStates.value(for: status)
+
+        // Set the text or the attributedText from textType and states
+        if let text = self.textStates.value(for: status),
+           textType == .text {
+            self.attributedText = nil
+            self.text = text
+
+        } else if let attributedText = self.attributedTextStates.value(for: status),
+                  textType == .attributedText {
+            self.text = nil
+            self.attributedText = attributedText
+
+        } else { // No text to displayed
+            self.text = nil
+            self.attributedText = nil
+        }
+    }
+}

--- a/core/Sources/Common/Control/SwiftUI/ControlStateTextTests.swift
+++ b/core/Sources/Common/Control/SwiftUI/ControlStateTextTests.swift
@@ -1,0 +1,124 @@
+//
+//  ControlStateTextTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by robin.lemaire on 24/11/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+
+@testable import SparkCore
+
+final class ControlStateTextTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_default_values() {
+        // GIVEN / WHEN
+        let controlStateText = ControlStateText()
+
+        // THEN
+        XCTAssertNil(
+            controlStateText.text,
+            "Wrong text value"
+        )
+        XCTAssertNil(
+            controlStateText.attributedText,
+            "Wrong attributedText value"
+        )
+    }
+
+    func test_setText() {
+        // GIVEN
+        let givenText = "My Text"
+
+        let controlStateText = ControlStateText()
+
+        let statesMock = ControlPropertyStates<String>()
+        statesMock.setValue(
+            givenText,
+            for: .normal
+        )
+
+        // WHEN
+        controlStateText.setText(
+            givenText,
+            for: .normal,
+            on: .init()
+        )
+
+        // THEN
+        XCTAssertEqual(
+            controlStateText.text,
+            statesMock.value(for: .normal),
+            "Wrong text value"
+        )
+        XCTAssertNil(
+            controlStateText.attributedText,
+            "Wrong attributedText value"
+        )
+    }
+
+    func test_setAttributedText() {
+        // GIVEN
+        let givenAttributedText = AttributedString("My AT Text")
+
+        let controlStateText = ControlStateText()
+
+        let statesMock = ControlPropertyStates<AttributedString>()
+        statesMock.setValue(
+            givenAttributedText,
+            for: .normal
+        )
+
+        // WHEN
+        controlStateText.setAttributedText(
+            givenAttributedText,
+            for: .normal,
+            on: .init()
+        )
+
+        // THEN
+        XCTAssertNil(
+            controlStateText.text,
+            "Wrong text value"
+        )
+        XCTAssertEqual(
+            controlStateText.attributedText,
+            statesMock.value(for: .normal),
+            "Wrong attributedText value"
+        )
+    }
+
+    func test_updateContent() {
+        // GIVEN
+        let givenDisabledText = "My Disabled Text"
+
+        let control = Control(isDisabled: true)
+
+        let controlStateText = ControlStateText()
+
+        let statesMock = ControlPropertyStates<String>()
+
+        controlStateText.setText(
+            givenDisabledText,
+            for: .disabled,
+            on: .init()
+        )
+        statesMock.setValue(
+            givenDisabledText,
+            for: .disabled
+        )
+
+        // WHEN
+        controlStateText.updateContent(from: control)
+
+        // THEN
+        XCTAssertEqual(
+            controlStateText.text,
+            statesMock.value(for: .disabled)
+        )
+    }
+}

--- a/core/Sources/Common/Control/SwiftUI/ControlTests.swift
+++ b/core/Sources/Common/Control/SwiftUI/ControlTests.swift
@@ -1,0 +1,26 @@
+//
+//  ControlTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by robin.lemaire on 24/11/2023.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+@testable import SparkCore
+
+final class ControlTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func test_default_values() {
+        // GIVEN / WHEN
+        let control = Control()
+
+        // THEN
+        XCTAssertFalse(control.isDisabled, "Wrong isDisabled value")
+        XCTAssertFalse(control.isSelected, "Wrong isSelected value")
+        XCTAssertFalse(control.isPressed, "Wrong isPressed value")
+    }
+}

--- a/core/Sources/Common/Control/UIView/UIControlStateLabel.swift
+++ b/core/Sources/Common/Control/UIView/UIControlStateLabel.swift
@@ -204,11 +204,10 @@ final class UIControlStateLabel: UILabel {
     /// The attributedText is displayed or not.
     private var isAttributedDisplayed: Bool {
         // There is an attributedText ?
-        guard let attributedText = self.attributedText else {
+        guard let attributedText = self.attributedText, attributedText.length > 0 else {
             return false
         }
 
-        // The attributedText contains attributes ?
-        return !attributedText.attributes(at: 0, effectiveRange: nil).isEmpty
+        return self.storedAttributedText == attributedText
     }
 }


### PR DESCRIPTION
This PR contains all needed class to manage the control status on a Text and Image SwiftUI (normal, pressed, selected, disabled states).

