### PR TITLE
[Bug] Prevent cancelTracking from being called in UIControls by addin…

### DIFF
--- a/core/Sources/Common/UIKit/Extension/UIControl/UIControl+Extensions.swift
+++ b/core/Sources/Common/UIKit/Extension/UIControl/UIControl+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  UIControl-EnableTouches.swift
+//  UIControl+Extensions.swift
 //  SparkCore
 //
 //  Created by Michael Zimmermann on 21.02.24.
@@ -11,11 +11,20 @@ import UIKit
 extension UIControl {
 
     // Add a default tap gesture recognizer without any action to detect the action/publisher/target action even if the parent view has a gesture recognizer
-    // Why ? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
+    // Why? UIControl action/publisher/target doesn't work if the parent contains a gesture recognizer.
     // Note: Native UIButton add the same default recognizer to manage this use case.
     func enableTouch() {
         let gestureRecognizer = UITapGestureRecognizer()
         gestureRecognizer.cancelsTouchesInView = false
         self.addGestureRecognizer(gestureRecognizer)
+    }
+
+    /// Fixes conflict with other swipes (scrollViews, bottomSheets...) by adding a panGesture to prevent cancelTracking from being called
+    @discardableResult
+    func addPanGestureToPreventCancelTracking() -> UIPanGestureRecognizer {
+        let panGesture = UIPanGestureRecognizer(target: nil, action: nil)
+        panGesture.cancelsTouchesInView = false
+        self.addGestureRecognizer(panGesture)
+        return panGesture
     }
 }

--- a/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUIControl.swift
+++ b/core/Sources/Components/ProgressTracker/View/UIKit/ProgressTrackerUIControl.swift
@@ -236,6 +236,7 @@ public final class ProgressTrackerUIControl: UIControl {
         self.setupView(content: content, orientation: orientation)
         self.setupSubscriptions()
         self.enableTouch()
+        self.addPanGestureToPreventCancelTracking()
         self.isUserInteractionEnabled = false
     }
 

--- a/core/Sources/Components/Rating/View/UIKit/RatingInputUIView.swift
+++ b/core/Sources/Components/Rating/View/UIKit/RatingInputUIView.swift
@@ -103,6 +103,7 @@ public final class RatingInputUIView: UIControl {
         super.init(frame: .zero)
         self.setupView()
         self.enableTouch()
+        self.addPanGestureToPreventCancelTracking()
     }
     
     required init?(coder: NSCoder) {

--- a/core/Sources/Components/Slider/View/UIKit/SliderUIControl.swift
+++ b/core/Sources/Components/Slider/View/UIKit/SliderUIControl.swift
@@ -118,6 +118,8 @@ public final class SliderUIControl<V>: UIControl where V: BinaryFloatingPoint, V
         }), for: .valueChanged)
 
         self.setupAccessibility()
+
+        self.addPanGestureToPreventCancelTracking()
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
To test:
replace
```swift
self.navigationController?.pushViewController(viewController, animated: true)
```
by
```swift
self.navigationController?.present(viewController, isAnimated: true)
```
in `ComponentsViewController.swift`