### PR TITLE
[Radiobutton#918] Fix horizontal radiobutton group bottom padding

### DIFF
--- a/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupView.swift
+++ b/core/Sources/Components/RadioButton/View/SwiftUI/RadioButtonGroupView.swift
@@ -160,7 +160,7 @@ public struct RadioButtonGroupView<ID: Equatable & Hashable & CustomStringConver
     }
 
     private func bottomPadding(of item: RadioButtonItem<ID>) -> CGFloat {
-        if item.id == items.last?.id {
+        if self.groupLayout == .horizontal || item.id == items.last?.id {
             return 0
         } else {
             return self.viewModel.spacing


### PR DESCRIPTION
There was a extra bottom padding for horizontal radio button group on swiftui side. I fixed it.

![image](https://github.com/adevinta/spark-ios/assets/139964419/63f2a3f5-8c33-4765-b0dd-99d1a52598f0)
 
