### PR TITLE
[TextField] Replaced usage of isUserInteractionEnabled by isReadOnly

### DIFF
--- a/.Demo/Classes/View/Components/TextField/Addons/UIKit/TextFieldAddonsComponentUIView.swift
+++ b/.Demo/Classes/View/Components/TextField/Addons/UIKit/TextFieldAddonsComponentUIView.swift
@@ -58,10 +58,10 @@ final class TextFieldAddonsComponentUIView: ComponentUIView {
             self.textFieldAddons.isEnabled = isEnabled
         }
 
-        self.viewModel.$isUserInteractionEnabled.subscribe(in: &self.cancellables) { [weak self] isUserInteractionEnabled in
+        self.viewModel.$isReadOnly.subscribe(in: &self.cancellables) { [weak self] isReadOnly in
             guard let self = self else { return }
-            self.viewModel.isUserInteractionEnabledConfigurationItemViewModel.isOn = isUserInteractionEnabled
-            self.textFieldAddons.isUserInteractionEnabled = isUserInteractionEnabled
+            self.viewModel.isReadOnlyConfigurationItemViewModel.isOn = isReadOnly
+            self.textFieldAddons.isReadOnly = isReadOnly
         }
 
         self.viewModel.$leftViewContent.subscribe(in: &self.cancellables) { [weak self] content in

--- a/.Demo/Classes/View/Components/TextField/Addons/UIKit/TextFieldAddonsComponentUIViewModel.swift
+++ b/.Demo/Classes/View/Components/TextField/Addons/UIKit/TextFieldAddonsComponentUIViewModel.swift
@@ -15,7 +15,7 @@ final class TextFieldAddonsComponentUIViewModel: ComponentUIViewModel, Observabl
     @Published var theme: Theme
     @Published var intent: TextFieldIntent
     @Published var isEnabled: Bool = true
-    @Published var isUserInteractionEnabled: Bool = true
+    @Published var isReadOnly: Bool = false
     @Published var leftViewContent: TextFieldSideViewContent = .none
     @Published var rightViewContent: TextFieldSideViewContent = .none
     @Published var leftAddonContent: TextFieldAddonContent = .buttonFull
@@ -76,11 +76,11 @@ final class TextFieldAddonsComponentUIViewModel: ComponentUIViewModel, Observabl
         )
     }()
 
-    lazy var isUserInteractionEnabledConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+    lazy var isReadOnlyConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
-            name: "IsUserInteractionEnabled",
-            type: .toggle(isOn: self.isUserInteractionEnabled),
-            target: (source: self, action: #selector(self.toggleIsUserInteractionEnabled))
+            name: "IsReadOnly",
+            type: .toggle(isOn: self.isReadOnly),
+            target: (source: self, action: #selector(self.toggleIsReadOnly))
         )
     }()
     lazy var leftViewContentConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
@@ -152,7 +152,7 @@ final class TextFieldAddonsComponentUIViewModel: ComponentUIViewModel, Observabl
             self.themeConfigurationItemViewModel,
             self.intentConfigurationItemViewModel,
             self.isEnabledConfigurationItemViewModel,
-            self.isUserInteractionEnabledConfigurationItemViewModel,
+            self.isReadOnlyConfigurationItemViewModel,
             self.leftViewContentConfigurationItemViewModel,
             self.rightViewContentConfigurationItemViewModel,
             self.leftAddonContentConfigurationItemViewModel,
@@ -174,8 +174,8 @@ final class TextFieldAddonsComponentUIViewModel: ComponentUIViewModel, Observabl
         self.isEnabled.toggle()
     }
 
-    @objc func toggleIsUserInteractionEnabled() {
-        self.isUserInteractionEnabled.toggle()
+    @objc func toggleIsReadOnly() {
+        self.isReadOnly.toggle()
     }
 
     @objc func presentLeftViewContent() {

--- a/.Demo/Classes/View/Components/TextField/UIKit/TextFieldComponentUIView.swift
+++ b/.Demo/Classes/View/Components/TextField/UIKit/TextFieldComponentUIView.swift
@@ -56,10 +56,10 @@ final class TextFieldComponentUIView: ComponentUIView {
             self.textField.isEnabled = isEnabled
         }
 
-        self.viewModel.$isUserInteractionEnabled.subscribe(in: &self.cancellables) { [weak self] isUserInteractionEnabled in
+        self.viewModel.$isReadOnly.subscribe(in: &self.cancellables) { [weak self] isReadOnly in
             guard let self = self else { return }
-            self.viewModel.isUserInteractionEnabledConfigurationItemViewModel.isOn = isUserInteractionEnabled
-            self.textField.isUserInteractionEnabled = isUserInteractionEnabled
+            self.viewModel.isReadOnlyConfigurationItemViewModel.isOn = isReadOnly
+            self.textField.isReadOnly = isReadOnly
         }
 
         self.viewModel.$clearButtonMode.subscribe(in: &self.cancellables) { [weak self] viewMode in

--- a/.Demo/Classes/View/Components/TextField/UIKit/TextFieldComponentUIViewModel.swift
+++ b/.Demo/Classes/View/Components/TextField/UIKit/TextFieldComponentUIViewModel.swift
@@ -15,7 +15,7 @@ final class TextFieldComponentUIViewModel: ComponentUIViewModel, ObservableObjec
     @Published var theme: Theme
     @Published var intent: TextFieldIntent
     @Published var isEnabled: Bool = true
-    @Published var isUserInteractionEnabled: Bool = true
+    @Published var isReadOnly: Bool = false
     @Published var leftViewMode: UITextField.ViewMode = .always
     @Published var rightViewMode: UITextField.ViewMode = .always
     @Published var leftViewContent: TextFieldSideViewContent = .none
@@ -82,11 +82,11 @@ final class TextFieldComponentUIViewModel: ComponentUIViewModel, ObservableObjec
         )
     }()
 
-    lazy var isUserInteractionEnabledConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
+    lazy var isReadOnlyConfigurationItemViewModel: ComponentsConfigurationItemUIViewModel = {
         return .init(
-            name: "IsUserInteractionEnabled",
-            type: .toggle(isOn: self.isUserInteractionEnabled),
-            target: (source: self, action: #selector(self.toggleIsUserInteractionEnabled))
+            name: "IsReadOnly",
+            type: .toggle(isOn: self.isReadOnly),
+            target: (source: self, action: #selector(self.toggleIsReadOnly))
         )
     }()
 
@@ -159,7 +159,7 @@ final class TextFieldComponentUIViewModel: ComponentUIViewModel, ObservableObjec
             self.themeConfigurationItemViewModel,
             self.intentConfigurationItemViewModel,
             self.isEnabledConfigurationItemViewModel,
-            self.isUserInteractionEnabledConfigurationItemViewModel,
+            self.isReadOnlyConfigurationItemViewModel,
             self.clearButtonModeConfigurationItemViewModel,
             self.leftViewModeConfigurationItemViewModel,
             self.rightViewModeConfigurationItemViewModel,
@@ -181,8 +181,8 @@ final class TextFieldComponentUIViewModel: ComponentUIViewModel, ObservableObjec
         self.isEnabled.toggle()
     }
 
-    @objc func toggleIsUserInteractionEnabled() {
-        self.isUserInteractionEnabled.toggle()
+    @objc func toggleIsReadOnly() {
+        self.isReadOnly.toggle()
     }
 
     @objc func presentClearButtonMode() {


### PR DESCRIPTION
See PR https://github.com/adevinta/spark-ios-component-text-input/pull/18