### PR TITLE
[CheckboxGroup#754] Fix axis issue when component is created

### DIFF
--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -183,6 +183,8 @@ public final class CheckboxGroupUIView: UIControl {
     }
 
     private func setupItemsStackView() {
+        self.updateLayout()
+        
         for item in self.items {
 
             var content: Either<NSAttributedString?, String?>


### PR DESCRIPTION
When checkboxGroup component is created, axis parameter wasn't applied.
