### PR TITLE
[Tabs] Fixed tabs height for swiftui

### DIFF
--- a/core/Sources/Components/Tab/View/SwiftUI/TabApportionsSizeView.swift
+++ b/core/Sources/Components/Tab/View/SwiftUI/TabApportionsSizeView.swift
@@ -71,8 +71,8 @@ struct TabApportionsSizeView: View {
                     .frame(height: self.itemHeight)
                     .accessibilityIdentifier(TabAccessibilityIdentifier.tab)
             }
-            .frame(height: self.itemHeight)
         }
+        .frame(height: self.itemHeight)
     }
 
     // MARK: - Private functions

--- a/core/Sources/Components/Tab/View/SwiftUI/TabEqualSizeView.swift
+++ b/core/Sources/Components/Tab/View/SwiftUI/TabEqualSizeView.swift
@@ -77,11 +77,11 @@ struct TabEqualSizeView: View {
                     .frame(height: self.itemHeight)
                     .accessibilityIdentifier(TabAccessibilityIdentifier.tab)
             }
-            .frame(height: self.itemHeight)
             .onChange(of: self.viewModel.content) { content in
                 self.minItemWidth = self.screenWidth / CGFloat(content.count)
             }
         }
+        .frame(height: self.itemHeight)
     }
 
     // MARK: - Private functions


### PR DESCRIPTION
A bug occures on the tabs height in swifuti when the tabs are inside a vstack
This should fix it