### PR TITLE
[Slider#1977] Updated Slider handle size from 24x24 to 32x32

### DIFF
--- a/core/Sources/Components/Slider/Constant/SliderConstants.swift
+++ b/core/Sources/Components/Slider/Constant/SliderConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum SliderConstants {
-    static let handleSize = CGSize(width: 24, height: 24)
-    static let activeIndicatorSize = CGSize(width: 32, height: 32)
+    static let handleSize = CGSize(width: 32, height: 32)
+    static let activeIndicatorSize = CGSize(width: 40, height: 40)
     static let barHeight: CGFloat = 4.0
 }


### PR DESCRIPTION
Related snapshot PR https://github.com/adevinta/spark-ios-snapshots/pull/92
