### PR TITLE
[ProgressTracker#906] Fix touch area and label sizing in vertical model.

### DIFF
--- a/core/Sources/Components/ProgressTracker/View/SwiftUI/ProgressTrackerVerticalView.swift
+++ b/core/Sources/Components/ProgressTracker/View/SwiftUI/ProgressTrackerVerticalView.swift
@@ -67,7 +67,7 @@ struct ProgressTrackerVerticalView: View {
     private func verticalLayout() -> some View {
         VStack(alignment: .leading, spacing: self.verticalStackSpacing) {
             ForEach((0..<self.viewModel.content.numberOfPages), id: \.self) { index in
-                    self.pageContent(at: index)
+                self.pageContent(at: index)
                     .frame(maxHeight: .infinity)
                     .disabled(!self.viewModel.isEnabled(at: index))
                     .accessibilityAttributes(viewModel: self.viewModel, index:  index)
@@ -83,6 +83,7 @@ struct ProgressTrackerVerticalView: View {
 
             if let label = self.viewModel.content.getAttributedLabel(atIndex: index)  {
                 self.label(label, at: index)
+                    .fixedSize(horizontal: false, vertical: true)
                     .alignmentGuide(.xAlignment) { ($0.height - ($0[.lastTextBaseline] - $0[.firstTextBaseline])) / 2 }
             }
         }

--- a/core/Sources/Components/ProgressTracker/View/SwiftUI/ProgressTrackerView.swift
+++ b/core/Sources/Components/ProgressTracker/View/SwiftUI/ProgressTrackerView.swift
@@ -100,7 +100,7 @@ public struct ProgressTrackerView: View {
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier(AccessibilityIdentifier.identifier)
             .accessibilityValue("\(self.currentPageIndex)")
-            .backgroundPreferenceValue(ProgressTrackerSizePreferences.self) { preferences in
+            .overlayPreferenceValue(ProgressTrackerSizePreferences.self) { preferences in
                 if self.viewModel.interactionState != .none {
                     GeometryReader { geometry in
                         Color.black.opacity(0.000001)

--- a/spark/Demo/Classes/View/Components/ProgressTracker/SwiftUI/ProgressTrackerComponent.swift
+++ b/spark/Demo/Classes/View/Components/ProgressTracker/SwiftUI/ProgressTrackerComponent.swift
@@ -196,7 +196,7 @@ struct ProgressTrackerComponent: View {
         }
 
         if self.completedPageIndicator == .selected {
-            let image: Image? = Image(uiImage: DemoIconography.shared.checkmark.uiImage)
+            let image: Image? = DemoIconography.shared.checkmark.image
             view = view.completedIndicatorImage(image)
         } else {
             view = view.completedIndicatorImage(nil)
@@ -236,7 +236,8 @@ struct ProgressTrackerComponent: View {
         if self.label.isEmpty {
             return "\(index)"
         } else {
-            return "\(self.label) \(index)"
+            let label = index % 2 == 0 ? String(self.label.prefix(4)) : self.label
+            return "\(label.trimmingCharacters(in: .whitespaces)) \(index)"
         }
     }
 }


### PR DESCRIPTION
Added fixes for:

- The labels contained within the container were not touchable.
- In the vertical mode, a long label did not wrap correctly.

Example of labels not rendered correctly.
<img width="392" alt="Bildschirmfoto 2024-04-19 um 14 00 19" src="https://github.com/adevinta/spark-ios/assets/128726463/b3d4de4d-d80e-4490-ba11-bddf57e632a8">

After update:
<img width="380" alt="Bildschirmfoto 2024-04-19 um 14 01 04" src="https://github.com/adevinta/spark-ios/assets/128726463/df78da80-c1f3-4e97-933e-1a71fc51849b">
