### PR TITLE
[Button] Split width constraint

### DIFF
--- a/core/Sources/Components/Button/View/UIKit/Button/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Button/ButtonUIView.swift
@@ -188,6 +188,12 @@ public final class ButtonUIView: ButtonMainUIView {
         self.setupImageContentViewConstraints()
     }
 
+    internal override func setupViewConstraints() {
+        super.setupViewConstraints()
+
+        self.widthAnchor.constraint(greaterThanOrEqualTo: self.heightAnchor).isActive = true
+    }
+
     private func setupContentStackViewConstraints() {
         self.contentStackView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/core/Sources/Components/Button/View/UIKit/Icon/IconButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Icon/IconButtonUIView.swift
@@ -56,6 +56,12 @@ public final class IconButtonUIView: ButtonMainUIView {
 
     // MARK: - Constraints
 
+    internal override func setupViewConstraints() {
+        super.setupViewConstraints()
+
+        self.widthAnchor.constraint(equalTo: self.heightAnchor).isActive = true
+    }
+
     internal override func setupImageViewConstraints() {
         super.setupImageViewConstraints()
 

--- a/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
@@ -204,13 +204,13 @@ public class ButtonMainUIView: UIControl {
         self.setupImageViewConstraints()
     }
 
-    private func setupViewConstraints() {
+    /// Setup the size constraints for this view.
+    /// This method is internal because it can be overriden by the view that inherits from this class.
+    internal func setupViewConstraints() {
         self.translatesAutoresizingMaskIntoConstraints = false
 
         self.heightConstraint = self.heightAnchor.constraint(equalToConstant: self.height)
         self.heightConstraint?.isActive = true
-
-        self.widthAnchor.constraint(greaterThanOrEqualTo: self.heightAnchor).isActive = true
     }
 
     /// Setup the imageView constraints.


### PR DESCRIPTION
To be sure to have a square icon button, the width constraint have been changed:
- greaterThanOrEqualTo the height of the view is used by the button
- equalTo the height of the view is used by the icon button
