### PR TITLE
[Chip#922] Updated icon and label size.

### DIFF
--- a/core/Sources/Components/Chip/Enum/ChipConstants.swift
+++ b/core/Sources/Components/Chip/Enum/ChipConstants.swift
@@ -11,7 +11,7 @@ import Foundation
 // MARK: - Constants
 
 enum ChipConstants {
-    static let imageSize: CGFloat = 13.33
+    static let imageSize: CGFloat = 16
     static let height: CGFloat = 32
     static let borderWidth: CGFloat = 1
     static let dashLength: CGFloat = 1.9

--- a/core/Sources/Components/Chip/View/ChipViewModel.swift
+++ b/core/Sources/Components/Chip/View/ChipViewModel.swift
@@ -90,7 +90,7 @@ class ChipViewModel<Content>: ObservableObject {
         self.spacing = self.theme.layout.spacing.small
         self.padding = self.theme.layout.spacing.medium
         self.borderRadius = self.theme.border.radius.medium
-        self.font = self.theme.typography.body2
+        self.font = self.theme.bodyFont
         self.isIconLeading = alignment.isIconLeading
     }
 
@@ -132,7 +132,7 @@ class ChipViewModel<Content>: ObservableObject {
         self.spacing = self.theme.layout.spacing.small
         self.padding = self.theme.layout.spacing.medium
         self.borderRadius = self.theme.border.radius.medium
-        self.font = self.theme.typography.body2
+        self.font = self.theme.bodyFont
     }
 
     private func variantDidUpdate() {
@@ -141,6 +141,12 @@ class ChipViewModel<Content>: ObservableObject {
 
     private func intentColorsDidUpdate() {
         self.updateColors()
+    }
+}
+
+private extension Theme {
+    var bodyFont: TypographyFontToken {
+        return self.typography.body1
     }
 }
 

--- a/core/Sources/Components/Chip/View/ChipViewModelTests.swift
+++ b/core/Sources/Components/Chip/View/ChipViewModelTests.swift
@@ -197,7 +197,7 @@ final class ChipViewModelTests: XCTestCase {
         // When
         let newTheme = ThemeGeneratedMock.mocked()
         let typography = TypographyGeneratedMock.mocked()
-        typography.body2 = TypographyFontTokenGeneratedMock.mocked(.title)
+        typography.body1 = TypographyFontTokenGeneratedMock.mocked(.title)
         newTheme.typography = typography
 
         self.sut.set(theme: newTheme)


### PR DESCRIPTION
The Label and Icon had the wrong size.

See [PR for the updated snapshots.](https://github.com/adevinta/spark-ios-snapshots/pull/95/files)

<img width="487" alt="Bildschirmfoto 2024-05-06 um 10 59 55" src="https://github.com/adevinta/spark-ios/assets/128726463/ed36d192-f72e-41c8-95a0-021c08df6a7a">
