### PR TITLE
[Git] Updated .gitignore with sourcery-bin and sourcery.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ spark-ios-snapshots
 
 #sourcery
 *Generated/
+sourcery-bin
+sourcery.zip
 
 vendor/
 *.lock


### PR DESCRIPTION
To install sourcery, we'll now have to 

- curl -L https://github.com/krzysztofzablocki/Sourcery/releases/download/$VERSION/sourcery-$VERSION.zip -o sourcery.zip
- unzip sourcery.zip -d sourcery-bin
- ./sourcery-bin/bin/sourcery

Current used version should be 2.1.7