### PR TITLE
[Checkbox#866] Fix extanding content issue in stack for single checkbox

### DIFF
--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
@@ -108,6 +108,7 @@ public struct CheckboxView: View {
         .isEnabledChanged { isEnabled in
             self.viewModel.isEnabled = isEnabled
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     @ViewBuilder 


### PR DESCRIPTION
When you put swiftui single checkbox in stack, It might extend It's content according to parent's frame. It was fixed 
