### PR TITLE
[Button-972] Fix button animation

### DIFF
--- a/core/Sources/Components/Button/View/SwiftUI/Internal/ButtonContainerView.swift
+++ b/core/Sources/Components/Button/View/SwiftUI/Internal/ButtonContainerView.swift
@@ -62,7 +62,6 @@ struct ButtonContainerView<ContainerView: View, ViewModel: ButtonMainViewModel &
                     radius: self.borderRadius,
                     colorToken: self.viewModel.currentColors?.borderColor ?? ColorTokenDefault.clear
                 )
-                .animation(nil, value: UUID())
         }
         .buttonStyle(PressedButtonStyle(
             isPressed: self.$isPressed

--- a/core/Sources/Components/Button/View/SwiftUI/Public/Button/ButtonView.swift
+++ b/core/Sources/Components/Button/View/SwiftUI/Public/Button/ButtonView.swift
@@ -93,6 +93,8 @@ public struct ButtonView: View {
             maxWidth: self.viewModel.maxWidth,
             alignment: self.viewModel.frameAlignment
         )
+        .animation(nil, value: self.viewModel.maxWidth)
+        .animation(nil, value: self.viewModel.frameAlignment)
     }
 
     @ViewBuilder
@@ -107,9 +109,11 @@ public struct ButtonView: View {
                 .foregroundStyle(self.viewModel.currentColors?.titleColor?.color ?? ColorTokenDefault.clear.color)
                 .font(self.viewModel.titleFontToken?.font)
                 .accessibilityIdentifier(ButtonAccessibilityIdentifier.text)
+                .animation(nil, value: text)
         } else if let attributedText = self.viewModel.controlStateText?.attributedText {
             Text(attributedText)
                 .accessibilityIdentifier(ButtonAccessibilityIdentifier.text)
+                .animation(nil, value: attributedText)
         }
     }
 


### PR DESCRIPTION
When we remove animation on the entire button without specify an value, some animations on the parent view of the button are also removed.

The fix found is to remove the animation for the text and for the frame.
