### PR TITLE
[Button-834] Fix button

### DIFF
--- a/core/Sources/Common/Control/UIView/UIControlStateLabel.swift
+++ b/core/Sources/Common/Control/UIView/UIControlStateLabel.swift
@@ -181,13 +181,10 @@ final class UIControlStateLabel: UILabel {
         let textType = self.textTypesStates.value(for: status)
         let textTypeContainsText = textType?.containsText ?? false
 
-        // Reset attributedText & text
-        self.storedAttributedText = nil
-        self.storedText = nil
-
         // Set the text or the attributedText from textType and states
         if let text = self.textStates.value(for: status),
            textType == .text || !textTypeContainsText {
+            self.storedAttributedText = nil
             self.storedText = text
 
         } else if let attributedText = self.attributedTextStates.value(for: status),
@@ -195,7 +192,7 @@ final class UIControlStateLabel: UILabel {
             self.storedAttributedText = attributedText
 
         } else { // No text to displayed
-            self.text = nil
+            self.storedText = nil
         }
     }
 

--- a/core/Sources/Components/Button/View/UIKit/Button/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Button/ButtonUIView.swift
@@ -36,10 +36,6 @@ public final class ButtonUIView: ButtonMainUIView {
         let view = UIView()
         view.addSubview(self.imageView)
         view.accessibilityIdentifier = ButtonAccessibilityIdentifier.imageContentView
-        view.setContentCompressionResistancePriority(.required,
-                                                     for: .vertical)
-        view.setContentCompressionResistancePriority(.required,
-                                                     for: .horizontal)
         return view
     }()
 
@@ -55,6 +51,10 @@ public final class ButtonUIView: ButtonMainUIView {
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = ButtonAccessibilityIdentifier.text
         label.lineBreakMode = .byTruncatingMiddle
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.setContentHuggingPriority(.defaultLow, for: .vertical)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return label
     }()
 

--- a/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Main/ButtonMainUIView.swift
@@ -28,6 +28,10 @@ public class ButtonMainUIView: UIControl {
         imageView.contentMode = .scaleAspectFit
         imageView.tintAdjustmentMode = .normal
         imageView.accessibilityIdentifier = ButtonAccessibilityIdentifier.imageView
+        imageView.setContentCompressionResistancePriority(.required, for: .vertical)
+        imageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        imageView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        imageView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return imageView
     }()
 


### PR DESCRIPTION
Polaris developers found two problems:
- When they add an animation which encapsulate the modification of the title (title or attributedTitle), the title is always empty
- They can have a dynamic space between two button in same line

**This PR should fixes theses issues.**