### PR TITLE
[Tag#1939] Use default attributes of label if not overwritten by attributed text.

### DIFF
--- a/core/Sources/Components/RadioButton/UseCases/RadioButtonGetColorsUseCase.swift
+++ b/core/Sources/Components/RadioButton/UseCases/RadioButtonGetColorsUseCase.swift
@@ -53,19 +53,7 @@ private extension SparkCore.Colors {
     func buttonColor(
         intent: RadioButtonIntent,
         isSelected: Bool) -> any ColorToken {
-            return  isSelected ? self.selectedColor(intent: intent) : self.outlineColor(intent: intent)
-    }
-
-    private func outlineColor(intent: RadioButtonIntent) -> any ColorToken {
-        switch intent {
-        case .danger:
-            return self.feedback.error
-        case .alert:
-            return self.feedback.alert
-        case .success:
-            return self.feedback.success
-        default: return self.base.outline
-        }
+            return  isSelected ? self.selectedColor(intent: intent) : self.base.outline
     }
 
     private func selectedColor(intent: RadioButtonIntent) -> any ColorToken {

--- a/core/Sources/Components/RadioButton/UseCases/RadioButtonGetColorsUseCaseTests.swift
+++ b/core/Sources/Components/RadioButton/UseCases/RadioButtonGetColorsUseCaseTests.swift
@@ -54,7 +54,7 @@ final class RadioButtonGetColorsUseCaseTests: XCTestCase {
         // Given
         let colors = self.theme.colors
         let expectedColors = RadioButtonColors(
-            button: colors.feedback.error,
+            button: colors.base.outline,
             label: colors.base.onBackground,
             halo: colors.feedback.errorContainer,
             fill: ColorTokenDefault.clear,
@@ -96,7 +96,7 @@ final class RadioButtonGetColorsUseCaseTests: XCTestCase {
         // Given
         let colors = self.theme.colors
         let expectedColors = RadioButtonColors(
-            button: colors.feedback.alert,
+            button: colors.base.outline,
             label: colors.base.onBackground,
             halo: colors.feedback.alertContainer,
             fill: ColorTokenDefault.clear,
@@ -117,7 +117,7 @@ final class RadioButtonGetColorsUseCaseTests: XCTestCase {
         // Given
         let colors = self.theme.colors
         let expectedColors = RadioButtonColors(
-            button: colors.feedback.success,
+            button: colors.base.outline,
             label: colors.base.onBackground,
             halo: colors.feedback.successContainer,
             fill: ColorTokenDefault.clear,

--- a/core/Sources/Components/Tag/View/UIKit/TagUIView.swift
+++ b/core/Sources/Components/Tag/View/UIKit/TagUIView.swift
@@ -335,21 +335,18 @@ public final class TagUIView: UIView {
     }
 
     private func reloadTextLabel() {
+        self.reloadTextStyle()
         if let attributedText = self.attributedText {
             self.textLabel.attributedText = attributedText
         } else {
             self.textLabel.text = self.text
-            self.reloadTextStyle()
         }
         self.textLabel.isHidden = (self.text == nil && self.attributedText == nil)
     }
 
     private func reloadTextStyle() {
-        // Change the style only if the text is displayed and not the attributedText
-        if self._attributedText == nil {
-            self.textLabel.font = self.theme.typography.captionHighlight.uiFont
-            self.textLabel.textColor = self.colors.foregroundColor.uiColor
-        }
+        self.textLabel.font = self.theme.typography.captionHighlight.uiFont
+        self.textLabel.textColor = self.colors.foregroundColor.uiColor
     }
 
     private func reloadUIFromTheme() {
@@ -364,7 +361,7 @@ public final class TagUIView: UIView {
         self.setMasksToBounds(true)
 
         // Subviews
-        self.reloadTextStyle()
+        self.reloadTextLabel()
     }
 
     private func reloadUIFromColors() {
@@ -374,7 +371,7 @@ public final class TagUIView: UIView {
 
         // Subviews
         self.iconImageView.tintColor = self.colors.foregroundColor.uiColor
-        self.reloadTextStyle()
+        self.reloadTextLabel()
     }
 
     private func reloadUIFromSize() {

--- a/spark/Demo/Classes/View/Components/Tag/TagContent.swift
+++ b/spark/Demo/Classes/View/Components/Tag/TagContent.swift
@@ -31,7 +31,7 @@ enum TagContent: CaseIterable {
     var text: String {
         switch self {
         case .attributedText, .iconAndAttributedText:
-            return "This is a AT Tag"
+            return "This is an AT Tag"
         case .longText, .longAttributedText, .iconAndLongText, .iconAndLongAttributedText:
             return "This is a Tag with a very very very very very long long long long width"
         default:

--- a/spark/Demo/Classes/View/Components/Tag/UIKit/TagComponentUIViewModel.swift
+++ b/spark/Demo/Classes/View/Components/Tag/UIKit/TagComponentUIViewModel.swift
@@ -92,13 +92,11 @@ final class TagComponentUIViewModel: ComponentUIViewModel {
     let image: UIImage = UIImage(named: "alert") ?? UIImage()
 
     func attributeText(_ text: String) -> NSAttributedString {
-        let attributeString = NSMutableAttributedString(
-            string: text,
-            attributes: [
-                .font: UIFont.boldSystemFont(ofSize: 14),
-                .foregroundColor: UIColor.red
-            ]
-        )
+        let attributeString = NSMutableAttributedString(string: text)
+        let range = NSRange(location: text.count/3, length: text.count/3)
+
+        attributeString.addAttribute(NSAttributedString.Key.font, value: UIFont.boldSystemFont(ofSize: 14), range: range)
+        attributeString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.red, range: range)
         return attributeString
     }
 


### PR DESCRIPTION


See [updated snapshots](https://github.com/adevinta/spark-ios-snapshots/pull/96).