### PR TITLE
[Button-807] UIKit: change default isAnimated value

### DIFF
--- a/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
@@ -132,8 +132,8 @@ public class ButtonMainUIView: UIControl {
         }
     }
 
-    /// Button modifications should be animated or not. **True** by default.
-    public var isAnimated: Bool = true
+    /// Button modifications should be animated or not. **False** by default.
+    public var isAnimated: Bool = false
 
     // MARK: - Internal Properties
 


### PR DESCRIPTION
Because there is no animation on the native UIKit button, we need to change the default isAnimated value to false on Spark