### PR TITLE
[Chip#736] Set tint adjustment mode on icon.

### DIFF
--- a/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
+++ b/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
@@ -202,6 +202,7 @@ public final class ChipUIView: UIControl {
         imageView.isUserInteractionEnabled = false
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
+        imageView.tintAdjustmentMode = .normal
         imageView.accessibilityIdentifier = ChipAccessibilityIdentifier.icon
         imageView.setContentCompressionResistancePriority(.required,
                                                           for: .horizontal)

--- a/spark/Demo/Classes/View/Components/Chip/UIKit/ChipComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Chip/UIKit/ChipComponentUIView.swift
@@ -120,7 +120,17 @@ final class ChipComponentUIView: ComponentUIView {
         self.viewModel.$action.subscribe(in: &self.cancellables) { [weak self] action in
             guard let self = self else { return }
 
-            self.componentView.action = action
+            self.componentView.action = action.map{ [weak self] _ in { self?.showAlert() } }
         }
+    }
+
+    func showAlert() {
+        let alertController = UIAlertController(
+            title: "Chip tap",
+            message: nil,
+            preferredStyle: .alert
+        )
+        alertController.addAction(.init(title: "Ok", style: .default))
+        self.viewController?.present(alertController, animated: true)
     }
 }


### PR DESCRIPTION
Avoid the icon tint color being changed by the system.

<img width="378" alt="Bildschirmfoto 2024-01-10 um 15 12 47" src="https://github.com/adevinta/spark-ios/assets/128726463/2cd8417c-d007-47dd-bf3d-c1c965782c02">
