### PR TITLE
[ProgressTracker#790] Add user interactions

### DIFF
--- a/core/Sources/Components/ProgressTracker/AccessibilityIdentifier/ProgressTrackerAccessibilityIdentifier.swift
+++ b/core/Sources/Components/ProgressTracker/AccessibilityIdentifier/ProgressTrackerAccessibilityIdentifier.swift
@@ -1,0 +1,28 @@
+//
+//  ProgressTrackerAccessibilityIdentifier.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 09.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import Foundation
+
+/// The accessibility identifiers for the Progress Tracker
+public enum ProgressTrackerAccessibilityIdentifier {
+
+    /// The general identifier for the control
+    public static let identifier = "progress-tracker"
+
+    public static let indicator = "\(Self.identifier)-indicator"
+
+    public static let label = "\(Self.identifier)-label"
+
+    public static func indicator(forIndex index: Int) -> String {
+        return "\(Self.indicator)-\(index)"
+    }
+
+    public static func label(forIndex index: Int) -> String {
+        return "\(Self.label)-\(index)"
+    }
+}

--- a/core/Sources/Components/ProgressTracker/AccessibilityIdentifier/ProgressTrackerAccessibilityIdentifierTests.swift
+++ b/core/Sources/Components/ProgressTracker/AccessibilityIdentifier/ProgressTrackerAccessibilityIdentifierTests.swift
@@ -1,0 +1,21 @@
+//
+//  ProgressTrackerAccessibilityIdentifierTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 09.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import SparkCore
+import XCTest
+
+final class ProgressTrackerAccessibilityIdentifierTests: XCTestCase {
+
+    func test_indicator_identifier() {
+        XCTAssertEqual(ProgressTrackerAccessibilityIdentifier.indicator(forIndex: 99), "progress-tracker-indicator-99")
+    }
+
+    func test_label_identifier() {
+        XCTAssertEqual(ProgressTrackerAccessibilityIdentifier.label(forIndex: 99), "progress-tracker-label-99")
+    }
+}

--- a/core/Sources/Components/ProgressTracker/Enum/ProgressTrackerInteractionState.swift
+++ b/core/Sources/Components/ProgressTracker/Enum/ProgressTrackerInteractionState.swift
@@ -13,4 +13,5 @@ public enum ProgressTrackerInteractionState: CaseIterable {
     case none
     case discrete
     case continuous
+    case independent
 }

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetColorsUseCase.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetColorsUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol ProgressTrackerGetColorsUseCaseable {
-    func execute(theme: Theme,
+    func execute(colors: Colors,
                  intent: ProgressTrackerIntent,
                  variant: ProgressTrackerVariant,
                  state: ProgressTrackerState) -> ProgressTrackerColors
@@ -34,13 +34,13 @@ struct ProgressTrackerGetColorsUseCase: ProgressTrackerGetColorsUseCaseable {
     // MARK: Execute
     /// Returns the colors of the progress tracker indicator
     func execute(
-        theme: Theme,
+        colors: Colors,
         intent: ProgressTrackerIntent,
         variant: ProgressTrackerVariant,
         state: ProgressTrackerState) -> ProgressTrackerColors {
             switch variant {
-            case .outlined: return self.getOutlinedColorsUseCase.execute(theme: theme, intent: intent, state: state)
-            case .tinted: return self.getTintedColorsUseCase.execute(theme: theme, intent: intent, state: state)
+            case .outlined: return self.getOutlinedColorsUseCase.execute(colors: colors, intent: intent, state: state)
+            case .tinted: return self.getTintedColorsUseCase.execute(colors: colors, intent: intent, state: state)
             }
     }
 }

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetColorsUseCaseTests.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetColorsUseCaseTests.swift
@@ -41,11 +41,11 @@ final class ProgressTrackerGetColorsUseCaseTests: XCTestCase {
             outline: colors.main.mainContainer,
             content: colors.main.onMainContainer)
 
-        self.tintedUseCase.executeWithThemeAndIntentAndStateReturnValue = expectedColors
+        self.tintedUseCase.executeWithColorsAndIntentAndStateReturnValue = expectedColors
 
         // WHEN
         let tabColors = self.sut.execute(
-            theme: self.theme,
+            colors: colors,
             intent: .basic,
             variant: .tinted,
             state: .normal)
@@ -62,11 +62,11 @@ final class ProgressTrackerGetColorsUseCaseTests: XCTestCase {
             outline: colors.main.main,
             content: colors.main.main)
 
-        self.outlinedUseCase.executeWithThemeAndIntentAndStateReturnValue = expectedColors
+        self.outlinedUseCase.executeWithColorsAndIntentAndStateReturnValue = expectedColors
 
         // WHEN
         let tabColors = self.sut.execute(
-            theme: self.theme,
+            colors: colors,
             intent: .basic,
             variant: .outlined,
             state: .normal)

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetOutlinedColorsUseCase.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetOutlinedColorsUseCase.swift
@@ -12,19 +12,17 @@ import Foundation
 struct ProgressTrackerGetOutlinedColorsUseCase: ProgressTrackerGetVariantColorsUseCaseable {
 
     /// Return the colors of the progress tracker indicator
-    func execute(theme: Theme,
+    func execute(colors: Colors,
                  intent: ProgressTrackerIntent,
                  state: ProgressTrackerState
     ) -> ProgressTrackerColors {
         let intentColors: ProgressTrackerColors = {
-            if state.isDisabled {
-                return self.disabledColors(colors: theme.colors, dims: theme.dims, intent: intent)
-            } else if state.isSelected {
-                    return self.selectedColors(colors: theme.colors, intent: intent)
+            if state.isSelected {
+                    return self.selectedColors(colors: colors, intent: intent)
             } else if state.isPressed {
-                return self.pressedColors(colors: theme.colors, intent: intent)
+                return self.pressedColors(colors: colors, intent: intent)
             } else {
-                return self.enabledColors(colors: theme.colors, intent: intent)
+                return self.enabledColors(colors: colors, intent: intent)
             }
         }()
 
@@ -32,15 +30,6 @@ struct ProgressTrackerGetOutlinedColorsUseCase: ProgressTrackerGetVariantColorsU
             background: intentColors.background,
             outline: intentColors.outline,
             content: intentColors.content)
-    }
-
-    private func disabledColors(colors: Colors, dims: Dims, intent: ProgressTrackerIntent) -> ProgressTrackerColors {
-        let variantColors = self.enabledColors(colors: colors, intent: intent)
-        return .init(
-            background: variantColors.background,
-            outline: variantColors.outline.opacity(dims.dim2),
-            content: variantColors.content.opacity(dims.dim2)
-            )
     }
 
     private func pressedColors(colors: Colors, intent: ProgressTrackerIntent) -> ProgressTrackerColors {

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetOutlinedColorsUseCaseTests.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetOutlinedColorsUseCaseTests.swift
@@ -13,13 +13,13 @@ import XCTest
 final class ProgressTrackerGetOutlinedColorsUseCaseTests: XCTestCase {
 
     var sut: ProgressTrackerGetOutlinedColorsUseCase!
-    var theme: ThemeGeneratedMock!
+    var colors: ColorsGeneratedMock!
 
     // MARK: - Setup
     override func setUp()  {
         super.setUp()
 
-        self.theme = ThemeGeneratedMock.mocked()
+        self.colors = ColorsGeneratedMock.mocked()
         self.sut = ProgressTrackerGetOutlinedColorsUseCase()
     }
 
@@ -29,10 +29,10 @@ final class ProgressTrackerGetOutlinedColorsUseCaseTests: XCTestCase {
 
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .selected)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .selected)
 
             // THEN
-            XCTAssertEqual(colors, intent.selectedColors(self.theme.colors), "Selected colors for intent \(intent) not as expected")
+            XCTAssertEqual(colors, intent.selectedColors(self.colors), "Selected colors for intent \(intent) not as expected")
         }
     }
 
@@ -42,10 +42,10 @@ final class ProgressTrackerGetOutlinedColorsUseCaseTests: XCTestCase {
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
 
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .normal)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .normal)
 
             // THEN
-            XCTAssertEqual(colors, intent.enabledColors(self.theme.colors), "Enabled colors for intent \(intent) not as expected")
+            XCTAssertEqual(colors, intent.enabledColors(self.colors), "Enabled colors for intent \(intent) not as expected")
         }
     }
 
@@ -55,10 +55,10 @@ final class ProgressTrackerGetOutlinedColorsUseCaseTests: XCTestCase {
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
 
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .pressed)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .pressed)
 
             // THEN
-            XCTAssertEqual(colors, intent.pressedColors(self.theme.colors), "Pressed colors for intent \(intent) not as expected")
+            XCTAssertEqual(colors, intent.pressedColors(self.colors), "Pressed colors for intent \(intent) not as expected")
         }
     }
 
@@ -68,9 +68,9 @@ final class ProgressTrackerGetOutlinedColorsUseCaseTests: XCTestCase {
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
 
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .disabled)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .disabled)
 
-            let expectedColors = intent.disabledColors(self.theme.colors, dims: self.theme.dims)
+            let expectedColors = intent.enabledColors(self.colors)
 
             // THEN
             XCTAssertEqual(colors, expectedColors, "Disabled colors for intent \(intent) not as expected")
@@ -129,14 +129,6 @@ private extension ProgressTrackerIntent {
                 outline: colors.support.support,
                 content: colors.support.onSupportContainer)
         }
-    }
-
-    func disabledColors(_ colors: Colors, dims: Dims) -> ProgressTrackerColors {
-        let variantColors = self.enabledColors(colors)
-        return ProgressTrackerColors(
-            background: variantColors.background,
-            outline: variantColors.outline.opacity(dims.dim2),
-            content: variantColors.content.opacity(dims.dim2))
     }
 
     func enabledColors(_ colors: Colors) -> ProgressTrackerColors {

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTintedColorsUseCase.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTintedColorsUseCase.swift
@@ -11,19 +11,17 @@ import Foundation
 /// A use case to calculate the tinted colors of the progress tracker
 struct ProgressTrackerGetTintedColorsUseCase: ProgressTrackerGetVariantColorsUseCaseable {
 
-    func execute(theme: Theme,
+    func execute(colors: Colors,
                  intent: ProgressTrackerIntent,
                  state: ProgressTrackerState
     ) -> ProgressTrackerColors {
         let intentColors: ProgressTrackerTintedColors = {
-            if state.isDisabled {
-                return self.disabledColors(colors: theme.colors, dims: theme.dims, intent: intent)
-            } else if state.isSelected {
-                return self.selectedColors(colors: theme.colors, intent: intent)
+            if state.isSelected {
+                return self.selectedColors(colors: colors, intent: intent)
             } else if state.isPressed {
-                return self.pressedColors(colors: theme.colors, intent: intent)
+                return self.pressedColors(colors: colors, intent: intent)
             } else {
-                return self.enabledColors(colors: theme.colors, intent: intent)
+                return self.enabledColors(colors: colors, intent: intent)
             }
         }()
 
@@ -34,15 +32,6 @@ struct ProgressTrackerGetTintedColorsUseCase: ProgressTrackerGetVariantColorsUse
     }
 
     // MARK: - Private functions
-    private func disabledColors(colors: Colors, dims: Dims, intent: ProgressTrackerIntent) -> ProgressTrackerTintedColors {
-        let variantColors = self.enabledColors(colors: colors, intent: intent)
-
-        return ProgressTrackerTintedColors(
-            background: variantColors.background.opacity(dims.dim2),
-            content: variantColors.content.opacity(dims.dim2)
-        )
-    }
-
     private func pressedColors(colors: Colors, intent: ProgressTrackerIntent) -> ProgressTrackerTintedColors {
         switch intent {
         case .accent:

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTintedColorsUseCaseTests.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTintedColorsUseCaseTests.swift
@@ -14,14 +14,14 @@ final class ProgressTrackerGetTintedColorsUseCaseTests: XCTestCase {
 
     // MARK: Properties
     var sut: ProgressTrackerGetTintedColorsUseCase!
-    var theme: ThemeGeneratedMock!
+    var colors: ColorsGeneratedMock!
 
     // MARK: Setup
     override func setUp()  {
         super.setUp()
 
         self.sut = ProgressTrackerGetTintedColorsUseCase()
-        self.theme = ThemeGeneratedMock.mocked()
+        self.colors = ColorsGeneratedMock.mocked()
     }
 
     // MARK: - Tests
@@ -30,10 +30,10 @@ final class ProgressTrackerGetTintedColorsUseCaseTests: XCTestCase {
 
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .selected)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .selected)
 
             // THEN
-            XCTAssertEqual(colors, intent.selectedColors(self.theme.colors), "Selected colors for intent \(intent) not as expected")
+            XCTAssertEqual(colors, intent.selectedColors(self.colors), "Selected colors for intent \(intent) not as expected")
         }
     }
 
@@ -43,10 +43,10 @@ final class ProgressTrackerGetTintedColorsUseCaseTests: XCTestCase {
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
 
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .normal)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .normal)
 
             // THEN
-            XCTAssertEqual(colors, intent.enabledColors(self.theme.colors), "Enabled colors for intent \(intent) not as expected")
+            XCTAssertEqual(colors, intent.enabledColors(self.colors), "Enabled colors for intent \(intent) not as expected")
         }
     }
 
@@ -56,10 +56,10 @@ final class ProgressTrackerGetTintedColorsUseCaseTests: XCTestCase {
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
 
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .pressed)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .pressed)
 
             // THEN
-            XCTAssertEqual(colors, intent.pressedColors(self.theme.colors), "Pressed colors for intent \(intent) not as expected")
+            XCTAssertEqual(colors, intent.pressedColors(self.colors), "Pressed colors for intent \(intent) not as expected")
         }
     }
 
@@ -70,9 +70,9 @@ final class ProgressTrackerGetTintedColorsUseCaseTests: XCTestCase {
         for intent in ProgressTrackerIntent.allCases {
             // WHEN
 
-            let colors = self.sut.execute(theme: self.theme, intent: intent, state: .disabled)
+            let colors = self.sut.execute(colors: self.colors, intent: intent, state: .disabled)
 
-            let expectedColors = intent.disabledColors(self.theme.colors, dims: self.theme.dims)
+            let expectedColors = intent.enabledColors(self.colors)
 
             // THEN
             XCTAssertEqual(colors, expectedColors, "Disabled colors for intent \(intent) not as expected")
@@ -129,15 +129,6 @@ private extension ProgressTrackerIntent {
             background: tintedColors.background,
             outline: tintedColors.background,
             content: tintedColors.content)
-    }
-
-    func disabledColors(_ colors: Colors, dims: Dims) -> ProgressTrackerColors {
-        let enabledColors = self.enabledColors(colors)
-
-        return ProgressTrackerColors(
-            background: enabledColors.background.opacity(dims.dim2),
-            outline: enabledColors.outline.opacity(dims.dim2),
-            content: enabledColors.content.opacity(dims.dim2))
     }
 
     func enabledColors(_ colors: Colors) -> ProgressTrackerColors {

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTrackColorUseCase.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTrackColorUseCase.swift
@@ -10,32 +10,25 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol ProgressTrackerGetTrackColorUseCaseable {
-    func execute(theme: Theme,
-                 intent: ProgressTrackerIntent,
-                 isEnabled: Bool) -> any ColorToken
+    func execute(colors: Colors,
+                 intent: ProgressTrackerIntent) -> any ColorToken
 }
 
 /// A use cate returning the color of the `track` between the progress tracker indicators.
 struct ProgressTrackerGetTrackColorUseCase: ProgressTrackerGetTrackColorUseCaseable {
 
-    func execute(theme: Theme,
-                 intent: ProgressTrackerIntent,
-                 isEnabled: Bool) -> any ColorToken {
-
-        let colorToken: any ColorToken = {
-            switch intent {
-            case .basic: return theme.colors.basic.basic
-            case .accent: return theme.colors.accent.accent
-            case .alert: return theme.colors.feedback.alert
-            case .danger: return theme.colors.feedback.error
-            case .info: return theme.colors.feedback.info
-            case .main: return theme.colors.main.main
-            case .neutral: return theme.colors.feedback.neutral
-            case .success: return theme.colors.feedback.success
-            case .support: return theme.colors.support.support
-            }
-        }()
-
-        return isEnabled ? colorToken : colorToken.opacity(theme.dims.dim3)
+    func execute(colors: Colors,
+                 intent: ProgressTrackerIntent) -> any ColorToken {
+        switch intent {
+        case .basic: return colors.basic.basic
+        case .accent: return colors.accent.accent
+        case .alert: return colors.feedback.alert
+        case .danger: return colors.feedback.error
+        case .info: return colors.feedback.info
+        case .main: return colors.main.main
+        case .neutral: return colors.feedback.neutral
+        case .success: return colors.feedback.success
+        case .support: return colors.support.support
+        }
     }
 }

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTrackColorUseCaseTests.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetTrackColorUseCaseTests.swift
@@ -14,43 +14,35 @@ final class ProgressTrackerGetTrackColorUseCaseTests: XCTestCase {
 
     // MARK: - Properties
     var sut: ProgressTrackerGetTrackColorUseCase!
-    var theme: ThemeGeneratedMock!
+    var colors: ColorsGeneratedMock!
 
     // MARK: - Setup
     override func setUp() {
         super.setUp()
 
-        self.theme = ThemeGeneratedMock.mocked()
+        self.colors = ColorsGeneratedMock.mocked()
         self.sut = ProgressTrackerGetTrackColorUseCase()
     }
 
     // MARK: - Tests
     func test_all_intents() {
-        let colors = self.theme.colors
         let expectedColors: [ProgressTrackerIntent: any ColorToken] =
         [
-            .accent: colors.accent.accent,
-            .alert: colors.feedback.alert,
-            .basic: colors.basic.basic,
-            .danger: colors.feedback.error,
-            .info: colors.feedback.info,
-            .main: colors.main.main,
-            .neutral: colors.feedback.neutral,
-            .success: colors.feedback.success,
-            .support: colors.support.support
+            .accent: self.colors.accent.accent,
+            .alert: self.colors.feedback.alert,
+            .basic: self.colors.basic.basic,
+            .danger: self.colors.feedback.error,
+            .info: self.colors.feedback.info,
+            .main: self.colors.main.main,
+            .neutral: self.colors.feedback.neutral,
+            .success: self.colors.feedback.success,
+            .support: self.colors.support.support
         ]
 
         for intent in ProgressTrackerIntent.allCases {
             let expectedColor = expectedColors[intent]
-            let givenColor = self.sut.execute(theme: self.theme, intent: intent, isEnabled: true)
+            let givenColor = self.sut.execute(colors: self.colors, intent: intent)
             XCTAssertTrue(expectedColor?.equals(givenColor) == true, "Enabled color for \(intent) is not as expected")
         }
-
-        for intent in ProgressTrackerIntent.allCases {
-            let expectedColor = expectedColors[intent]?.opacity(self.theme.dims.dim3)
-            let givenColor = self.sut.execute(theme: self.theme, intent: intent, isEnabled: false)
-            XCTAssertTrue(expectedColor?.equals(givenColor) == true, "Disabled color for \(intent) is not as expected")
-        }
-
     }
 }

--- a/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetVariantColorsUseCaseable.swift
+++ b/core/Sources/Components/ProgressTracker/UseCase/ProgressTrackerGetVariantColorsUseCaseable.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol ProgressTrackerGetVariantColorsUseCaseable {
-    func execute(theme: Theme,
+    func execute(colors: Colors,
                  intent: ProgressTrackerIntent,
                  state: ProgressTrackerState
     ) -> ProgressTrackerColors

--- a/core/Sources/Components/ProgressTracker/View/ProgressTrackerIndicatorViewModel.swift
+++ b/core/Sources/Components/ProgressTracker/View/ProgressTrackerIndicatorViewModel.swift
@@ -37,6 +37,7 @@ final class ProgressTrackerIndicatorViewModel<ComponentContent: ProgressTrackerC
         didSet {
             guard self.state != oldValue else { return }
             self.updateColors()
+            self.updateOpacity()
         }
     }
 
@@ -48,6 +49,7 @@ final class ProgressTrackerIndicatorViewModel<ComponentContent: ProgressTrackerC
     @Published var content: ComponentContent
     @Published var colors: ProgressTrackerColors
     @Published var font: TypographyFontToken
+    @Published var opacity: CGFloat = 1.0
 
     // MARK: Initialization
     init(theme: Theme,
@@ -66,13 +68,18 @@ final class ProgressTrackerIndicatorViewModel<ComponentContent: ProgressTrackerC
         self.colorsUseCase = colorsUseCase
         self.state = state
 
-        self.colors = colorsUseCase.execute(theme: theme, intent: intent, variant: variant, state: state)
+        self.colors = colorsUseCase.execute(colors: theme.colors, intent: intent, variant: variant, state: state)
 
         self.font = theme.typography.body2Highlight
+        self.updateOpacity()
     }
 
     private func updateColors() {
-        self.colors = self.colorsUseCase.execute(theme: theme, intent: intent, variant: variant, state: self.state)
+        self.colors = self.colorsUseCase.execute(colors: theme.colors, intent: intent, variant: variant, state: self.state)
+    }
+
+    private func updateOpacity() {
+        self.opacity = self.state.isEnabled ? 1.0 : self.theme.dims.dim3
     }
 
     func set(enabled: Bool) {

--- a/core/Sources/Components/ProgressTracker/View/ProgressTrackerIndicatorViewModelTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/ProgressTrackerIndicatorViewModelTests.swift
@@ -24,7 +24,7 @@ final class ProgressTrackerIndicatorViewModelTests: XCTestCase {
         self.colorsUseCase = ProgressTrackerGetColorsUseCaseableGeneratedMock()
 
         self.colorsUseCase
-            .executeWithThemeAndIntentAndVariantAndStateReturnValue = .init(
+            .executeWithColorsAndIntentAndVariantAndStateReturnValue = .init(
                 background: self.theme.colors.basic.basicContainer,
                 outline: self.theme.colors.basic.onBasic,
                 content: self.theme.colors.basic.basic
@@ -43,7 +43,7 @@ final class ProgressTrackerIndicatorViewModelTests: XCTestCase {
         XCTAssertEqual(sut.size, .small, "Expected size to be small")
         XCTAssertIdentical(sut.theme as? ThemeGeneratedMock, self.theme, "Expected theme to be identical")
 
-        XCTAssertEqual(self.colorsUseCase.executeWithThemeAndIntentAndVariantAndStateCallsCount, 1)
+        XCTAssertEqual(self.colorsUseCase.executeWithColorsAndIntentAndVariantAndStateCallsCount, 1)
     }
 
     func test_update_theme() {

--- a/core/Sources/Components/ProgressTracker/View/ProgressTrackerTrackViewModel.swift
+++ b/core/Sources/Components/ProgressTracker/View/ProgressTrackerTrackViewModel.swift
@@ -27,12 +27,13 @@ final class ProgressTrackerTrackViewModel: ObservableObject {
     var isEnabled: Bool {
         didSet {
             guard self.isEnabled != oldValue else { return }
-            self.updateLineColor()
+            self.updateOpacity()
         }
     }
 
     private var useCase: ProgressTrackerGetTrackColorUseCaseable
     @Published var lineColor: any ColorToken
+    @Published var opacity: CGFloat = 1.0
 
     // MARK: - Initialization
     init(theme: Theme,
@@ -44,13 +45,18 @@ final class ProgressTrackerTrackViewModel: ObservableObject {
         self.intent = intent
         self.useCase = useCase
         self.isEnabled = isEnabled
-        self.lineColor = useCase.execute(theme: theme, intent: intent, isEnabled: isEnabled)
+        self.lineColor = useCase.execute(colors: theme.colors, intent: intent)
+        self.updateOpacity()
     }
 
     private func updateLineColor() {
-        let newLineColor = useCase.execute(theme: theme, intent: intent, isEnabled: isEnabled)
+        let newLineColor = useCase.execute(colors: theme.colors, intent: intent)
         if !newLineColor.equals(self.lineColor) {
             self.lineColor = newLineColor
         }
+    }
+
+    private func updateOpacity() {
+        self.opacity = self.isEnabled ? 1.0 : self.theme.dims.dim3
     }
 }

--- a/core/Sources/Components/ProgressTracker/View/ProgressTrackerViewModel.swift
+++ b/core/Sources/Components/ProgressTracker/View/ProgressTrackerViewModel.swift
@@ -14,8 +14,7 @@ final class ProgressTrackerViewModel<ComponentContent: ProgressTrackerContentInd
 
     var theme: Theme {
         didSet {
-            self.updateSpacings()
-            self.updateFont()
+            self.themeDidUpdate()
         }
     }
 
@@ -66,6 +65,7 @@ final class ProgressTrackerViewModel<ComponentContent: ProgressTrackerContentInd
 
     @Published var spacings: ProgressTrackerSpacing
     @Published var font: TypographyFontToken
+    @Published var labelColor: any ColorToken
 
     // MARK: Private properties
     private var spacingUseCase: ProgressTrackerGetSpacingsUseCaseable
@@ -84,6 +84,13 @@ final class ProgressTrackerViewModel<ComponentContent: ProgressTrackerContentInd
         self.spacings = spacingUseCase.execute(spacing: theme.layout.spacing, orientation: orientation)
 
         self.font = theme.typography.body2Highlight
+        self.labelColor = theme.colors.base.onSurface
+    }
+
+    private func themeDidUpdate() {
+        self.updateSpacings()
+        self.updateFont()
+        self.updateLabelColor()
     }
 
     private func updateSpacings() {
@@ -94,16 +101,16 @@ final class ProgressTrackerViewModel<ComponentContent: ProgressTrackerContentInd
         self.font = self.theme.typography.body2Highlight
     }
 
-    func labelColor(forIndex index: Int) -> any ColorToken {
-        return self.labelColor(isDisabled: self.disabledIndices.contains(index))
+    private func updateLabelColor() {
+        self.labelColor = self.theme.colors.base.onSurface
     }
 
-    func labelColor(isDisabled: Bool) -> any ColorToken {
-        var color = self.theme.colors.base.onSurface
-        if isDisabled {
-            color = color.opacity(self.theme.dims.dim1)
-        }
-        return color
+    func labelOpacity(forIndex index: Int) -> CGFloat {
+        return self.labelOpacity(isDisabled: self.disabledIndices.contains(index))
+    }
+
+    func labelOpacity(isDisabled: Bool) -> CGFloat {
+        return isDisabled ? self.theme.dims.dim1 : 1.0
     }
 
     func setIsEnabled(isEnabled: Bool, forIndex index: Int) {

--- a/core/Sources/Components/ProgressTracker/View/ProgressTrackerViewModel.swift
+++ b/core/Sources/Components/ProgressTracker/View/ProgressTrackerViewModel.swift
@@ -95,11 +95,7 @@ final class ProgressTrackerViewModel<ComponentContent: ProgressTrackerContentInd
     }
 
     func labelColor(forIndex index: Int) -> any ColorToken {
-        var color = self.theme.colors.base.onSurface
-        if self.disabledIndices.contains(index) {
-            color = color.opacity(self.theme.dims.dim1)
-        }
-        return color
+        return self.labelColor(isDisabled: self.disabledIndices.contains(index))
     }
 
     func labelColor(isDisabled: Bool) -> any ColorToken {

--- a/core/Sources/Components/ProgressTracker/View/ProgressTrackerViewModelTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/ProgressTrackerViewModelTests.swift
@@ -69,23 +69,6 @@ final class ProgressTrackerViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func test_enabled_status_changed() {
-        // GIVEN
-        let sut = self.sut(orientation: . vertical)
-        let expectation = expectation(description: "Wait for color change")
-        expectation.expectedFulfillmentCount = 2
-
-        sut.$labelColor.sink { _ in
-            expectation.fulfill()
-        }.store(in: &self.cancellables)
-
-        // WHEN
-        sut.isEnabled = false
-
-        // THEN
-        wait(for: [expectation], timeout: 1)
-    }
-
     func test_orientation_is_changed_spacings_updated() {
         // GIVEN
         let sut = self.sut(orientation: . vertical)
@@ -162,6 +145,75 @@ final class ProgressTrackerViewModelTests: XCTestCase {
             XCTAssertEqual(sut.currentPageIndex, givenExpected.expected, "Expected current page index when set to \(givenExpected.given) to be \(givenExpected.expected)")
 
         }
+    }
+
+    func test_set_disabled() {
+        // GIVEN
+        let sut = sut(orientation: .vertical, numberOfPages: 4)
+
+        // WHEN
+        sut.isEnabled = false
+
+        // THEN
+        XCTAssertEqual(sut.disabledIndices.count, 4)
+    }
+
+    func test_set_enabled_single_item() {
+        // GIVEN
+        let sut = sut(orientation: .vertical, numberOfPages: 4)
+
+        // WHEN
+        sut.isEnabled = false
+        sut.setIsEnabled(isEnabled: true, forIndex: 0)
+
+        // THEN
+        XCTAssertEqual(sut.disabledIndices, Set(arrayLiteral: 1,2,3))
+    }
+
+    func test_set_disabled_single_item() {
+        // GIVEN
+        let sut = sut(orientation: .vertical, numberOfPages: 4)
+
+        // WHEN
+        sut.setIsEnabled(isEnabled: false, forIndex: 0)
+
+        // THEN
+        XCTAssertEqual(sut.disabledIndices, Set(arrayLiteral: 0))
+    }
+
+    func test_set_enabled_after_disabled() {
+        // GIVEN
+        let sut = sut(orientation: .vertical, numberOfPages: 4)
+
+        // WHEN
+        sut.isEnabled = false
+        sut.isEnabled = true
+
+        // THEN
+        XCTAssertEqual(sut.disabledIndices.count, 0)
+    }
+
+    func test_enabled_color() {
+        // GIVEN
+        let sut = sut(orientation: .vertical, numberOfPages: 4)
+
+        // THEN
+        XCTAssertEqual(sut.disabledIndices.count, 0)
+    }
+
+    func test_disabled_color() {
+        // GIVEN
+        let sut = sut(orientation: .vertical, numberOfPages: 4)
+
+        // WHEN
+        sut.setIsEnabled(isEnabled: false, forIndex: 0)
+        let disabledColor = sut.labelColor(forIndex: 0)
+        let enabledColor = sut.labelColor(forIndex: 1)
+
+        // THEN
+        XCTAssertEqual(disabledColor.uiColor, self.theme.colors.base.onSurface.opacity(self.theme.dims.dim1).uiColor, "Wrong disabled color")
+
+        XCTAssertEqual(enabledColor.uiColor, self.theme.colors.base.onSurface.uiColor, "Wrong enabled color")
     }
 
     // MARK: - Private helper functions

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerContinuousUITouchHandlerTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerContinuousUITouchHandlerTests.swift
@@ -1,0 +1,199 @@
+//
+//  ProgressTrackerContinuousUITouchHandlerTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 12.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+import Combine
+import XCTest
+
+@testable import SparkCore
+
+final class ProgressTrackerContinuousUITouchHandlerTests: XCTestCase {
+
+    var controls: [UIControl]!
+
+    var sut: ProgressTrackerContinuousUITouchHandler!
+    var cancellables = Set<AnyCancellable>()
+
+    //MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.controls = (0...4)
+            .map { index in
+                return CGRect(x: index * 50, y: 0, width: 50, height: 50)
+            }
+            .map(UIControl.init(frame:))
+
+        let sut = ProgressTrackerInteractionState.continuous.touchHandler(currentPageIndex: 0, indicatorViews: self.controls) as? ProgressTrackerContinuousUITouchHandler
+
+        XCTAssertNotNil(sut)
+
+        self.sut = sut
+    }
+
+    func test_touch_on_current_page_nothing_happens() {
+        // WHEN
+        self.sut.beginTracking(location: .zero)
+
+        // THEN
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_touch_on_first_step() {
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_on_second_step() {
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 101, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_left_of_current_index() {
+        // GIVEN
+        self.sut.currentPageIndex = 3
+
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 2)
+    }
+
+    func test_touch_right_of_current_index() {
+        // GIVEN
+        self.sut.currentPageIndex = 3
+
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 251, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 4)
+    }
+
+    func test_touch_and_move() {
+        // GIVEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 301, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 2)
+    }
+
+    func test_touch_and_move_to_current_page() {
+        // GIVEN
+        self.sut.currentPageIndex = 2
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 101, y:10))
+
+        // THEN
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_touch_and_move_over_current_page() {
+        // GIVEN
+        self.sut.currentPageIndex = 2
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+        self.sut.continueTracking(location: CGPoint(x: 101, y:10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 1, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_value_published_on_end_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            XCTAssertEqual(currentPage, 1)
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect])
+
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_value_not_published_on_end_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        expect.isInverted = true
+        self.sut.beginTracking(location: CGPoint(x: 50, y: 10))
+
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            XCTFail("Nothing should have been published")
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect], timeout: 0.01)
+
+        XCTAssertEqual(self.sut.currentPageIndex, 0)
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_value_published_on_continue_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        expect.expectedFulfillmentCount = 4
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        var pages = [Int]()
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            pages.append(currentPage)
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 101, y: 10))
+        self.sut.continueTracking(location: CGPoint(x: 151, y: 10))
+        self.sut.continueTracking(location: CGPoint(x: 201, y: 10))
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect])
+
+        XCTAssertEqual(pages, [1,2,3,4])
+    }
+
+    func test_highlighted_onmove_tracking() {
+        // GIVEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 0, y: 10))
+
+        XCTAssertNil(self.sut.trackingPageIndex)
+
+        self.sut.continueTracking(location: CGPoint(x: 51, y: 10))
+        self.sut.continueTracking(location: CGPoint(x: 75, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+}

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerDiscreteUITouchHandlerTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerDiscreteUITouchHandlerTests.swift
@@ -1,0 +1,157 @@
+//
+//  ProgressTrackerDiscreteUITouchHandlerTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 12.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import Combine
+import XCTest
+
+@testable import SparkCore
+
+final class ProgressTrackerDiscreteUITouchHandlerTests: XCTestCase {
+
+    var controls: [UIControl]!
+
+    var sut: ProgressTrackerDiscreteUITouchHandler!
+    var cancellables = Set<AnyCancellable>()
+
+    //MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.controls = (0...4)
+            .map { index in
+                return CGRect(x: index * 50, y: 0, width: 50, height: 50)
+            }
+            .map(UIControl.init(frame:))
+
+        let sut = ProgressTrackerInteractionState.discrete.touchHandler(currentPageIndex: 0, indicatorViews: self.controls) as? ProgressTrackerDiscreteUITouchHandler
+
+        XCTAssertNotNil(sut)
+
+        self.sut = sut
+    }
+
+    func test_touch_on_current_page_nothing_happens() {
+        // WHEN
+        self.sut.beginTracking(location: .zero)
+
+        // THEN
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_touch_on_first_step() {
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_on_second_step() {
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 101, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_left_of_current_index() {
+        // GIVEN
+        self.sut.currentPageIndex = 3
+
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 2)
+    }
+
+    func test_touch_right_of_current_index() {
+        // GIVEN
+        self.sut.currentPageIndex = 3
+
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 251, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 4)
+    }
+
+    func test_touch_and_move() {
+        // GIVEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 301, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_and_move_to_current_page() {
+        // GIVEN
+        self.sut.currentPageIndex = 2
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 101, y:10))
+
+        // THEN
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_touch_and_move_over_current_page() {
+        // GIVEN
+        self.sut.currentPageIndex = 2
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+        self.sut.continueTracking(location: CGPoint(x: 101, y:10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 1, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_value_published_on_end_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            XCTAssertEqual(currentPage, 1)
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect])
+        
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_value_not_published_on_end_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        expect.isInverted = true
+        self.sut.beginTracking(location: CGPoint(x: 50, y: 10))
+
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            XCTFail("Nothing should have been published")
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect], timeout: 0.01)
+
+        XCTAssertEqual(self.sut.currentPageIndex, 0)
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+}

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerIndependentUITouchHandlerTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerIndependentUITouchHandlerTests.swift
@@ -1,0 +1,158 @@
+//
+//  ProgressTrackerIndependentUITouchHandlerTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 12.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+
+import Combine
+import XCTest
+
+@testable import SparkCore
+
+final class ProgressTrackerIndependentUITouchHandlerTests: XCTestCase {
+
+    var controls: [UIControl]!
+
+    var sut: ProgressTrackerIndependentUITouchHandler!
+    var cancellables = Set<AnyCancellable>()
+
+    //MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.controls = (0...4)
+            .map { index in
+                return CGRect(x: index * 50, y: 0, width: 50, height: 50)
+            }
+            .map(UIControl.init(frame:))
+
+        let sut = ProgressTrackerInteractionState.independent.touchHandler(currentPageIndex: 0, indicatorViews: self.controls) as? ProgressTrackerIndependentUITouchHandler
+
+        XCTAssertNotNil(sut)
+
+        self.sut = sut
+    }
+
+    func test_touch_on_current_page_nothing_happens() {
+        // WHEN
+        self.sut.beginTracking(location: .zero)
+
+        // THEN
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_touch_on_first_step() {
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_on_second_step() {
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 101, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 2)
+    }
+
+    func test_touch_left_of_current_index() {
+        // GIVEN
+        self.sut.currentPageIndex = 3
+
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_right_of_current_index() {
+        // GIVEN
+        self.sut.currentPageIndex = 3
+
+        // WHEN
+        self.sut.beginTracking(location: CGPoint(x: 251, y: 10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 4)
+    }
+
+    func test_touch_and_move() {
+        // GIVEN
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 301, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_and_move_to_current_page() {
+        // GIVEN
+        self.sut.currentPageIndex = 2
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 101, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_touch_and_move_over_current_page() {
+        // GIVEN
+        self.sut.currentPageIndex = 2
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+        self.sut.continueTracking(location: CGPoint(x: 101, y:10))
+
+        // WHEN
+        self.sut.continueTracking(location: CGPoint(x: 1, y:10))
+
+        // THEN
+        XCTAssertEqual(self.sut.trackingPageIndex, 1)
+    }
+
+    func test_value_published_on_end_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        self.sut.beginTracking(location: CGPoint(x: 51, y: 10))
+
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            XCTAssertEqual(currentPage, 1)
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect])
+
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+    func test_value_not_published_on_end_tracking() {
+        // GIVEN
+        let expect = expectation(description: "Expect current page to be published")
+        expect.isInverted = true
+        self.sut.beginTracking(location: CGPoint(x: 50, y: 10))
+
+        self.sut.currentPagePublisher.subscribe(in: &self.cancellables) { currentPage in
+            XCTFail("Nothing should have been published")
+            expect.fulfill()
+        }
+        // WHEN
+        self.sut.endTracking(location: CGPoint(x: 251, y:10))
+
+        // THEN
+        wait(for: [expect], timeout: 0.01)
+
+        XCTAssertEqual(self.sut.currentPageIndex, 0)
+        XCTAssertNil(self.sut.trackingPageIndex)
+    }
+
+}

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerIndicatorUIControl.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerIndicatorUIControl.swift
@@ -181,7 +181,7 @@ final class ProgressTrackerIndicatorUIControl: UIControl {
         self.indicatorView.addSubviewCentered(self.label)
 
         self.indicatorView.layer.cornerRadius = (self.viewModel.size.rawValue * self.scaleFactor) / 2
-        self.layer.opacity = Float(self.viewModel.opacity)
+        self.alpha = self.viewModel.opacity
 
         let heightConstraint = self.indicatorView.heightAnchor.constraint(equalToConstant: self.viewModel.size.rawValue * self.scaleFactor)
 
@@ -211,7 +211,7 @@ final class ProgressTrackerIndicatorUIControl: UIControl {
             self?.update(font: font)
         }
         self.viewModel.$opacity.removeDuplicates().subscribe(in: &self.cancellables) { [weak self] opacity in
-            self?.layer.opacity = Float(opacity)
+            self?.alpha = opacity
         }
     }
 

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerIndicatorUIControl.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerIndicatorUIControl.swift
@@ -181,7 +181,8 @@ final class ProgressTrackerIndicatorUIControl: UIControl {
         self.indicatorView.addSubviewCentered(self.label)
 
         self.indicatorView.layer.cornerRadius = (self.viewModel.size.rawValue * self.scaleFactor) / 2
-        
+        self.layer.opacity = Float(self.viewModel.opacity)
+
         let heightConstraint = self.indicatorView.heightAnchor.constraint(equalToConstant: self.viewModel.size.rawValue * self.scaleFactor)
 
         let imageHeightConstraint =
@@ -208,6 +209,9 @@ final class ProgressTrackerIndicatorUIControl: UIControl {
         }
         self.viewModel.$font.removeDuplicates(by: { $0.uiFont == $1.uiFont }).subscribe(in: &self.cancellables) { [weak self] font in
             self?.update(font: font)
+        }
+        self.viewModel.$opacity.removeDuplicates().subscribe(in: &self.cancellables) { [weak self] opacity in
+            self?.layer.opacity = Float(opacity)
         }
     }
 

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerTrackUIView.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerTrackUIView.swift
@@ -90,7 +90,7 @@ final class ProgressTrackerTrackUIView: UIView {
         }
 
         self.viewModel.$opacity.subscribe(in: &self.cancellables) { [weak self] opacity in
-            self?.lineView.layer.opacity = Float(opacity)
+            self?.lineView.alpha = opacity
         }
     }
 
@@ -118,7 +118,7 @@ final class ProgressTrackerTrackUIView: UIView {
 
         NSLayoutConstraint.activate(self.sizeConstraints)
         self.lineView.backgroundColor = self.viewModel.lineColor.uiColor
-        self.layer.opacity = Float(self.viewModel.opacity)
+        self.alpha = self.viewModel.opacity
     }
 
     private func updateSizeConstraints() {

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerTrackUIView.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerTrackUIView.swift
@@ -88,6 +88,10 @@ final class ProgressTrackerTrackUIView: UIView {
         self.viewModel.$lineColor.subscribe(in: &self.cancellables) { [weak self] newColor in
             self?.lineView.backgroundColor = newColor.uiColor
         }
+
+        self.viewModel.$opacity.subscribe(in: &self.cancellables) { [weak self] opacity in
+            self?.lineView.layer.opacity = Float(opacity)
+        }
     }
 
     private func reorganizeView() {
@@ -114,6 +118,7 @@ final class ProgressTrackerTrackUIView: UIView {
 
         NSLayoutConstraint.activate(self.sizeConstraints)
         self.lineView.backgroundColor = self.viewModel.lineColor.uiColor
+        self.layer.opacity = Float(self.viewModel.opacity)
     }
 
     private func updateSizeConstraints() {

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUIControl.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUIControl.swift
@@ -326,7 +326,7 @@ public final class ProgressTrackerUIControl: UIControl {
             label.attributedText = content.getAttributedLabel(atIndex: index)
             label.font = self.viewModel.font.uiFont
             label.textColor = self.viewModel.labelColor.uiColor
-            label.layer.opacity = Float(self.viewModel.labelOpacity(forIndex: index))
+            label.alpha = self.viewModel.labelOpacity(forIndex: index)
             label.numberOfLines = 0
             label.lineBreakMode = .byWordWrapping
             label.allowsDefaultTighteningForTruncation = true
@@ -620,7 +620,7 @@ public final class ProgressTrackerUIControl: UIControl {
     private func didUpdateDisabledStatus(for disabledIndices: Set<Int>) {
         for (index, view) in self.labels.enumerated() {
             let isDisabled = disabledIndices.contains(index)
-            view.layer.opacity = Float(self.viewModel.labelOpacity(isDisabled: isDisabled))
+            view.alpha = self.viewModel.labelOpacity(isDisabled: isDisabled)
         }
         for (index, view) in self.indicatorViews.enumerated() {
             view.isEnabled = !disabledIndices.contains(index)
@@ -702,8 +702,6 @@ public final class ProgressTrackerUIControl: UIControl {
         guard index < self.indicatorViews.count else { return }
 
         self.viewModel.setIsEnabled(isEnabled: isEnabled, forIndex: index)
-//        self.indicatorViews[index].isEnabled = isEnabled
-//        self.trackViews[safe: index-1]?.isEnabled = isEnabled
     }
 }
 

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUIControl.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUIControl.swift
@@ -255,7 +255,9 @@ public final class ProgressTrackerUIControl: UIControl {
     public override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
         let location = touch.location(in: self)
 
-        if let index = self.trackingIndex(closestTo: location) {
+        if self.interactionState == .independent, let index = self.indicatorViews.index(closestTo: location) {
+            self.trackingPageIndex = index
+        } else if let index = self.trackingIndex(closestTo: location) {
             self.trackingPageIndex = index
         }
 
@@ -268,7 +270,11 @@ public final class ProgressTrackerUIControl: UIControl {
             self.cancelHighlighted()
         } else {
             let location = touch.location(in: self)
-            if self.indicatorViews.index(closestTo: location) == self.currentPageIndex {
+            if self.interactionState == .independent {
+                if let index = self.trackingPageIndex {
+                    self.indicatorViews[index].isHighlighted = true
+                }
+            } else if self.indicatorViews.index(closestTo: location) == self.currentPageIndex {
                 self.trackingPageIndex = nil
             } else if self.trackingPageIndex == nil, let index = self.trackingIndex(closestTo: location) {
                 self.trackingPageIndex = index
@@ -278,6 +284,8 @@ public final class ProgressTrackerUIControl: UIControl {
                     self.updateCurrentPageTrackingIndex(trackingPageIndex)
                     self.trackingPageIndex = nextIndex
                 }
+            } else if let index = self.trackingPageIndex {
+                self.indicatorViews[index].isHighlighted = true
             }
         }
 

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUITouchHandler.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUITouchHandler.swift
@@ -1,0 +1,202 @@
+//
+//  ProgressTrackerUITouchHandler.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 12.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import Combine
+import Foundation
+import UIKit
+
+/// Touch handling for the progress tracker.
+/// There are four different typs of touch handler:
+/// - ProgressTrackerNoneUITouchHandler. This ignores all touch events
+/// - ProgressTrackerDiscreteUITouchHandler: This handles touches for discrete interaction. It is only possible to step from one page to the next with one interaction.
+/// - ProgressTrackerContinuousUITouchHandler: This handles continuous (drag) interaction. It is possible to step from one page to the next, and then the following, etc. in one interaction. It is not possible to skip a step and all steps will be published.
+/// - ProgressTrackerIndependentUITouchHandler: This handles touches quite similar to the discrete, but it is possible to skip steps.
+protocol ProgressTrackerUITouchHandling {
+    /// The current page being tracked by the touch event
+    var trackingPageIndex: Int? { get }
+    /// The current page will be published to the current page publisher
+    var currentPagePublisher: any Publisher<Int, Never> { get }
+
+    /// Handle begin tracking
+    func beginTracking(location: CGPoint)
+
+    /// Handle continue tracking
+    func continueTracking(location: CGPoint)
+
+    /// Handle end tracking
+    func endTracking(location: CGPoint)
+}
+
+/// A helper extention to return a touch handler matching the interaction state
+extension ProgressTrackerInteractionState {
+    func touchHandler(currentPageIndex: Int, indicatorViews: [UIControl]) -> ProgressTrackerUITouchHandling {
+        switch self {
+        case .none: return ProgressTrackerNoneUITouchHandler()
+        case .continuous: return ProgressTrackerContinuousUITouchHandler(currentPageIndex: currentPageIndex, indicatorViews: indicatorViews)
+        case .discrete: return ProgressTrackerDiscreteUITouchHandler(currentPageIndex: currentPageIndex, indicatorViews: indicatorViews)
+        case .independent: return ProgressTrackerIndependentUITouchHandler(currentPageIndex: currentPageIndex, indicatorViews: indicatorViews)
+        }
+    }
+}
+
+/// The root touch handler from which others inherit.
+class ProgressTrackerUITouchHandler: ProgressTrackerUITouchHandling {
+
+    /// The current page being tracked by the touch event
+    var trackingPageIndex: Int? {
+        didSet {
+            if let formerPageIndex = oldValue {
+                self.indicatorViews[formerPageIndex].isHighlighted = false
+            }
+            if let newIndex = self.trackingPageIndex {
+                self.indicatorViews[newIndex].isHighlighted = true
+            }
+        }
+    }
+
+    /// The current page index
+    var currentPageIndex: Int {
+        get {
+            return self.currentPageSubject.value
+        }
+        set {
+            self.currentPageSubject.send(newValue)
+        }
+    }
+
+    /// The number of pages
+    var numberOfPages: Int {
+        return indicatorViews.count
+    }
+
+    /// The indicator views, each representing a page
+    var indicatorViews: [UIControl] = []
+
+    /// Changes to the current page are published to the publisher
+    private var currentPageSubject: CurrentValueSubject<Int, Never>
+    var currentPagePublisher: any Publisher<Int, Never> {
+        return self.currentPageSubject.dropFirst()
+    }
+
+    // MARK: Initialization
+    fileprivate init(currentPageIndex: Int,
+         indicatorViews: [UIControl]) {
+        self.currentPageSubject = .init(currentPageIndex)
+        self.indicatorViews = indicatorViews
+    }
+
+    func beginTracking(location: CGPoint) {
+        self.trackingPageIndex = self.trackingIndex(closestTo: location)
+    }
+
+    /// Continue tracking is handled in each tracker seperately
+    func continueTracking(location: CGPoint) {   }
+
+    /// Tracking has finished.
+    func endTracking(location: CGPoint) {
+        if self.indicatorViews.index(closestTo: location) != self.currentPageIndex, let index = self.trackingPageIndex {
+            self.updateCurrentPageTrackingIndex(index)
+        }
+
+        self.trackingPageIndex = nil
+    }
+
+    /// Set the new current page
+    fileprivate func updateCurrentPageTrackingIndex(_ index: Int) {
+        self.currentPageIndex = index
+    }
+
+    /// Return the index of the indicator closest the current page
+    fileprivate func trackingIndex(closestTo location: CGPoint) -> Int? {
+        if let index = self.indicatorViews.index(closestTo: location), index != self.currentPageIndex {
+            let trackingPageIndex = index < self.currentPageIndex ? max(0, self.currentPageIndex - 1) : min(self.numberOfPages - 1, self.currentPageIndex + 1)
+            return trackingPageIndex
+        }
+        return nil
+    }
+}
+
+/// The `none` touch handler ignores all touch events
+final class ProgressTrackerNoneUITouchHandler: ProgressTrackerUITouchHandling {
+    var trackingPageIndex: Int?
+    
+    private var voidSubject = PassthroughSubject<Int, Never>()
+    var currentPagePublisher: any Publisher<Int, Never> {
+        return self.voidSubject
+    }
+
+    func beginTracking(location: CGPoint) {}
+    
+    func continueTracking(location: CGPoint) {}
+    
+    func endTracking(location: CGPoint) {}
+}
+
+/// With the `independent` touch handler,  steps in the progress tracker may be skipped.
+final class ProgressTrackerIndependentUITouchHandler: ProgressTrackerUITouchHandler {
+
+    override func beginTracking(location: CGPoint) {
+        let index = self.indicatorViews.index(closestTo: location)
+        if index != self.currentPageIndex {
+            self.trackingPageIndex = index
+        }
+    }
+
+    override func continueTracking(location: CGPoint) {
+        if let index = self.trackingPageIndex {
+            self.indicatorViews[index].isHighlighted = true
+        }
+    }
+}
+
+/// With the `discrete` touch handler, only those steps next to the current selected index may be selected.
+class ProgressTrackerDiscreteUITouchHandler: ProgressTrackerUITouchHandler  {
+
+    override func continueTracking(location: CGPoint) {
+        if self.indicatorViews.index(closestTo: location) == self.currentPageIndex {
+            self.trackingPageIndex = nil
+        } else if self.trackingPageIndex == nil, let index = self.trackingIndex(closestTo: location) {
+            self.trackingPageIndex = index
+        } else if let index = self.trackingPageIndex {
+            self.indicatorViews[index].isHighlighted = true
+        }
+    }
+}
+
+/// With the `continuous` touch handler, multipe steps can be published by dragging across the view. Each single step will be published.
+final class ProgressTrackerContinuousUITouchHandler: ProgressTrackerDiscreteUITouchHandler {
+
+    override func continueTracking(location: CGPoint) {
+
+        if self.indicatorViews.index(closestTo: location) == self.currentPageIndex {
+            self.trackingPageIndex = nil
+        } else if let trackingPageIndex = self.trackingPageIndex {
+            if let nextIndex = self.nextTrackingIndex(closestTo: location) {
+                self.updateCurrentPageTrackingIndex(trackingPageIndex)
+                self.trackingPageIndex = nextIndex
+            } else {
+                self.indicatorViews[trackingPageIndex].isHighlighted = true
+            }
+        } else {
+            super.continueTracking(location: location)
+        }
+    }
+
+    private func nextTrackingIndex(closestTo location: CGPoint) -> Int? {
+        guard let trackingPageIndex = self.trackingPageIndex else { return nil }
+
+        guard let index = self.indicatorViews.index(closestTo: location), index != self.currentPageIndex,
+              index != trackingPageIndex else
+        { return nil }
+
+        let nextTrackingPageIndex = index < trackingPageIndex ? max(0, trackingPageIndex - 1) : min(self.numberOfPages - 1, trackingPageIndex + 1)
+
+        return nextTrackingPageIndex
+    }
+
+}

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUITouchHandlerCreationTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUITouchHandlerCreationTests.swift
@@ -1,0 +1,51 @@
+//
+//  ProgressTrackerUITouchHandlerCreationTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 12.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+@testable import SparkCore
+
+final class ProgressTrackerUITouchHandlerCreationTests: XCTestCase {
+    var controls: [UIControl]!
+
+    //MARK: - Setup
+    override func setUp() {
+        super.setUp()
+        self.controls = (0...4)
+            .map { index in
+                return CGRect(x: index * 50, y: 0, width: 50, height: 50)
+            }
+            .map(UIControl.init(frame:))
+    }
+
+    //MARK: - Tests
+    func test_setup_none() {
+        let sut = ProgressTrackerInteractionState.none.touchHandler(currentPageIndex: 0, indicatorViews: self.controls)
+
+        XCTAssertTrue(sut is ProgressTrackerNoneUITouchHandler)
+    }
+
+    func test_setup_discrete() {
+        let sut = ProgressTrackerInteractionState.discrete.touchHandler(currentPageIndex: 0, indicatorViews: self.controls)
+
+        XCTAssertTrue(sut is ProgressTrackerDiscreteUITouchHandler)
+    }
+
+    func test_setup_continuous() {
+        let sut = ProgressTrackerInteractionState.continuous.touchHandler(currentPageIndex: 0, indicatorViews: self.controls)
+
+        XCTAssertTrue(sut is ProgressTrackerContinuousUITouchHandler)
+    }
+
+    func test_setup_independent() {
+        let sut = ProgressTrackerInteractionState.independent.touchHandler(currentPageIndex: 0, indicatorViews: self.controls)
+
+        XCTAssertTrue(sut is ProgressTrackerIndependentUITouchHandler)
+    }
+
+}

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUITouchHandlerTests.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUITouchHandlerTests.swift
@@ -1,0 +1,22 @@
+//
+//  ProgressTrackerUITouchHandlerTests.swift
+//  SparkCoreUnitTests
+//
+//  Created by Michael Zimmermann on 12.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import XCTest
+
+@testable import SparkCore
+
+final class ProgressTrackerUITouchHandlerTests: XCTestCase {
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIView.swift
@@ -59,6 +59,7 @@ final class ProgressTrackerComponentUIView: ComponentUIView {
                 orientation: viewModel.orientation
             )
         }
+        view.interactionState = viewModel.interaction
         view.showDefaultPageNumber = viewModel.contentType == .page
         return view
     }
@@ -79,6 +80,12 @@ final class ProgressTrackerComponentUIView: ComponentUIView {
             guard let self = self else { return }
             self.viewModel.sizeConfigurationItemViewModel.buttonTitle = size.name
             self.componentView.size = size
+        }
+
+        self.viewModel.$interaction.subscribe(in: &self.cancellables) { [weak self] interaction in
+            guard let self = self else { return }
+            self.viewModel.interactionConfigurationItemViewModel.buttonTitle = interaction.name
+            self.componentView.interactionState = interaction
         }
 
         self.viewModel.$variant.subscribe(in: &self.cancellables) { [weak self] variant in

--- a/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIView.swift
@@ -158,6 +158,9 @@ final class ProgressTrackerComponentUIView: ComponentUIView {
         self.viewModel.$isDisabled.subscribe(in: &self.cancellables) { [weak self] isDisabled in
             guard let self else { return }
             self.componentView.isEnabled = !isDisabled
+            if !isDisabled && self.viewModel.disabledPageIndex > -1 {
+                self.componentView.setIsEnabled(false, forIndex: self.viewModel.disabledPageIndex)
+            }
         }
 
         self.viewModel.$useCompletedPageIndicator.subscribe(in: &self.cancellables) { useImage in

--- a/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewController.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewController.swift
@@ -77,6 +77,10 @@ final class ProgressTrackerComponentUIViewController: UIViewController {
             self.presentSizeActionSheet(sizes)
         }
 
+        self.viewModel.showInteractionSheet.subscribe(in: &self.cancellables) { variants in
+            self.presentInteractionActionSheet(variants)
+        }
+
         self.viewModel.showVariantSheet.subscribe(in: &self.cancellables) { variant in
             self.presentVariantActionSheet(variant)
         }
@@ -132,6 +136,15 @@ extension ProgressTrackerComponentUIViewController {
             values: sizes,
             texts: sizes.map{ $0.name }) { size in
                 self.viewModel.size = size
+            }
+            self.present(actionSheet, isAnimated: true)
+    }
+
+    private func presentInteractionActionSheet(_ variants: [ProgressTrackerInteractionState]) {
+        let actionSheet = SparkActionSheet<ProgressTrackerInteractionState>.init(
+            values: variants,
+            texts: variants.map{ $0.name }) { interaction in
+                self.viewModel.interaction = interaction
             }
             self.present(actionSheet, isAnimated: true)
     }

--- a/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewModel.swift
@@ -58,6 +58,14 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
         )
     }()
 
+    lazy var interactionConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Interaction* (Size Large)",
+            type: .button,
+            target: (source: self, action: #selector(self.presentInteractionSheet))
+        )
+    }()
+
     lazy var contentConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
             name: "Content",
@@ -150,6 +158,11 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
             .eraseToAnyPublisher()
     }
 
+    var showInteractionSheet: AnyPublisher<[ProgressTrackerInteractionState], Never> {
+        self.showInteractionSheetSubject
+            .eraseToAnyPublisher()
+    }
+
     var showVariantSheet: AnyPublisher<[ProgressTrackerVariant], Never> {
         self.showVariantSheetSubject
             .eraseToAnyPublisher()
@@ -167,6 +180,7 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
     private var showIntentSheetSubject: PassthroughSubject<[ProgressTrackerIntent], Never> = .init()
     private var showOrientationSheetSubject: PassthroughSubject<[ProgressTrackerOrientation], Never> = .init()
     private var showSizeSheetSubject: PassthroughSubject<[ProgressTrackerSize], Never> = .init()
+    private var showInteractionSheetSubject: PassthroughSubject<[ProgressTrackerInteractionState], Never> = .init()
     private var showVariantSheetSubject: PassthroughSubject<[ProgressTrackerVariant], Never> = .init()
     private var showContentSheetSubject: PassthroughSubject<[ContentType], Never> = .init()
 
@@ -175,6 +189,7 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
             self.themeConfigurationItemViewModel,
             self.intentConfigurationItemViewModel,
             self.sizeConfigurationItemViewModel,
+            self.interactionConfigurationItemViewModel,
             self.variantConfigurationItemViewModel,
             self.orientationConfigurationItemViewModel,
             self.contentConfigurationItemViewModel,
@@ -196,6 +211,7 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
     @Published var orientation: ProgressTrackerOrientation = .horizontal
     @Published var variant: ProgressTrackerVariant
     @Published var size: ProgressTrackerSize
+    @Published var interaction: ProgressTrackerInteractionState
     @Published var contentType: ContentType
     @Published var showPageNumber = true
     @Published var isDisabled = false
@@ -210,13 +226,14 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
         theme: Theme,
         intent: ProgressTrackerIntent = .main,
         variant: ProgressTrackerVariant = .tinted,
-        size: ProgressTrackerSize = .medium
+        size: ProgressTrackerSize = .large
     ) {
         self.theme = theme
         self.intent = intent
         self.size = size
         self.contentType = .none
         self.variant = variant
+        self.interaction = size.interaction
         super.init(identifier: "Progress Tracker")
     }
 
@@ -242,6 +259,10 @@ extension ProgressTrackerComponentUIViewModel {
 
     @objc func presentSizeSheet() {
         self.showSizeSheetSubject.send(ProgressTrackerSize.allCases)
+    }
+
+    @objc func presentInteractionSheet() {
+        self.showInteractionSheetSubject.send(ProgressTrackerInteractionState.allCases)
     }
 
     @objc func presentVariantSheet() {
@@ -283,7 +304,6 @@ extension ProgressTrackerComponentUIViewModel {
     @objc func useCurrentPageIndicatorImageChanged(_ selected: Any?) {
         self.useCurrentPageIndicatorImage = isTrue(selected)
     }
-
 }
 
 extension String {
@@ -293,5 +313,14 @@ extension String {
 
     var characters: [Character] {
         return Array(self)
+    }
+}
+
+private extension ProgressTrackerSize {
+    var interaction: ProgressTrackerInteractionState {
+        switch self {
+        case .large: return .discrete
+        default: return .none
+        }
     }
 }

--- a/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewModel.swift
@@ -60,7 +60,7 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
 
     lazy var interactionConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
-            name: "Interaction* (Size Large)",
+            name: "Interaction",
             type: .button,
             target: (source: self, action: #selector(self.presentInteractionSheet))
         )

--- a/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/UIKit/ProgressTrackerComponentUIViewModel.swift
@@ -127,6 +127,16 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
             target: (source: self, action: #selector(self.selectedPageChanged(_:))))
     }()
 
+    lazy var disabledPageIndexConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+        return .init(
+            name: "Disabled Page",
+            type: .rangeSelector(
+                selected: self.disabledPageIndex,
+                range: -1...7
+            ),
+            target: (source: self, action: #selector(self.disabledPageChanged(_:))))
+    }()
+
     lazy var numberOfPagesPageIndexConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
             name: "Number of Pages",
@@ -196,6 +206,7 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
             self.disableConfigurationItemViewModel,
             self.completedPageIndicatorConfigurationItemViewModel,
             self.currentPageIndicatorImageConfigurationItemViewModel,
+            self.disabledPageIndexConfigurationItemViewModel,
             self.currentPageIndexConfigurationItemViewModel,
             self.numberOfPagesPageIndexConfigurationItemViewModel,
             self.labelContentConfigurationItemViewModel,
@@ -207,9 +218,9 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
 
     // MARK: - Initialization
     @Published var theme: Theme
-    @Published var intent: ProgressTrackerIntent
+    @Published var intent: ProgressTrackerIntent = .basic
     @Published var orientation: ProgressTrackerOrientation = .horizontal
-    @Published var variant: ProgressTrackerVariant
+    @Published var variant: ProgressTrackerVariant = .outlined
     @Published var size: ProgressTrackerSize
     @Published var interaction: ProgressTrackerInteractionState
     @Published var contentType: ContentType
@@ -220,13 +231,14 @@ final class ProgressTrackerComponentUIViewModel: ComponentUIViewModel {
     @Published var showLabels = true
     @Published var title: String? = "Lore"
     @Published var selectedPageIndex: Int = 0
+    @Published var disabledPageIndex: Int = -1
     @Published var numberOfPages = Constants.numberOfPages
 
     init(
         theme: Theme,
-        intent: ProgressTrackerIntent = .main,
-        variant: ProgressTrackerVariant = .tinted,
-        size: ProgressTrackerSize = .large
+        intent: ProgressTrackerIntent = .basic,
+        variant: ProgressTrackerVariant = .outlined,
+        size: ProgressTrackerSize = .medium
     ) {
         self.theme = theme
         self.intent = intent
@@ -291,6 +303,10 @@ extension ProgressTrackerComponentUIViewModel {
 
     @objc func selectedPageChanged(_ control: NumberSelector) {
         self.selectedPageIndex = control.selectedValue
+    }
+
+    @objc func disabledPageChanged(_ control: NumberSelector) {
+        self.disabledPageIndex = control.selectedValue
     }
 
     @objc func numberOfPagesChanged(_ control: NumberSelector) {


### PR DESCRIPTION
Added use interaction to the progress tracker:
There are four types of user interaction:
- discrete (similar to the UIPage control). The use can only navigate to an adjacent step and not skip any step. Only one navigation step is allowed with one interaction
- continuous (similar to UIPage control). The user can only navigate to an adjacent step, but may drag and move to other steps with one interaction. All current pages will be published, i.e. multiple values may be published with this interaction type.
- independent (Not available in UIPage control). The user can tap on any step.
- none: no interaction possible
