### PR TITLE
[Checkbox#876] Fix accessibility issues

### DIFF
--- a/core/Sources/Components/Checkbox/AccessibilityIdentifier/CheckboxAccessibilityIdentifier.swift
+++ b/core/Sources/Components/Checkbox/AccessibilityIdentifier/CheckboxAccessibilityIdentifier.swift
@@ -17,3 +17,8 @@ public enum CheckboxAccessibilityIdentifier {
     /// The identifier of checkbox group ui view title
     public static let checkboxGroupTitle = "spark-check-box-group-title"
 }
+
+public enum CheckboxAccessibilityValue {
+    public static let ticked = "1"
+    public static let unticked = "0"
+}

--- a/core/Sources/Components/Checkbox/AccessibilityIdentifier/CheckboxAccessibilityIdentifier.swift
+++ b/core/Sources/Components/Checkbox/AccessibilityIdentifier/CheckboxAccessibilityIdentifier.swift
@@ -10,15 +10,20 @@ import Foundation
 
 /// The accessibility identifiers for the checkbox.
 public enum CheckboxAccessibilityIdentifier {
-    /// The default accessibility identifier. Can be changed by the consumer
+    /// The default checkbox accessibility identifier.
     public static let checkbox = "spark-check-box"
-    /// The default accessibility identifier. Can be changed by the consumer
+    /// The default checkbox group accessibility identifier.
     public static let checkboxGroup = "spark-check-box-group"
     /// The identifier of checkbox group ui view title
     public static let checkboxGroupTitle = "spark-check-box-group-title"
+    /// The default checkbox group item accessibility identifier.
+    public static func checkboxGroupItem(_ id: String) -> String {
+        Self.checkbox + "-\(id)"
+    }
 }
 
 public enum CheckboxAccessibilityValue {
-    public static let ticked = "1"
-    public static let unticked = "0"
+    public static let checked = "1"
+    public static let indeterminate = "0.5"
+    public static let unchecked = "0"
 }

--- a/core/Sources/Components/Checkbox/Model/CheckboxGroupViewModel.swift
+++ b/core/Sources/Components/Checkbox/Model/CheckboxGroupViewModel.swift
@@ -17,7 +17,6 @@ final class CheckboxGroupViewModel: ObservableObject {
     @Published var checkedImage: Image
     @Published var layout: CheckboxGroupLayout
     @Published var spacing: LayoutSpacing
-    @Published var accessibilityIdentifierPrefix: String
     @Published var titleFont: TypographyFontToken
     @Published var titleColor: any ColorToken
     @Published var intent: CheckboxIntent
@@ -28,7 +27,6 @@ final class CheckboxGroupViewModel: ObservableObject {
     init(
         title: String?,
         checkedImage: Image,
-        accessibilityIdentifierPrefix: String,
         theme: Theme,
         intent: CheckboxIntent = .main,
         alignment: CheckboxAlignment = .left,
@@ -43,7 +41,6 @@ final class CheckboxGroupViewModel: ObservableObject {
         self.spacing = theme.layout.spacing
         self.titleFont = theme.typography.subhead
         self.titleColor = theme.colors.base.onSurface
-        self.accessibilityIdentifierPrefix = accessibilityIdentifierPrefix
     }
 
     func calculateSingleCheckboxWidth(string: String?) -> CGFloat {

--- a/core/Sources/Components/Checkbox/Model/CheckboxGroupViewModelTests.swift
+++ b/core/Sources/Components/Checkbox/Model/CheckboxGroupViewModelTests.swift
@@ -25,7 +25,6 @@ final class CheckboxGroupViewModelTests: XCTestCase {
         self.sut = CheckboxGroupViewModel(
             title: "Title",
             checkedImage: Image(uiImage: self.checkedImage),
-            accessibilityIdentifierPrefix: "id",
             theme: self.theme
         )
     }
@@ -45,7 +44,6 @@ final class CheckboxGroupViewModelTests: XCTestCase {
             XCTAssertEqual(sut.intent, .main, "Intent does not match")
             XCTAssertEqual(sut.titleFont.uiFont, self.theme.typography.subhead.uiFont, "Title font does not match" )
             XCTAssertEqual(sut.titleColor.uiColor, self.theme.colors.base.onSurface.uiColor, "Title color does not match" )
-            XCTAssertEqual(sut.accessibilityIdentifierPrefix, "id", "Accessibility identifier does not match" )
     }
 
     func test_singleCheckbox_width() throws {

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxGroupView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxGroupView.swift
@@ -38,7 +38,7 @@ public struct CheckboxGroupView: View {
     ///   - checkboxAlignment: The checkbox is positioned on the leading or trailing edge of the view.
     ///   - theme: The Spark-Theme.
     ///   - accessibilityIdentifierPrefix: All checkbox-views are prefixed by this identifier followed by the `CheckboxGroupItemProtocol`-identifier.
-    @available(*, deprecated, message: "Please use init without accessibilityIdentifierPrefix. It was gived as a static string.")
+    @available(*, deprecated, message: "Please use init without accessibilityIdentifierPrefix. It was given as a static string.")
     public init(
         title: String? = nil,
         checkedImage: Image,

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxGroupView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxGroupView.swift
@@ -194,6 +194,7 @@ public struct CheckboxGroupView: View {
             isEnabled: item.isEnabled.wrappedValue,
             selectionState: item.selectionState
         )
+        .accessibilityIdentifier(CheckboxAccessibilityIdentifier.checkboxGroupItem(item.id.wrappedValue))
     }
 }
 

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxGroupView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxGroupView.swift
@@ -38,6 +38,7 @@ public struct CheckboxGroupView: View {
     ///   - checkboxAlignment: The checkbox is positioned on the leading or trailing edge of the view.
     ///   - theme: The Spark-Theme.
     ///   - accessibilityIdentifierPrefix: All checkbox-views are prefixed by this identifier followed by the `CheckboxGroupItemProtocol`-identifier.
+    @available(*, deprecated, message: "Please use init without accessibilityIdentifierPrefix. It was gived as a static string.")
     public init(
         title: String? = nil,
         checkedImage: Image,
@@ -48,10 +49,37 @@ public struct CheckboxGroupView: View {
         intent: CheckboxIntent = .main,
         accessibilityIdentifierPrefix: String
     ) {
+        self.init(
+            title: title,
+            checkedImage: checkedImage,
+            items: items,
+            layout: layout,
+            alignment: alignment,
+            theme: theme,
+            intent: intent
+        )
+    }
+
+    /// Initialize a group of one or multiple checkboxes.
+    /// - Parameters:
+    ///   - title: An optional group title displayed on top of the checkbox group..
+    ///   - checkedImage: The tick-checkbox image for checked-state.
+    ///   - items: An array containing of multiple `CheckboxGroupItemProtocol`. Each array item is used to render a single checkbox.
+    ///   - layout: The layout of the group can be horizontal or vertical.
+    ///   - checkboxAlignment: The checkbox is positioned on the leading or trailing edge of the view.
+    ///   - theme: The Spark-Theme.
+    public init(
+        title: String? = nil,
+        checkedImage: Image,
+        items: Binding<[any CheckboxGroupItemProtocol]>,
+        layout: CheckboxGroupLayout = .vertical,
+        alignment: CheckboxAlignment,
+        theme: Theme,
+        intent: CheckboxIntent = .main
+    ) {
         let viewModel = CheckboxGroupViewModel(
             title: title,
             checkedImage: checkedImage,
-            accessibilityIdentifierPrefix: accessibilityIdentifierPrefix,
             theme: theme,
             intent: intent,
             alignment: alignment,
@@ -94,7 +122,8 @@ public struct CheckboxGroupView: View {
         .onChange(of: self.itemContents) { newValue in
             self.isScrollableHStack = true
         }
-        .accessibilityIdentifier("\(self.viewModel.accessibilityIdentifierPrefix).\(CheckboxAccessibilityIdentifier.checkboxGroup)")
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(CheckboxAccessibilityIdentifier.checkboxGroup)
     }
 
     private func makeHStackView() -> some View {
@@ -156,7 +185,6 @@ public struct CheckboxGroupView: View {
     }
 
     private func checkBoxView(item: Binding<any CheckboxGroupItemProtocol>) -> some View {
-        let identifier = "\(self.viewModel.accessibilityIdentifierPrefix).\(item.id.wrappedValue)"
         return CheckboxView(
             text: item.title.wrappedValue,
             checkedImage: self.viewModel.checkedImage,
@@ -166,7 +194,6 @@ public struct CheckboxGroupView: View {
             isEnabled: item.isEnabled.wrappedValue,
             selectionState: item.selectionState
         )
-        .accessibilityIdentifier(identifier)
     }
 }
 

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
@@ -104,10 +104,12 @@ public struct CheckboxView: View {
             }
         )
         .buttonStyle(PressedButtonStyle(isPressed: self.$isPressed))
-        .accessibilityIdentifier(CheckboxAccessibilityIdentifier.checkbox)
         .isEnabledChanged { isEnabled in
             self.viewModel.isEnabled = isEnabled
         }
+        .accessibilityIdentifier(CheckboxAccessibilityIdentifier.checkbox)
+        .accessibilityValue(self.viewModel.selectionState == .selected ? CheckboxAccessibilityValue.ticked : CheckboxAccessibilityValue.unticked)
+        .accessibilityRemoveTraits(.isButton)
     }
 
     @ViewBuilder 
@@ -147,9 +149,6 @@ public struct CheckboxView: View {
                     .fill(iconColor)
                     .frame(width: self.checkboxIndeterminateWidth, height: self.checkboxIndeterminateHeight)
             }
-        }
-        .if(self.selectionState == .selected) {
-            $0.accessibilityAddTraits(.isSelected)
         }
         .id(Identifier.checkbox.rawValue)
         .matchedGeometryEffect(id: Identifier.checkbox.rawValue, in: self.namespace)

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
@@ -108,8 +108,19 @@ public struct CheckboxView: View {
             self.viewModel.isEnabled = isEnabled
         }
         .accessibilityIdentifier(CheckboxAccessibilityIdentifier.checkbox)
-        .accessibilityValue(self.viewModel.selectionState == .selected ? CheckboxAccessibilityValue.ticked : CheckboxAccessibilityValue.unticked)
-        .accessibilityRemoveTraits(.isButton)
+        .accessibilityValue(setAccessibilityValue(selectionState: self.viewModel.selectionState))
+        .accessibilityRemoveTraits(.isSelected)
+    }
+
+    private func setAccessibilityValue(selectionState: CheckboxSelectionState) -> String {
+        switch selectionState {
+        case .selected:
+            CheckboxAccessibilityValue.checked
+        case .indeterminate:
+            CheckboxAccessibilityValue.indeterminate
+        case .unselected:
+            CheckboxAccessibilityValue.unchecked
+        }
     }
 
     @ViewBuilder 

--- a/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
+++ b/core/Sources/Components/Checkbox/View/SwiftUI/CheckboxView.swift
@@ -115,11 +115,11 @@ public struct CheckboxView: View {
     private func setAccessibilityValue(selectionState: CheckboxSelectionState) -> String {
         switch selectionState {
         case .selected:
-            CheckboxAccessibilityValue.checked
+            return CheckboxAccessibilityValue.checked
         case .indeterminate:
-            CheckboxAccessibilityValue.indeterminate
+            return CheckboxAccessibilityValue.indeterminate
         case .unselected:
-            CheckboxAccessibilityValue.unchecked
+            return CheckboxAccessibilityValue.unchecked
         }
     }
 

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -141,7 +141,7 @@ public final class CheckboxGroupUIView: UIControl {
     ///   - theme: The Spark-Theme.
     ///   - intent: Current intent of checkbox group
     ///   - accessibilityIdentifierPrefix: All checkbox-views are prefixed by this identifier followed by the `CheckboxGroupItemProtocol`-identifier.
-    @available(*, deprecated, message: "Please use init without accessibilityIdentifierPrefix. It was gived as a static string.")
+    @available(*, deprecated, message: "Please use init without accessibilityIdentifierPrefix. It was given as a static string.")
     public convenience init(
         title: String? = nil,
         checkedImage: UIImage,
@@ -172,7 +172,6 @@ public final class CheckboxGroupUIView: UIControl {
     ///   - checkboxAlignment: The checkbox is positioned on the leading or trailing edge of the view.
     ///   - theme: The Spark-Theme.
     ///   - intent: Current intent of checkbox group
-    ///   - accessibilityIdentifierPrefix: All checkbox-views are prefixed by this identifier followed by the `CheckboxGroupItemProtocol`-identifier.
     public init(
         title: String? = nil,
         checkedImage: UIImage,

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -243,6 +243,7 @@ public final class CheckboxGroupUIView: UIControl {
                 selectionState: item.selectionState,
                 alignment: self.alignment
             )
+            checkbox.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkboxGroupItem(item.id)
 
             checkbox.publisher.sink { [weak self] in
                 guard

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxGroupUIView.swift
@@ -56,7 +56,6 @@ public final class CheckboxGroupUIView: UIControl {
     private var subscriptions = Set<AnyCancellable>()
     private var items: [any CheckboxGroupItemProtocol]
     private var subject = PassthroughSubject<[any CheckboxGroupItemProtocol], Never>()
-    private var accessibilityIdentifierPrefix: String
 
     @ScaledUIMetric private var spacingLarge: CGFloat
     @ScaledUIMetric private var padding: CGFloat = CheckboxControlUIView.Constants.lineWidthPressed
@@ -142,7 +141,8 @@ public final class CheckboxGroupUIView: UIControl {
     ///   - theme: The Spark-Theme.
     ///   - intent: Current intent of checkbox group
     ///   - accessibilityIdentifierPrefix: All checkbox-views are prefixed by this identifier followed by the `CheckboxGroupItemProtocol`-identifier.
-    public init(
+    @available(*, deprecated, message: "Please use init without accessibilityIdentifierPrefix. It was gived as a static string.")
+    public convenience init(
         title: String? = nil,
         checkedImage: UIImage,
         items: [any CheckboxGroupItemProtocol],
@@ -152,6 +152,36 @@ public final class CheckboxGroupUIView: UIControl {
         intent: CheckboxIntent = .main,
         accessibilityIdentifierPrefix: String
     ) {
+        self.init(
+            title: title,
+            checkedImage: checkedImage,
+            items: items,
+            layout: layout,
+            alignment: alignment,
+            theme: theme,
+            intent: intent
+        )
+    }
+
+    /// Initialize a group of one or multiple checkboxes.
+    /// - Parameters:
+    ///   - title: An optional group title displayed on top of the checkbox group..
+    ///   - checkedImage: The tick-checkbox image for checked-state.
+    ///   - items: An array containing of multiple `CheckboxGroupItemProtocol`. Each array item is used to render a single checkbox.
+    ///   - layout: The layout of the group can be horizontal or vertical.
+    ///   - checkboxAlignment: The checkbox is positioned on the leading or trailing edge of the view.
+    ///   - theme: The Spark-Theme.
+    ///   - intent: Current intent of checkbox group
+    ///   - accessibilityIdentifierPrefix: All checkbox-views are prefixed by this identifier followed by the `CheckboxGroupItemProtocol`-identifier.
+    public init(
+        title: String? = nil,
+        checkedImage: UIImage,
+        items: [any CheckboxGroupItemProtocol],
+        layout: CheckboxGroupLayout = .vertical,
+        alignment: CheckboxAlignment = .left,
+        theme: Theme,
+        intent: CheckboxIntent = .main
+    ) {
         self.title = title
         self.checkedImage = checkedImage
         self.items = items
@@ -160,7 +190,6 @@ public final class CheckboxGroupUIView: UIControl {
         self.checkboxAlignment = alignment
         self.theme = theme
         self.intent = intent
-        self.accessibilityIdentifierPrefix = accessibilityIdentifierPrefix
         self.spacingLarge = theme.layout.spacing.large
         self.spacingSmall = theme.layout.spacing.small
         super.init(frame: .zero)
@@ -172,6 +201,7 @@ public final class CheckboxGroupUIView: UIControl {
         self.setupView()
         self.enableTouch()
         self.updateTitle()
+        self.updateAccessibility()
     }
 
     // MARK: - Methods
@@ -183,6 +213,12 @@ public final class CheckboxGroupUIView: UIControl {
         self._spacingLarge.update(traitCollection: self.traitCollection)
         self._spacingSmall.update(traitCollection: self.traitCollection)
         self._padding.update(traitCollection: self.traitCollection)
+    }
+
+    private func updateAccessibility() {
+        self.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkboxGroup
+        self.isAccessibilityElement = false
+        self.accessibilityContainerType = .semanticGroup
     }
 
     private func setupItemsStackView() {
@@ -207,9 +243,7 @@ public final class CheckboxGroupUIView: UIControl {
                 selectionState: item.selectionState,
                 alignment: self.alignment
             )
-            let identifier = "\(self.accessibilityIdentifierPrefix).\(item.id)"
 
-            checkbox.accessibilityIdentifier = identifier
             checkbox.publisher.sink { [weak self] in
                 guard
                     let self,
@@ -230,8 +264,6 @@ public final class CheckboxGroupUIView: UIControl {
     }
 
     private func setupView() {
-
-        self.accessibilityIdentifier =  "\(self.accessibilityIdentifierPrefix).\(CheckboxAccessibilityIdentifier.checkboxGroup)"
 
         self.addSubview(self.titleStackView)
         self.scrollView.addSubview(self.itemsStackView)

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -259,8 +259,6 @@ public final class CheckboxUIView: UIControl {
     }
 
     private func commonInit() {
-        self.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkbox
-        
         self.setupViews()
         self.enableTouch()
         self.subscribe()
@@ -340,11 +338,13 @@ public final class CheckboxUIView: UIControl {
         self.viewModel.$opacity.subscribe(in: &self.cancellables) { [weak self] opacity in
             guard let self else { return }
             self.layer.opacity = Float(opacity)
+            self.setAccessibilityEnable()
         }
 
         self.viewModel.$selectionState.subscribe(in: &self.cancellables) { [weak self] selectionState in
             guard let self else { return }
             self.controlView.selectionState = selectionState
+            self.setAccessibilityValue(isSelected: selectionState == .selected)
         }
 
         self.viewModel.$alignment.subscribe(in: &self.cancellables) { [weak self] alignment in
@@ -358,6 +358,7 @@ public final class CheckboxUIView: UIControl {
             self.textLabel.isHidden = labelHidden
             self.textLabel.font = self.viewModel.font.uiFont
             self.textLabel.attributedText = text.leftValue
+            self.setAccessibilityLabel(text.leftValue?.string)
         }
 
         self.viewModel.$checkedImage.subscribe(in: &self.cancellables) { [weak self] icon in
@@ -382,7 +383,23 @@ public final class CheckboxUIView: UIControl {
 private extension CheckboxUIView {
 
     private func updateAccessibility() {
-        self.accessibilityLabel = self.textLabel.text
+        self.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkbox
+        self.isAccessibilityElement = true
+        self.setAccessibilityLabel(self.textLabel.text)
+        self.setAccessibilityValue(isSelected: self.isSelected)
+        self.setAccessibilityEnable()
+    }
+
+    private func setAccessibilityLabel(_ label: String?) {
+        self.accessibilityLabel = label
+    }
+
+    private func setAccessibilityValue(isSelected: Bool) {
+        self.accessibilityValue = isSelected ? CheckboxAccessibilityValue.ticked : CheckboxAccessibilityValue.unticked
+    }
+
+    private func setAccessibilityEnable() {
+        self.accessibilityTraits = self.isEnabled ? [.none] : [.notEnabled]
     }
 
     private func updateTheme(colors: CheckboxColors) {

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -344,7 +344,7 @@ public final class CheckboxUIView: UIControl {
         self.viewModel.$selectionState.subscribe(in: &self.cancellables) { [weak self] selectionState in
             guard let self else { return }
             self.controlView.selectionState = selectionState
-            self.setAccessibilityValue(selectionState: selectionState)
+            self.setAccessibilityValue()
         }
 
         self.viewModel.$alignment.subscribe(in: &self.cancellables) { [weak self] alignment in
@@ -388,7 +388,7 @@ private extension CheckboxUIView {
         self.accessibilityTraits.insert(.button)
         self.accessibilityTraits.remove(.selected)
         self.setAccessibilityLabel(self.textLabel.text)
-        self.setAccessibilityValue(selectionState: self.selectionState)
+        self.setAccessibilityValue()
         self.setAccessibilityEnable()
     }
 
@@ -396,8 +396,8 @@ private extension CheckboxUIView {
         self.accessibilityLabel = label
     }
 
-    private func setAccessibilityValue(selectionState: CheckboxSelectionState) {
-        switch selectionState {
+    private func setAccessibilityValue() {
+        switch self.selectionState {
         case .selected:
             self.accessibilityValue = CheckboxAccessibilityValue.checked
         case .indeterminate:

--- a/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
+++ b/core/Sources/Components/Checkbox/View/UIKit/CheckboxUIView.swift
@@ -344,7 +344,7 @@ public final class CheckboxUIView: UIControl {
         self.viewModel.$selectionState.subscribe(in: &self.cancellables) { [weak self] selectionState in
             guard let self else { return }
             self.controlView.selectionState = selectionState
-            self.setAccessibilityValue(isSelected: selectionState == .selected)
+            self.setAccessibilityValue(selectionState: selectionState)
         }
 
         self.viewModel.$alignment.subscribe(in: &self.cancellables) { [weak self] alignment in
@@ -385,8 +385,10 @@ private extension CheckboxUIView {
     private func updateAccessibility() {
         self.accessibilityIdentifier = CheckboxAccessibilityIdentifier.checkbox
         self.isAccessibilityElement = true
+        self.accessibilityTraits.insert(.button)
+        self.accessibilityTraits.remove(.selected)
         self.setAccessibilityLabel(self.textLabel.text)
-        self.setAccessibilityValue(isSelected: self.isSelected)
+        self.setAccessibilityValue(selectionState: self.selectionState)
         self.setAccessibilityEnable()
     }
 
@@ -394,12 +396,23 @@ private extension CheckboxUIView {
         self.accessibilityLabel = label
     }
 
-    private func setAccessibilityValue(isSelected: Bool) {
-        self.accessibilityValue = isSelected ? CheckboxAccessibilityValue.ticked : CheckboxAccessibilityValue.unticked
+    private func setAccessibilityValue(selectionState: CheckboxSelectionState) {
+        switch selectionState {
+        case .selected:
+            self.accessibilityValue = CheckboxAccessibilityValue.checked
+        case .indeterminate:
+            self.accessibilityValue = CheckboxAccessibilityValue.indeterminate
+        case .unselected:
+            self.accessibilityValue = CheckboxAccessibilityValue.unchecked
+        }
     }
 
     private func setAccessibilityEnable() {
-        self.accessibilityTraits = self.isEnabled ? [.none] : [.notEnabled]
+        if self.isEnabled {
+            self.accessibilityTraits.remove(.notEnabled)
+        } else {
+            self.accessibilityTraits.insert(.notEnabled)
+        }
     }
 
     private func updateTheme(colors: CheckboxColors) {

--- a/spark/Demo/Classes/View/Components/Checkbox/SwiftUI/CheckboxGroupView.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/SwiftUI/CheckboxGroupView.swift
@@ -108,15 +108,12 @@ struct CheckboxGroupListView: View {
                     layout: self.layout == .selected ? .vertical : .horizontal,
                     alignment: self.alignment,
                     theme: self.theme,
-                    intent: self.intent,
-                    accessibilityIdentifierPrefix: "checkbox-group"
+                    intent: self.intent
                 )
                 .onChange(of: self.groupType) { newValue in
                     self.items = self.setItems(groupType: newValue)
                 }
                 .disabled(self.isEnabled == .unselected)
-//                .accessibilityLabel("I am checkbox group")
-                /// If you want to modifiy component accessibility, open the above command lines. First It will read checkbox group labels then start to read single checkbox items.
             }
         )
     }

--- a/spark/Demo/Classes/View/Components/Checkbox/SwiftUI/CheckboxGroupView.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/SwiftUI/CheckboxGroupView.swift
@@ -115,6 +115,8 @@ struct CheckboxGroupListView: View {
                     self.items = self.setItems(groupType: newValue)
                 }
                 .disabled(self.isEnabled == .unselected)
+//                .accessibilityLabel("I am checkbox group")
+                /// If you want to modifiy component accessibility, open the above command lines. First It will read checkbox group labels then start to read single checkbox items.
             }
         )
     }

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroup/CheckboxGroupComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroup/CheckboxGroupComponentUIView.swift
@@ -31,9 +31,6 @@ final class CheckboxGroupComponentUIView: ComponentUIView {
         )
         self.componentView.delegate = self
 
-        /// If you want to modifiy component accessibility, open the command lines. First It will read checkbox group labels then start to read single checkbox items.
-        self.updateCheckboxGroupAccessibility()
-
         // Setup
         self.setupSubscriptions()
 
@@ -42,10 +39,6 @@ final class CheckboxGroupComponentUIView: ComponentUIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func updateCheckboxGroupAccessibility() {
-        self.componentView.accessibilityLabel = "I am checkbox group"
     }
 
     // MARK: - Subscribe
@@ -109,8 +102,7 @@ final class CheckboxGroupComponentUIView: ComponentUIView {
             items: CheckboxGroupComponentUIViewModel.makeCheckboxGroupItems(type: viewModel.groupType),
             alignment: viewModel.isAlignmentLeft ? .left : .right,
             theme: viewModel.theme,
-            intent: viewModel.intent,
-            accessibilityIdentifierPrefix: "Checkbox"
+            intent: viewModel.intent
         )
     }
 }

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroup/CheckboxGroupComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroup/CheckboxGroupComponentUIView.swift
@@ -32,7 +32,7 @@ final class CheckboxGroupComponentUIView: ComponentUIView {
         self.componentView.delegate = self
 
         /// If you want to modifiy component accessibility, open the command lines. First It will read checkbox group labels then start to read single checkbox items.
-//        self.updateCheckboxGroupAccessibility()
+        self.updateCheckboxGroupAccessibility()
 
         // Setup
         self.setupSubscriptions()

--- a/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroup/CheckboxGroupComponentUIView.swift
+++ b/spark/Demo/Classes/View/Components/Checkbox/UIKit/CheckboxGroup/CheckboxGroupComponentUIView.swift
@@ -29,8 +29,11 @@ final class CheckboxGroupComponentUIView: ComponentUIView {
             viewModel: viewModel,
             componentView: self.componentView
         )
-
         self.componentView.delegate = self
+
+        /// If you want to modifiy component accessibility, open the command lines. First It will read checkbox group labels then start to read single checkbox items.
+//        self.updateCheckboxGroupAccessibility()
+
         // Setup
         self.setupSubscriptions()
 
@@ -39,6 +42,10 @@ final class CheckboxGroupComponentUIView: ComponentUIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func updateCheckboxGroupAccessibility() {
+        self.componentView.accessibilityLabel = "I am checkbox group"
     }
 
     // MARK: - Subscribe


### PR DESCRIPTION
- I tried to fix all accessibility issue. 
- I removed indexes from checkbox identifier for items which are in checkbox group. I dont know If we change checkbox identifier in checkbox group as adding index.
-  I marked checkbox group as an list type. this mean; when client click space that isn't accessible part on checkbox group, First; Voice over will read checkbox group label or hint if they exist. I didn't specify from component side but consumer might set.
- I also didn't give trait to single checkbox item. Lots of app specify checkbox type  giving a value property.  ex: 
accessibilityValue = "Checkbox checked" or "Checkbox unchecked". 
