### PR TITLE
[RatingInput#897] Rating display update disabled

### DIFF
--- a/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
@@ -9,12 +9,8 @@
 import Combine
 import Foundation
 
-protocol Disableable {
-    func setDisabled(_ disabled: Bool) -> Self
-}
-
 /// A view model for the rating display.
-final class RatingDisplayViewModel: Disableable, ObservableObject {
+final class RatingDisplayViewModel: ObservableObject {
 
     /// The current theme of which colors and sizes are dependent.
     var theme: Theme {
@@ -112,8 +108,8 @@ final class RatingDisplayViewModel: Disableable, ObservableObject {
             state: self.ratingState)
     }
 
-    func setDisabled(_ disabled: Bool) -> Self {
-        self.updateState(isEnabled: !disabled)
+    func isEnabled(_ enabled: Bool) -> Self {
+        self.updateState(isEnabled: enabled)
         return self
     }
 

--- a/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
@@ -98,18 +98,16 @@ final class RatingDisplayViewModel: ObservableObject {
             state: self.ratingState)
     }
 
-    func updateState(isEnabled: Bool) {
-        guard self.ratingState.isEnabled != isEnabled else { return }
+    @discardableResult
+    func updateState(isEnabled: Bool) -> Self {
+        guard self.ratingState.isEnabled != isEnabled else { return self }
 
         self.ratingState.isEnabled = isEnabled
         self.colors = self.colorsUseCase.execute(
             theme: self.theme,
             intent: self.intent,
             state: self.ratingState)
-    }
 
-    func isEnabled(_ enabled: Bool) -> Self {
-        self.updateState(isEnabled: enabled)
         return self
     }
 

--- a/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
+++ b/core/Sources/Components/Rating/View/RatingDisplayViewModel.swift
@@ -9,9 +9,13 @@
 import Combine
 import Foundation
 
+protocol Disableable {
+    func setDisabled(_ disabled: Bool) -> Self
+}
+
 /// A view model for the rating display.
-final class RatingDisplayViewModel: ObservableObject {
-    
+final class RatingDisplayViewModel: Disableable, ObservableObject {
+
     /// The current theme of which colors and sizes are dependent.
     var theme: Theme {
         didSet {
@@ -106,6 +110,11 @@ final class RatingDisplayViewModel: ObservableObject {
             theme: self.theme,
             intent: self.intent,
             state: self.ratingState)
+    }
+
+    func setDisabled(_ disabled: Bool) -> Self {
+        self.updateState(isEnabled: !disabled)
+        return self
     }
 
     // MARK: - Private functions

--- a/core/Sources/Components/Rating/View/SwiftUI/RatingInputView.swift
+++ b/core/Sources/Components/Rating/View/SwiftUI/RatingInputView.swift
@@ -42,7 +42,7 @@ public struct RatingInputView: View {
 
     // MARK: - View
     public var body: some View {
-        RatingInputInternalView(viewModel: viewModel.isEnabled(self.isEnabled), rating: self.rating)
+        RatingInputInternalView(viewModel: viewModel.updateState(isEnabled: self.isEnabled), rating: self.rating, configuration: self.configuration)
     }
 
     // MARK: - Internal functions
@@ -68,11 +68,11 @@ struct RatingInputInternalView: View {
     /// - Parameters:
     ///   - viewModel: The view model of the view.
     ///   - rating: A binding containg the rating value. This should be a value within the range 0...5
-    ///   - configuration: A configuration of the star. A default value is defined.
+    ///   - configuration: A configuration of the star
     init(
         viewModel: RatingDisplayViewModel,
         rating: Binding<CGFloat>,
-        configuration: StarConfiguration = .default
+        configuration: StarConfiguration
     ) {
         self._rating = rating
         self._displayRating = State(initialValue: rating.wrappedValue)

--- a/core/Sources/Components/Rating/View/SwiftUI/RatingInputView.swift
+++ b/core/Sources/Components/Rating/View/SwiftUI/RatingInputView.swift
@@ -8,7 +8,9 @@
 
 import SwiftUI
 
+/// A SwiftUI native rating input component.
 public struct RatingInputView: View {
+    // MARK: - Private variables
     @ObservedObject private var viewModel: RatingDisplayViewModel
     @Environment(\.isEnabled) private var isEnabled: Bool
     private var rating: Binding<CGFloat>
@@ -38,12 +40,20 @@ public struct RatingInputView: View {
             count: .five)
     }
 
+    // MARK: - View
     public var body: some View {
-        RatingInputInternalView(viewModel: viewModel.setDisabled(!self.isEnabled), rating: self.rating)
+        RatingInputInternalView(viewModel: viewModel.isEnabled(self.isEnabled), rating: self.rating)
+    }
+
+    // MARK: - Internal functions
+    /// This function is just exposed for testing
+    internal func highlighted(_ isHiglighed: Bool) -> Self {
+        self.viewModel.updateState(isPressed: isHiglighed)
+        return self
     }
 }
 
-/// A SwiftUI native rating input component.
+// MARK: - Internal Rating Input
 struct RatingInputInternalView: View {
 
     // MARK: - Private variables
@@ -56,8 +66,7 @@ struct RatingInputInternalView: View {
     // MARK: - Initialization
     /// Create a rating display view with the following parameters
     /// - Parameters:
-    ///   - theme: The current theme
-    ///   - intent: The intent to define the colors
+    ///   - viewModel: The view model of the view.
     ///   - rating: A binding containg the rating value. This should be a value within the range 0...5
     ///   - configuration: A configuration of the star. A default value is defined.
     init(
@@ -103,13 +112,6 @@ struct RatingInputInternalView: View {
         .frame(width: width, height: size)
         .accessibilityIdentifier(RatingInputAccessibilityIdentifier.identifier)
         .accessibilityValue("\(self.displayRating)")
-    }
-
-    // MARK: - Internal functions
-    /// This function is just exposed for testing
-    internal func highlighted(_ isHiglighed: Bool) -> Self {
-        self.viewModel.updateState(isPressed: isHiglighed)
-        return self
     }
 
     // MARK: - Private functions

--- a/core/Sources/Components/Rating/View/SwiftUI/RatingInputView.swift
+++ b/core/Sources/Components/Rating/View/SwiftUI/RatingInputView.swift
@@ -8,8 +8,43 @@
 
 import SwiftUI
 
-/// A SwiftUI native rating input component.
 public struct RatingInputView: View {
+    @ObservedObject private var viewModel: RatingDisplayViewModel
+    @Environment(\.isEnabled) private var isEnabled: Bool
+    private var rating: Binding<CGFloat>
+    private var configuration: StarConfiguration
+    private var intent: RatingIntent
+
+    // MARK: - Initialization
+    /// Create a rating display view with the following parameters
+    /// - Parameters:
+    ///   - theme: The current theme
+    ///   - intent: The intent to define the colors
+    ///   - rating: A binding containg the rating value. This should be a value within the range 0...5
+    ///   - configuration: A configuration of the star. A default value is defined.
+    public init(
+        theme: Theme,
+        intent: RatingIntent,
+        rating: Binding<CGFloat>,
+        configuration: StarConfiguration = .default
+    ) {
+        self.rating = rating
+        self.intent = intent
+        self.configuration = configuration
+        self.viewModel = RatingDisplayViewModel(
+            theme: theme,
+            intent: intent,
+            size: .input,
+            count: .five)
+    }
+
+    public var body: some View {
+        RatingInputInternalView(viewModel: viewModel.setDisabled(!self.isEnabled), rating: self.rating)
+    }
+}
+
+/// A SwiftUI native rating input component.
+struct RatingInputInternalView: View {
 
     // MARK: - Private variables
     @ObservedObject private var viewModel: RatingDisplayViewModel
@@ -25,24 +60,19 @@ public struct RatingInputView: View {
     ///   - intent: The intent to define the colors
     ///   - rating: A binding containg the rating value. This should be a value within the range 0...5
     ///   - configuration: A configuration of the star. A default value is defined.
-    public init(
-        theme: Theme,
-        intent: RatingIntent,
+    init(
+        viewModel: RatingDisplayViewModel,
         rating: Binding<CGFloat>,
         configuration: StarConfiguration = .default
     ) {
         self._rating = rating
         self._displayRating = State(initialValue: rating.wrappedValue)
         self.configuration = configuration
-        self.viewModel = RatingDisplayViewModel(
-            theme: theme,
-            intent: intent,
-            size: .input,
-            count: .five)
+        self.viewModel = viewModel
     }
 
     // MARK: - View
-    public var body: some View {
+    var body: some View {
         let size = self.viewModel.ratingSize.height * self.scaleFactor
         let lineWidth = self.viewModel.ratingSize.borderWidth * self.scaleFactor
         let spacing = self.viewModel.ratingSize.spacing * self.scaleFactor
@@ -66,9 +96,6 @@ public struct RatingInputView: View {
                 )
                 .accessibilityIdentifier("\(RatingInputAccessibilityIdentifier.identifier)-\(index)")
             }
-        }
-        .isEnabledChanged { isEnabled in
-            self.viewModel.updateState(isEnabled: isEnabled)
         }
         .compositingGroup()
         .opacity(colors.opacity)


### PR DESCRIPTION
This is an example of avoiding the isEnabledModifier.
In this example. The RatingInputView creates the view model and updates the enables state of the view model when the body is build. This viewmodel is then passed to internal rating views.