### PR TITLE
[Checkbox#735] add single checkbox snapshot tests

### DIFF
--- a/core/Sources/Components/Checkbox/Enum/CheckboxSelectionState.swift
+++ b/core/Sources/Components/Checkbox/Enum/CheckboxSelectionState.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Enum describing Checkbox selection states.
-public enum CheckboxSelectionState {
+public enum CheckboxSelectionState: CaseIterable {
     /// Checkbox is selected.
     case selected
 

--- a/core/Sources/Components/Checkbox/TestHelper/CheckboxConfigurationSnapshotTest.swift
+++ b/core/Sources/Components/Checkbox/TestHelper/CheckboxConfigurationSnapshotTest.swift
@@ -1,0 +1,45 @@
+//
+//  CheckboxConfigurationSnapshotTest.swift
+//  SparkCoreSnapshotTests
+//
+//  Created by alican.aycil on 12.01.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+@testable import SparkCore
+
+struct CheckboxConfigurationSnapshotTests {
+
+    // MARK: - Properties
+
+    let scenario: CheckboxScenarioSnapshotTests
+    let intent: CheckboxIntent
+    let selectionState: CheckboxSelectionState
+    let state: CheckboxState
+    let alignment: CheckboxAlignment
+    let text: String
+    let image: UIImage
+    let modes: [ComponentSnapshotTestMode]
+    let sizes: [UIContentSizeCategory]
+
+    // MARK: - Getter
+
+    func testName() -> String {
+        return [
+            "\(self.scenario.rawValue)",
+            "\(self.intent)",
+            "\(self.selectionState)",
+            "\(self.state)",
+            "\(self.alignment)"
+        ].joined(separator: "-")
+    }
+}
+
+enum CheckboxState: CaseIterable {
+    case enabled
+    case disabled
+    case pressed
+}

--- a/core/Sources/Components/Checkbox/TestHelper/CheckboxConfigurationSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/TestHelper/CheckboxConfigurationSnapshotTests.swift
@@ -1,8 +1,8 @@
 //
-//  CheckboxConfigurationSnapshotTest.swift
+//  CheckboxConfigurationSnapshotTests.swift
 //  SparkCoreSnapshotTests
 //
-//  Created by alican.aycil on 12.01.24.
+//  Created by alican.aycil on 16.01.24.
 //  Copyright © 2024 Adevinta. All rights reserved.
 //
 

--- a/core/Sources/Components/Checkbox/TestHelper/CheckboxScenarioSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/TestHelper/CheckboxScenarioSnapshotTests.swift
@@ -13,8 +13,9 @@ import SwiftUI
 
 enum CheckboxScenarioSnapshotTests: String, CaseIterable {
     case test1
-//    case test2
-//    case test3
+    case test2
+    case test3
+    case test4
 
     // MARK: - Type Alias
 
@@ -22,14 +23,16 @@ enum CheckboxScenarioSnapshotTests: String, CaseIterable {
 
     // MARK: - Configurations
 
-    func configuration(isSwiftUIComponent: Bool) -> [CheckboxConfigurationSnapshotTests] {
+    func configuration(isSwiftUIComponent: Bool = false) -> [CheckboxConfigurationSnapshotTests] {
         switch self {
         case .test1:
-            return self.test1(isSwiftUIComponent: isSwiftUIComponent)
-//        case .test2:
-//            return self.test2(isSwiftUIComponent: isSwiftUIComponent)
-//        case .test3:
-//            return self.test3(isSwiftUIComponent: isSwiftUIComponent)
+            return self.test1()
+        case .test2:
+            return self.test2(isSwiftUIComponent: isSwiftUIComponent)
+        case .test3:
+            return self.test3()
+        case .test4:
+            return self.test4()
         }
     }
 
@@ -47,7 +50,7 @@ enum CheckboxScenarioSnapshotTests: String, CaseIterable {
     ///  - text: normal text
     ///  - modes: all
     ///  - sizes (accessibility): default
-    private func test1(isSwiftUIComponent: Bool) -> [CheckboxConfigurationSnapshotTests] {
+    private func test1() -> [CheckboxConfigurationSnapshotTests] {
         let intents = CheckboxIntent.allCases
 
         return intents.map { intent in
@@ -57,7 +60,7 @@ enum CheckboxScenarioSnapshotTests: String, CaseIterable {
                 selectionState: .selected,
                 state: .enabled,
                 alignment: .left,
-                text: "Hello world", 
+                text: "Hello World", 
                 image: UIImage.mock,
                 modes: Constants.Modes.all,
                 sizes: Constants.Sizes.default
@@ -67,49 +70,97 @@ enum CheckboxScenarioSnapshotTests: String, CaseIterable {
 
     /// Test 2
     ///
-    ///
-    /// Description: To various accessibility sizes
+    /// Description: To test all states (content and component)
     ///
     /// Content:
-    ///  - ratings: [ 2.5]
-    ///  - size: small
-    ///  - count: five (number of stars)
-    ///  - modes: default
-    ///  - sizes: all
-//    private func test2(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
-//            return [.init(
-//                scenario: self,
-//                rating: 2.5,
-//                size: .small,
-//                count: .five,
-//                modes: Constants.Modes.default,
-//                sizes: Constants.Sizes.all
-//            )]
-//    }
+    ///  - intent: all
+    ///  - selectionState: selected
+    ///  - state: enabled
+    ///  - alignment: left
+    ///  - text: normal text
+    ///  - modes: all
+    ///  - sizes (accessibility): default
+    private func test2(isSwiftUIComponent: Bool) -> [CheckboxConfigurationSnapshotTests] {
+        let selectionStates = CheckboxSelectionState.allCases
+        let states = isSwiftUIComponent ? [.enabled, .disabled] : CheckboxState.allCases
+
+        return selectionStates.flatMap { selectionState in
+            states.map { state in
+                return CheckboxConfigurationSnapshotTests.init(
+                    scenario: self,
+                    intent: .basic,
+                    selectionState: selectionState,
+                    state: state,
+                    alignment: .left,
+                    text: "Hello World",
+                    image: UIImage.mock,
+                    modes: Constants.Modes.all,
+                    sizes: Constants.Sizes.default
+                )
+            }
+        }
+    }
 
     /// Test 3
     ///
-    /// Description: To various rating sizes
+    /// Description: To test label resilience
     ///
     /// Content:
-    ///  - ratings: [2.5]
-    ///  - size: [small, medium, input]
-    ///  - count: five (number of stars)
-    ///  - modes: default
-    ///  - accessibility sizes: default
-//    private func test3(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
-//
-//        return RatingDisplaySize.allCases.map { size in
-//            return .init(
-//                scenario: self,
-//                rating: 2.5,
-//                size: size,
-//                count: .five,
-//                modes: Constants.Modes.default,
-//                sizes: Constants.Sizes.default
-//            )
-//        }
-//    }
+    ///  - intent: all
+    ///  - selectionState: selected
+    ///  - state: enabled
+    ///  - alignment: left
+    ///  - text: normal text
+    ///  - modes: all
+    ///  - sizes (accessibility): default
+    private func test3() -> [CheckboxConfigurationSnapshotTests] {
+        let texts = ["Hello World", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."]
+        let alignments = CheckboxAlignment.allCases
+
+        return texts.flatMap { text in
+            alignments.map { alignment in
+                return CheckboxConfigurationSnapshotTests.init(
+                    scenario: self,
+                    intent: .main,
+                    selectionState: .selected,
+                    state: .enabled,
+                    alignment: alignment,
+                    text: text,
+                    image: UIImage.mock,
+                    modes: Constants.Modes.default,
+                    sizes: Constants.Sizes.default
+                )
+            }
+        }
+    }
+
+    /// Test 4
+    ///
+    /// Description: To test a11y sizes
+    ///
+    /// Content:
+    ///  - intent: all
+    ///  - selectionState: selected
+    ///  - state: enabled
+    ///  - alignment: left
+    ///  - text: normal text
+    ///  - modes: all
+    ///  - sizes (accessibility): default
+    private func test4() -> [CheckboxConfigurationSnapshotTests] {
+        let text = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+
+        return [.init(
+            scenario: self,
+            intent: .main,
+            selectionState: .unselected,
+            state: .enabled,
+            alignment: .right,
+            text: text,
+            image: UIImage.mock,
+            modes: Constants.Modes.default,
+            sizes: Constants.Sizes.all
+        )]
+    }
 }
 
 private extension UIImage {

--- a/core/Sources/Components/Checkbox/TestHelper/CheckboxScenarioSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/TestHelper/CheckboxScenarioSnapshotTests.swift
@@ -1,0 +1,117 @@
+//
+//  CheckboxScenarioSnapshotTests.swift
+//  Spark
+//
+//  Created by alican.aycil on 12.01.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+@testable import SparkCore
+
+enum CheckboxScenarioSnapshotTests: String, CaseIterable {
+    case test1
+//    case test2
+//    case test3
+
+    // MARK: - Type Alias
+
+    typealias Constants = ComponentSnapshotTestConstants
+
+    // MARK: - Configurations
+
+    func configuration(isSwiftUIComponent: Bool) -> [CheckboxConfigurationSnapshotTests] {
+        switch self {
+        case .test1:
+            return self.test1(isSwiftUIComponent: isSwiftUIComponent)
+//        case .test2:
+//            return self.test2(isSwiftUIComponent: isSwiftUIComponent)
+//        case .test3:
+//            return self.test3(isSwiftUIComponent: isSwiftUIComponent)
+        }
+    }
+
+    // MARK: - Scenarios
+
+    /// Test 1
+    ///
+    /// Description: To test all intents
+    ///
+    /// Content:
+    ///  - intent: all
+    ///  - selectionState: selected
+    ///  - state: enabled
+    ///  - alignment: left
+    ///  - text: normal text
+    ///  - modes: all
+    ///  - sizes (accessibility): default
+    private func test1(isSwiftUIComponent: Bool) -> [CheckboxConfigurationSnapshotTests] {
+        let intents = CheckboxIntent.allCases
+
+        return intents.map { intent in
+            return .init(
+                scenario: self,
+                intent: intent,
+                selectionState: .selected,
+                state: .enabled,
+                alignment: .left,
+                text: "Hello world", 
+                image: UIImage.mock,
+                modes: Constants.Modes.all,
+                sizes: Constants.Sizes.default
+            )
+        }
+    }
+
+    /// Test 2
+    ///
+    ///
+    /// Description: To various accessibility sizes
+    ///
+    /// Content:
+    ///  - ratings: [ 2.5]
+    ///  - size: small
+    ///  - count: five (number of stars)
+    ///  - modes: default
+    ///  - sizes: all
+//    private func test2(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
+//            return [.init(
+//                scenario: self,
+//                rating: 2.5,
+//                size: .small,
+//                count: .five,
+//                modes: Constants.Modes.default,
+//                sizes: Constants.Sizes.all
+//            )]
+//    }
+
+    /// Test 3
+    ///
+    /// Description: To various rating sizes
+    ///
+    /// Content:
+    ///  - ratings: [2.5]
+    ///  - size: [small, medium, input]
+    ///  - count: five (number of stars)
+    ///  - modes: default
+    ///  - accessibility sizes: default
+//    private func test3(isSwiftUIComponent: Bool) -> [RatingDisplayConfigurationSnapshotTests] {
+//
+//        return RatingDisplaySize.allCases.map { size in
+//            return .init(
+//                scenario: self,
+//                rating: 2.5,
+//                size: size,
+//                count: .five,
+//                modes: Constants.Modes.default,
+//                sizes: Constants.Sizes.default
+//            )
+//        }
+//    }
+}
+
+private extension UIImage {
+    static let mock: UIImage = UIImage(systemName: "checkmark")?.withRenderingMode(.alwaysTemplate) ?? UIImage()
+}

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxViewSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxViewSnapshotTests.swift
@@ -1,0 +1,63 @@
+//
+//  CheckboxViewSnapshotTests.swift
+//  SparkCoreSnapshotTests
+//
+//  Created by alican.aycil on 12.01.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import SwiftUI
+
+@testable import SparkCore
+
+final class CheckboxViewSnapshotTests: SwiftUIComponentSnapshotTestCase {
+
+    // MARK: - Properties
+
+    private let theme: Theme = SparkTheme.shared
+
+    private var selectionState: CheckboxSelectionState = .selected
+
+    private lazy var _selectionState: Binding<CheckboxSelectionState> = {
+        return Binding<CheckboxSelectionState>(
+            get: { return self.selectionState },
+            set: { newValue, transaction in
+                self.selectionState = newValue
+            }
+        )
+    }()
+
+    // MARK: - Tests
+
+    func test() {
+        let scenarios = CheckboxScenarioSnapshotTests.allCases
+
+        for scenario in scenarios {
+            let configurations = scenario.configuration(isSwiftUIComponent: true)
+
+            for configuration in configurations {
+                self.selectionState = configuration.selectionState
+
+                let view = CheckboxView(
+                    text: configuration.text,
+                    checkedImage: configuration.image,
+                    alignment: configuration.alignment,
+                    theme: self.theme,
+                    intent: configuration.intent,
+                    isEnabled: configuration.selectionState == .selected ? true : false,
+                    selectionState: self._selectionState
+                )
+                .background(Color.systemBackground)
+                .fixedSize()
+
+                self.assertSnapshot(
+                    matching: view,
+                    modes: configuration.modes,
+                    sizes: configuration.sizes,
+                    record: true,
+                    testName: configuration.testName()
+                )
+            }
+        }
+    }
+}

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxViewSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxViewSnapshotTests.swift
@@ -38,17 +38,24 @@ final class CheckboxViewSnapshotTests: SwiftUIComponentSnapshotTestCase {
             for configuration in configurations {
                 self.selectionState = configuration.selectionState
 
-                let view = CheckboxView(
+                var view = CheckboxView(
                     text: configuration.text,
                     checkedImage: configuration.image,
                     alignment: configuration.alignment,
                     theme: self.theme,
                     intent: configuration.intent,
-                    isEnabled: configuration.selectionState == .selected ? true : false,
+                    isEnabled: configuration.state == .disabled ? false : true,
                     selectionState: self._selectionState
                 )
                 .background(Color.systemBackground)
-                .fixedSize()
+                .if(configuration.text != "Hello World") { view in
+                    VStack {
+                        view
+                    }
+                    .frame(width: UIScreen.main.bounds.width)
+                } else: { view in
+                    view.fixedSize()
+                }
 
                 self.assertSnapshot(
                     matching: view,

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewSnapshotTests.swift
@@ -22,27 +22,53 @@ final class CheckboxUIViewSnapshotTests: UIKitComponentSnapshotTestCase {
         let scenarios = CheckboxScenarioSnapshotTests.allCases
 
         for scenario in scenarios {
-            let configurations = scenario.configuration(isSwiftUIComponent: false)
+            let configurations = scenario.configuration()
+            
             for configuration in configurations {
+
                 let view = CheckboxUIView(
                     theme: self.theme,
                     intent: configuration.intent,
                     text: configuration.text,
                     checkedImage: configuration.image,
-                    isEnabled: configuration.selectionState == .selected ? true : false,
+                    isEnabled: configuration.state == .disabled ? false : true,
                     selectionState: configuration.selectionState,
                     alignment: configuration.alignment
                 )
-
                 view.backgroundColor = UIColor.systemBackground
 
-                self.assertSnapshot(
-                    matching: view,
-                    modes: configuration.modes,
-                    sizes: configuration.sizes,
-                    record: false,
-                    testName: configuration.testName()
-                )
+                NSLayoutConstraint.activate([
+                    view.widthAnchor.constraint(lessThanOrEqualToConstant: UIScreen.main.bounds.size.width)
+                ])
+
+                if configuration.state == .pressed {
+                    view.isHighlighted = true
+
+                    let containerView = UIView()
+                    containerView.translatesAutoresizingMaskIntoConstraints = false
+                    containerView.addSubview(view)
+
+                    NSLayoutConstraint.activate([
+                        view.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 5),
+                        view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -5),
+                        view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 5),
+                        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5)
+                    ])
+
+                    self.assertSnapshot(
+                        matching: containerView,
+                        modes: configuration.modes,
+                        sizes: configuration.sizes,
+                        testName: configuration.testName()
+                    )
+                } else {
+                    self.assertSnapshot(
+                        matching: view,
+                        modes: configuration.modes,
+                        sizes: configuration.sizes,
+                        testName: configuration.testName()
+                    )
+                }
             }
         }
     }

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewSnapshotTests.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIViewSnapshotTests.swift
@@ -1,0 +1,49 @@
+//
+//  CheckboxUIViewSnapshotTests.swift
+//  SparkCoreSnapshotTests
+//
+//  Created by alican.aycil on 12.01.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import UIKit
+
+@testable import SparkCore
+
+final class CheckboxUIViewSnapshotTests: UIKitComponentSnapshotTestCase {
+
+    // MARK: - Properties
+
+    private let theme: Theme = SparkTheme.shared
+
+    // MARK: - Tests
+
+    func test() {
+        let scenarios = CheckboxScenarioSnapshotTests.allCases
+
+        for scenario in scenarios {
+            let configurations = scenario.configuration(isSwiftUIComponent: false)
+            for configuration in configurations {
+                let view = CheckboxUIView(
+                    theme: self.theme,
+                    intent: configuration.intent,
+                    text: configuration.text,
+                    checkedImage: configuration.image,
+                    isEnabled: configuration.selectionState == .selected ? true : false,
+                    selectionState: configuration.selectionState,
+                    alignment: configuration.alignment
+                )
+
+                view.backgroundColor = UIColor.systemBackground
+
+                self.assertSnapshot(
+                    matching: view,
+                    modes: configuration.modes,
+                    sizes: configuration.sizes,
+                    record: false,
+                    testName: configuration.testName()
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
I couldn't take pressed state snapshots for swiftui side so 6 of them are missed for now
https://docs.google.com/spreadsheets/d/1vdvHATjKpro3c5vjhKr97SpbBYOcYl-1-V76qWo9REo/edit#gid=485294969
