### PR TITLE
[UIControl-822] Add default gesture

### DIFF
--- a/core/Sources/Common/UIKit/Extension/UIControl/UIControl-EnableTouches.swift
+++ b/core/Sources/Common/UIKit/Extension/UIControl/UIControl-EnableTouches.swift
@@ -1,0 +1,21 @@
+//
+//  UIControl-EnableTouches.swift
+//  SparkCore
+//
+//  Created by Michael Zimmermann on 21.02.24.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import UIKit
+
+extension UIControl {
+
+    // Add a default tap gesture recognizer without any action to detect the action/publisher/target action even if the parent view has a gesture recognizer
+    // Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    // Note: Native UIButton add the same default recognizer to manage this use case.
+    func enableTouch() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
+    }
+}

--- a/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
@@ -185,7 +185,7 @@ public class ButtonMainUIView: UIControl {
         self.setupConstraints()
 
         // Setup gesture
-        self.setupGestureRecognizer()
+        self.enableTouch()
 
         // Setup publisher subcriptions
         self.setupSubscriptions()
@@ -229,18 +229,6 @@ public class ButtonMainUIView: UIControl {
         self.imageViewHeightConstraint?.isActive = true
 
         self.imageView.widthAnchor.constraint(equalTo: self.imageView.heightAnchor).isActive = true
-    }
-
-    // MARK: - Gesture Recognizer
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     // MARK: - Setter & Getter

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -170,6 +170,7 @@ public final class CheckboxGroupUIView: UIControl {
     private func commonInit() {
         self.setupItemsStackView()
         self.setupView()
+        self.setupGestureRecognizer()
         self.updateTitle()
     }
 
@@ -265,6 +266,16 @@ public final class CheckboxGroupUIView: UIControl {
             self.scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: self.padding),
             self.scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: self.padding),
         ])
+    }
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 }
 

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -170,7 +170,7 @@ public final class CheckboxGroupUIView: UIControl {
     private func commonInit() {
         self.setupItemsStackView()
         self.setupView()
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.updateTitle()
     }
 
@@ -266,16 +266,6 @@ public final class CheckboxGroupUIView: UIControl {
             self.scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: self.padding),
             self.scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: self.padding),
         ])
-    }
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 }
 

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -262,7 +262,7 @@ public final class CheckboxUIView: UIControl {
         self.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkbox
         
         self.setupViews()
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.subscribe()
         self.updateAccessibility()
         self.addActions()
@@ -319,16 +319,6 @@ public final class CheckboxUIView: UIControl {
             self.textLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: self.checkboxSize),
             self.heightAnchor.constraint(equalTo: textLabel.heightAnchor)
         ])
-    }
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -262,6 +262,7 @@ public final class CheckboxUIView: UIControl {
         self.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkbox
         
         self.setupViews()
+        self.setupGestureRecognizer()
         self.subscribe()
         self.updateAccessibility()
         self.addActions()
@@ -318,6 +319,16 @@ public final class CheckboxUIView: UIControl {
             self.textLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: self.checkboxSize),
             self.heightAnchor.constraint(equalTo: textLabel.heightAnchor)
         ])
+    }
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
+++ b/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
@@ -396,9 +396,20 @@ public final class ChipUIView: UIControl {
 
         self.setupConstraints()
         self.setChipColors(self.viewModel.colors)
+        self.setupGestureRecognizer()
         self.setupSubscriptions()
 
         self.accessibilityIdentifier = ChipAccessibilityIdentifier.identifier
+    }
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func updateLayoutMargins() {

--- a/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
+++ b/core/Sources/Components/Chip/View/UIKit/ChipUIView.swift
@@ -396,20 +396,10 @@ public final class ChipUIView: UIControl {
 
         self.setupConstraints()
         self.setChipColors(self.viewModel.colors)
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.setupSubscriptions()
 
         self.accessibilityIdentifier = ChipAccessibilityIdentifier.identifier
-    }
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func updateLayoutMargins() {

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
@@ -273,7 +273,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
 
         self.setupView()
         self.setupConstraints()
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.setupSubscriptions()
     }
 
@@ -347,16 +347,6 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
                        title: self.supplementaryText,
                        font: self.viewModel.sublabelFont.uiFont,
                        color: self.viewModel.sublabelColor.uiColor)
-    }
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func updateLayout(items: [RadioButtonUIItem<ID>]) {

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIGroupView.swift
@@ -273,6 +273,7 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
 
         self.setupView()
         self.setupConstraints()
+        self.setupGestureRecognizer()
         self.setupSubscriptions()
     }
 
@@ -348,6 +349,15 @@ public final class RadioButtonUIGroupView<ID: Equatable & Hashable & CustomStrin
                        color: self.viewModel.sublabelColor.uiColor)
     }
 
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
+    }
 
     private func updateLayout(items: [RadioButtonUIItem<ID>]) {
         NSLayoutConstraint.deactivate(self.allConstraints)

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
@@ -291,6 +291,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         self.arrangeViews()
         self.setupButtonActions()
         self.updateViewAttributes()
+        self.setupGestureRecognizer()
         self.setupSubscriptions()
     }
 
@@ -327,6 +328,17 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
 
 
     // MARK: - Private Functions
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
+    }
+
     private func setupSubscriptions() {
 
         self.viewModel.$opacity.subscribe(in: &self.subscriptions) { [weak self] opacity in

--- a/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
+++ b/core/Sources/Components/RadioButton/View/UIKit/RadioButtonUIView.swift
@@ -291,7 +291,7 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
         self.arrangeViews()
         self.setupButtonActions()
         self.updateViewAttributes()
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.setupSubscriptions()
     }
 
@@ -328,16 +328,6 @@ public final class RadioButtonUIView<ID: Equatable & CustomStringConvertible>: U
 
 
     // MARK: - Private Functions
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
-    }
 
     private func setupSubscriptions() {
 

--- a/core/Sources/Components/Rating/View/UIKit/RatingInputUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingInputUIView.swift
@@ -102,6 +102,7 @@ public final class RatingInputUIView: UIControl {
         self.rating = rating
         super.init(frame: .zero)
         self.setupView()
+        self.setupGestureRecognizer()
     }
     
     required init?(coder: NSCoder) {
@@ -144,6 +145,12 @@ public final class RatingInputUIView: UIControl {
         self.ratingDisplay.isUserInteractionEnabled = false
         self.addSubviewSizedEqually(self.ratingDisplay)
         self.accessibilityIdentifier = RatingInputAccessibilityIdentifier.identifier
+    }
+
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     // MARK: - Handling touch actions

--- a/core/Sources/Components/Rating/View/UIKit/RatingInputUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingInputUIView.swift
@@ -102,7 +102,7 @@ public final class RatingInputUIView: UIControl {
         self.rating = rating
         super.init(frame: .zero)
         self.setupView()
-        self.setupGestureRecognizer()
+        self.enableTouch()
     }
     
     required init?(coder: NSCoder) {
@@ -145,12 +145,6 @@ public final class RatingInputUIView: UIControl {
         self.ratingDisplay.isUserInteractionEnabled = false
         self.addSubviewSizedEqually(self.ratingDisplay)
         self.accessibilityIdentifier = RatingInputAccessibilityIdentifier.identifier
-    }
-
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     // MARK: - Handling touch actions

--- a/core/Sources/Components/Tab/View/UIKit/TabItemUIView.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabItemUIView.swift
@@ -338,7 +338,7 @@ public final class TabItemUIView: UIControl {
 
         self.setupView()
         self.setupConstraints()
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.setupSubscriptions()
     }
 
@@ -396,16 +396,6 @@ public final class TabItemUIView: UIControl {
         
         self.addOrRemoveIcon(self.viewModel.content.icon)
         self.addOrRemoveTitle(self.viewModel.content.title)
-    }
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func setupColors(attributes: TabStateAttributes) {

--- a/core/Sources/Components/Tab/View/UIKit/TabItemUIView.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabItemUIView.swift
@@ -338,6 +338,7 @@ public final class TabItemUIView: UIControl {
 
         self.setupView()
         self.setupConstraints()
+        self.setupGestureRecognizer()
         self.setupSubscriptions()
     }
 
@@ -395,6 +396,16 @@ public final class TabItemUIView: UIControl {
         
         self.addOrRemoveIcon(self.viewModel.content.icon)
         self.addOrRemoveTitle(self.viewModel.content.title)
+    }
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func setupColors(attributes: TabStateAttributes) {

--- a/core/Sources/Components/Tab/View/UIKit/TabUIView.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabUIView.swift
@@ -209,6 +209,7 @@ public final class TabUIView: UIControl {
 
         self.setupViews(items: content)
         self.setupConstraints()
+        self.setupGestureRecognizer()
         self.setupSubscriptions()
     }
 
@@ -547,6 +548,16 @@ public final class TabUIView: UIControl {
         }
         tabItem.addAction(pressedAction, for: .touchUpInside)
         tabItem.addAction(unselectAction, for: .otherSegmentSelected)
+    }
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func setupSubscriptions() {

--- a/core/Sources/Components/Tab/View/UIKit/TabUIView.swift
+++ b/core/Sources/Components/Tab/View/UIKit/TabUIView.swift
@@ -209,7 +209,7 @@ public final class TabUIView: UIControl {
 
         self.setupViews(items: content)
         self.setupConstraints()
-        self.setupGestureRecognizer()
+        self.enableTouch()
         self.setupSubscriptions()
     }
 
@@ -548,16 +548,6 @@ public final class TabUIView: UIControl {
         }
         tabItem.addAction(pressedAction, for: .touchUpInside)
         tabItem.addAction(unselectAction, for: .otherSegmentSelected)
-    }
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     private func setupSubscriptions() {

--- a/core/Sources/Components/TextLink/View/UIKit/TextLinkUIView.swift
+++ b/core/Sources/Components/TextLink/View/UIKit/TextLinkUIView.swift
@@ -267,7 +267,7 @@ public final class TextLinkUIView: UIControl {
         self.setupConstraints()
 
         // Setup gesture
-        self.setupGestureRecognizer()
+        self.enableTouch()
 
         // Setup subscriptions
         self.setupSubscriptions()
@@ -316,18 +316,6 @@ public final class TextLinkUIView: UIControl {
         self.imageViewHeightConstraint?.isActive = true
 
         self.imageView.widthAnchor.constraint(equalTo: self.imageView.heightAnchor).isActive = true
-    }
-
-    // MARK: - Gesture Recognizer
-
-    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
-    /// even if the parent view has a gesture recognizer
-    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
-    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
-    private func setupGestureRecognizer() {
-        let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(gestureRecognizer)
     }
 
     // MARK: - Update UI

--- a/core/Sources/Components/TextLink/View/UIKit/TextLinkUIView.swift
+++ b/core/Sources/Components/TextLink/View/UIKit/TextLinkUIView.swift
@@ -266,6 +266,9 @@ public final class TextLinkUIView: UIControl {
         // Setup constraints
         self.setupConstraints()
 
+        // Setup gesture
+        self.setupGestureRecognizer()
+
         // Setup subscriptions
         self.setupSubscriptions()
 
@@ -313,6 +316,18 @@ public final class TextLinkUIView: UIControl {
         self.imageViewHeightConstraint?.isActive = true
 
         self.imageView.widthAnchor.constraint(equalTo: self.imageView.heightAnchor).isActive = true
+    }
+
+    // MARK: - Gesture Recognizer
+
+    /// Add a default tap gesture recognizer without any action to detect the action/publisher/target action
+    /// even if the parent view has a gesture recognizer
+    /// Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    /// *Note*: Native UIButton add the same default recognizer to manage this use case.
+    private func setupGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = false
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     // MARK: - Update UI

--- a/spark/Demo/Classes/View/Components/Main/ComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Main/ComponentUIView.swift
@@ -166,6 +166,13 @@ class ComponentUIView: UIView {
         self.backgroundColor = .systemBackground
         self.accessibilityIdentifier = self.viewModel.identifier
 
+        // Gesture
+        let tapGestureRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(self.tagGestureRecognizerAction)
+        )
+        self.addGestureRecognizer(tapGestureRecognizer)
+
         // Subviews
         self.addSubview(self.scrollView)
 
@@ -257,6 +264,13 @@ class ComponentUIView: UIView {
                 self.viewModel.spaceContainerType = type
             }
         viewController.present(actionSheet, animated: true)
+    }
+
+    // MARK: - Action
+
+    @objc
+    func tagGestureRecognizerAction() {
+        Console.log("View tapped from gesture")
     }
 }
 


### PR DESCRIPTION
Add a default tap gesture recognizer without any action to detect the action/publisher/target action even if the parent view has a gesture recognizer
Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
Note: Native UIButton add the same default recognizer to manage this use case.