### PR TITLE
[Button-909] UIKit: Remove vertical spacing

### DIFF
--- a/core/Sources/Common/SwiftUI/Extension/EdgeInsets/EdgeInsets+Extension.swift
+++ b/core/Sources/Common/SwiftUI/Extension/EdgeInsets/EdgeInsets+Extension.swift
@@ -23,7 +23,7 @@ extension EdgeInsets {
     /// - Parameters:
     ///   - vertical: horizontal inset value use to set left and right insets.
     ///   - horizontal: horizontal inset value use to set left and right insets.
-    init(vertical: CGFloat, horizontal: CGFloat) {
+    init(vertical: CGFloat = 0, horizontal: CGFloat = 0) {
         self = .init(top: vertical, leading: horizontal, bottom: vertical, trailing: horizontal)
     }
 }

--- a/core/Sources/Components/Button/Properties/Internal/Spacings/ButtonSpacings+ExtensionTests.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Spacings/ButtonSpacings+ExtensionTests.swift
@@ -14,12 +14,10 @@ extension ButtonSpacings {
     // MARK: - Properties
 
     static func mocked(
-        verticalSpacing: CGFloat = 10,
         horizontalSpacing: CGFloat = 11,
         horizontalPadding: CGFloat = 12
     ) -> Self {
         return .init(
-            verticalSpacing: verticalSpacing,
             horizontalSpacing: horizontalSpacing,
             horizontalPadding: horizontalPadding
         )

--- a/core/Sources/Components/Button/Properties/Internal/Spacings/ButtonSpacings.swift
+++ b/core/Sources/Components/Button/Properties/Internal/Spacings/ButtonSpacings.swift
@@ -12,7 +12,6 @@ struct ButtonSpacings: Equatable {
 
     // MARK: - Properties
 
-    let verticalSpacing: CGFloat
     let horizontalSpacing: CGFloat
     let horizontalPadding: CGFloat
 }

--- a/core/Sources/Components/Button/UseCase/GetSpacings/ButtonGetSpacingsUseCase.swift
+++ b/core/Sources/Components/Button/UseCase/GetSpacings/ButtonGetSpacingsUseCase.swift
@@ -20,7 +20,6 @@ struct ButtonGetSpacingsUseCase: ButtonGetSpacingsUseCaseable {
 
     func execute(spacing: LayoutSpacing) -> ButtonSpacings {
         return .init(
-            verticalSpacing: spacing.medium,
             horizontalSpacing: spacing.large,
             horizontalPadding: spacing.medium
         )

--- a/core/Sources/Components/Button/UseCase/GetSpacings/ButtonGetSpacingsUseCaseTests.swift
+++ b/core/Sources/Components/Button/UseCase/GetSpacings/ButtonGetSpacingsUseCaseTests.swift
@@ -26,9 +26,6 @@ final class ButtonGetSpacingsUseCaseTests: XCTestCase {
         )
 
         // THEN
-        XCTAssertEqual(spacings.verticalSpacing,
-                       spacingMock.medium,
-                       "Wrong verticalSpacing value")
         XCTAssertEqual(spacings.horizontalSpacing,
                        spacingMock.large,
                        "Wrong horizontalSpacing value")

--- a/core/Sources/Components/Button/View/SwiftUI/Public/Button/ButtonView.swift
+++ b/core/Sources/Components/Button/View/SwiftUI/Public/Button/ButtonView.swift
@@ -15,7 +15,6 @@ public struct ButtonView: View {
 
     @ObservedObject private var viewModel: ButtonSUIViewModel
 
-    @ScaledMetric private var verticalSpacing: CGFloat
     @ScaledMetric private var horizontalSpacing: CGFloat
     @ScaledMetric private var horizontalPadding: CGFloat
 
@@ -53,7 +52,6 @@ public struct ButtonView: View {
 
         // **
         // Scaled Metric
-        self._verticalSpacing = .init(wrappedValue: viewModel.spacings?.verticalSpacing ?? .zero)
         self._horizontalSpacing = .init(wrappedValue: viewModel.spacings?.horizontalSpacing ?? .zero)
         self._horizontalPadding = .init(wrappedValue: viewModel.spacings?.horizontalPadding ?? .zero)
         // **
@@ -67,7 +65,6 @@ public struct ButtonView: View {
         ButtonContainerView(
             viewModel: self.viewModel,
             padding: .init(
-                vertical: self.verticalSpacing,
                 horizontal: self.horizontalSpacing
             ),
             action: self.action

--- a/core/Sources/Components/Button/View/UIKit/Button/ButtonUIView.swift
+++ b/core/Sources/Components/Button/View/UIKit/Button/ButtonUIView.swift
@@ -120,10 +120,7 @@ public final class ButtonUIView: ButtonMainUIView {
     private let viewModel: ButtonViewModel
 
     private var contentStackViewLeadingConstraint: NSLayoutConstraint?
-    private var contentStackViewTopConstraint: NSLayoutConstraint?
-    private var contentStackViewBottomConstraint: NSLayoutConstraint?
 
-    @ScaledUIMetric private var verticalSpacing: CGFloat = 0
     @ScaledUIMetric private var horizontalSpacing: CGFloat = 0
     @ScaledUIMetric private var horizontalPadding: CGFloat = 0
 
@@ -199,15 +196,15 @@ public final class ButtonUIView: ButtonMainUIView {
         self.contentStackView.translatesAutoresizingMaskIntoConstraints = false
 
         self.contentStackViewLeadingConstraint = self.contentStackView.leadingAnchor.constraint(greaterThanOrEqualTo: self.leadingAnchor)
-        self.contentStackViewTopConstraint = self.contentStackView.topAnchor.constraint(equalTo: self.topAnchor)
+        let contentStackViewTopConstraint = self.contentStackView.topAnchor.constraint(equalTo: self.topAnchor)
         let contentStackViewCenterXAnchor = self.contentStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor)
-        self.contentStackViewBottomConstraint = self.contentStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        let contentStackViewBottomConstraint = self.contentStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
 
         NSLayoutConstraint.activate([
             self.contentStackViewLeadingConstraint,
-            self.contentStackViewTopConstraint,
+            contentStackViewTopConstraint,
             contentStackViewCenterXAnchor,
-            self.contentStackViewBottomConstraint,
+            contentStackViewBottomConstraint,
         ].compactMap({ $0 }))
     }
 
@@ -283,12 +280,10 @@ public final class ButtonUIView: ButtonMainUIView {
 
     private func updateSpacings() {
         // Reload spacing only if value changed
-        let verticalSpacing = self._verticalSpacing.wrappedValue
         let horizontalSpacing = self._horizontalSpacing.wrappedValue
         let horizontalPadding = self._horizontalPadding.wrappedValue
 
-        if verticalSpacing != self.contentStackViewTopConstraint?.constant ||
-            horizontalSpacing != self.contentStackViewLeadingConstraint?.constant ||
+        if horizontalSpacing != self.contentStackViewLeadingConstraint?.constant ||
             horizontalPadding != self.contentStackView.spacing {
 
             let isAnimated = self.isAnimated && !self.firstContentStackViewAnimation
@@ -300,8 +295,6 @@ public final class ButtonUIView: ButtonMainUIView {
                 self.firstContentStackViewAnimation = false
 
                 self.contentStackViewLeadingConstraint?.constant = horizontalSpacing
-                self.contentStackViewTopConstraint?.constant = verticalSpacing
-                self.contentStackViewBottomConstraint?.constant = -verticalSpacing
                 self.contentStackView.updateConstraintsIfNeeded()
 
                 self.contentStackView.spacing = horizontalPadding
@@ -312,7 +305,6 @@ public final class ButtonUIView: ButtonMainUIView {
     // MARK: - Data Did Update
 
     private func spacingsDidUpdate(_ spacings: ButtonSpacings) {
-        self.verticalSpacing = spacings.verticalSpacing
         self.horizontalSpacing = spacings.horizontalSpacing
         self.horizontalPadding = spacings.horizontalPadding
 
@@ -383,7 +375,6 @@ public final class ButtonUIView: ButtonMainUIView {
         super.traitCollectionDidChange(previousTraitCollection)
 
         // Update spacings
-        self._verticalSpacing.update(traitCollection: self.traitCollection)
         self._horizontalSpacing.update(traitCollection: self.traitCollection)
         self._horizontalPadding.update(traitCollection: self.traitCollection)
         self.updateSpacings()


### PR DESCRIPTION
The vertical spacing is now removed, the height of the text is equals to the height of the button (the text is always centered vertically).

Related to this [ticket](https://github.com/orgs/adevinta/projects/4/views/19?pane=issue&itemId=60966156).